### PR TITLE
chore: bump version to 3.0.1-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kairos",
-  "version": "3.0.0",
+  "version": "3.0.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kairos",
-      "version": "3.0.0",
+      "version": "3.0.1-beta.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kairos",
-  "version": "3.0.0",
+  "version": "3.0.1-beta.2",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump for prerelease. After merge, release tag and publish workflows will run automatically.