### PR TITLE
feat(auth): protect root (/) with auth; only /health public

### DIFF
--- a/src/http/http-auth-middleware.ts
+++ b/src/http/http-auth-middleware.ts
@@ -1,5 +1,6 @@
 /**
- * Auth middleware: when AUTH_ENABLED, require session or Bearer for /api and /mcp.
+ * Auth middleware: when AUTH_ENABLED, require session or Bearer for / (UI), /api, /api/*, and /mcp.
+ * Only /health is unauthenticated (for load balancers and health checks).
  * Unauthenticated browser GET -> redirect to Keycloak; otherwise 401 with login_url.
  * When AUTH_MODE=oidc_bearer, Bearer tokens are validated (issuer, audience, exp); req.auth is set from session or validated Bearer.
  */
@@ -110,9 +111,9 @@ function hasBearer(req: Request): boolean {
   return getBearerToken(req) !== null;
 }
 
-/** Paths that require auth when AUTH_ENABLED: /api, /api/*, and /mcp (MCP-over-HTTP). */
+/** Paths that require auth when AUTH_ENABLED: / (UI), /api, /api/*, and /mcp. Only /health is public. */
 function isProtectedPath(path: string): boolean {
-  return path === '/api' || path.startsWith('/api/') || path === '/mcp';
+  return path === '/' || path === '/api' || path.startsWith('/api/') || path === '/mcp';
 }
 
 /** Build WWW-Authenticate value. Use error=invalid_token so MCP clients clear stored token and restart OAuth (e.g. after Keycloak session cleanup). */

--- a/src/http/http-health-routes.ts
+++ b/src/http/http-health-routes.ts
@@ -74,7 +74,7 @@ export function setupHealthRoutes(app: express.Express, memoryStore: MemoryQdran
         });
     });
 
-    // Basic info endpoint (non-MCP)
+    // Root (UI): when AUTH_ENABLED, only reached when authenticated; unauthenticated GET redirects to login.
     app.get('/', (req, res) => {
         const body: Record<string, unknown> = {
             service: 'KAIROS MCP Server',
@@ -88,7 +88,7 @@ export function setupHealthRoutes(app: express.Express, memoryStore: MemoryQdran
             note: 'Use POST /mcp for MCP protocol communication'
         };
         if (AUTH_ENABLED) {
-            body['api_note'] = 'GET /api and POST /api/* require authentication (session or Bearer). Use login_url from 401 or /auth/callback flow.';
+            body['api_note'] = 'GET / and GET /api, POST /api/* require authentication (session or Bearer). Use login_url from 401 or /auth/callback flow.';
         }
         res.json(body);
     });


### PR DESCRIPTION
## Summary
When `AUTH_ENABLED`, require authentication for `/` (root) in addition to `/api`, `/api/*`, and `/mcp`. Only `/health` remains unauthenticated for load balancers and health checks.

## Changes
- **http-auth-middleware**: `isProtectedPath` now includes `path === '/'`
- **http-health-routes**: Comment and `api_note` updated for root as UI entry (auth required)

## Behavior
- **Unauthenticated** `GET /` → 302 redirect to Keycloak login
- **Authenticated** `GET /` → 200 (current JSON; ready for UI)
- `GET /health` → always public (200/503 by status)
- No test changes; existing tests use `/health` for readiness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-gating in the auth middleware so unauthenticated access to `/` now triggers redirects/401s, which can affect UI entrypoints and any tooling expecting an open root endpoint. Scope is small and isolated to routing/middleware and informational messaging.
> 
> **Overview**
> When `AUTH_ENABLED`, the auth middleware now treats the root route (`/`) as a protected path (alongside `/api*` and `/mcp`), so unauthenticated `GET /` will follow the existing redirect-to-login/401 behavior.
> 
> Updates the root route’s informational response text in `http-health-routes` to reflect that `GET /` is authenticated, while keeping `/health` explicitly public.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 777e1954003096e22adf02021af83d166904d759. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->