### PR TITLE
chore: release pipeline (npm then Docker) and bump to 3.0.1-beta.3

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,3 +42,27 @@ In the workflow, use `${{ secrets.OPENAI_API_KEY }}` and `${{ vars.MY_VAR }}`. T
 
 - **UI:** Actions → Integration → Run workflow.
 - **CLI:** `gh workflow run integration.yml` (from default branch).
+
+## Release tag on version bump
+
+`release-tag-on-version-bump.yml` runs on **push to main**. If `package.json` version is **greater** than the latest existing tag (e.g. tag `v3.0.0` exists and package is `3.0.1`), it creates and pushes tag `v<version>`. That tag push triggers **Publish npm** and **Publish Docker** workflows, so you get an automatic release after merging a version-bump PR.
+
+**Flow:** Bump version in a PR with `npm version patch --no-git-tag-version` (or edit `package.json`), merge to main → this workflow tags → publish workflows run.
+
+Branch protection does not block tag pushes by default. If you use “Restrict pushes that create matching tags”, allow this repo’s GitHub Actions to create tags or run the tag step with a token that can push tags.
+
+## Release workflow (tag → npm + Docker)
+
+**Release** (`release.yml`) runs on **tag push** `v*.*.*` or `v*.*.*-*` (e.g. `v3.0.1`, `v3.0.1-beta.2`). It runs in order:
+
+1. **Publish npm** — lint, knip, build, `npm publish` (OIDC, no NPM_TOKEN).
+2. **Publish Docker** — only if npm succeeds; builds and pushes `debian777/kairos-mcp:<version>` and `latest` to Docker Hub.
+
+**Required secrets for release:** `DOCKER_USERNAME`, `DOCKER_PASSWORD` (Docker Hub). Without them, the Docker step fails.
+
+Flow: merge a version-bump PR to main → **Release tag on version bump** creates and pushes the tag → **Release** runs (npm then Docker).
+
+## Manual publish workflows
+
+- **Publish npm** (`publish-npm.yml`): **workflow_dispatch** only; uses `package.json` version. For ad-hoc npm publish.
+- **Publish Docker** (`publish-docker.yml`): **workflow_dispatch** only; for ad-hoc Docker Hub push.

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,9 +1,7 @@
 name: Publish Docker Image
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,9 +1,6 @@
 name: Publish npm Package
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -1,0 +1,55 @@
+# When a merge to main changes package.json version to a value greater than the
+# latest tag, create and push that tag. Publish workflows (npm, Docker) then run
+# on the tag push. Requires branch protection to allow this workflow to push tags
+# (default GITHUB_TOKEN can push; no extra secrets needed).
+name: Release tag on version bump
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  tag-release:
+    name: Tag if version bumped
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # push tag
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Get package version
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest tag
+        id: tag
+        run: |
+          latest=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=${latest}" >> "$GITHUB_OUTPUT"
+          echo "version=${latest#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag if version increased
+        run: |
+          pkg="${{ steps.pkg.outputs.version }}"
+          latest="${{ steps.tag.outputs.version }}"
+          higher=$(printf '%s\n' "$latest" "$pkg" | sort -V | tail -n1)
+          if [ "$higher" = "$pkg" ] && [ "$latest" != "$pkg" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            tag="v${pkg}"
+            git tag "$tag"
+            git push origin "$tag"
+            echo "Created and pushed tag $tag"
+          else
+            echo "No tag needed (package version $pkg not greater than latest $latest)"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+# Single release pipeline: on version tag push, publish npm then Docker.
+# Ensures npm package is in registry and Docker image is on Hub (only acceptable final output).
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+jobs:
+  publish-npm:
+    name: Publish npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Sync version from tag
+        run: npm version ${GITHUB_REF#refs/tags/v} --no-git-tag-version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Knip
+        run: npm run knip
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+
+  publish-docker:
+    name: Publish Docker image
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Sync version into package.json
+        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            debian777/kairos-mcp:latest
+            debian777/kairos-mcp:${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kairos",
-  "version": "3.0.1-beta.2",
+  "version": "3.0.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kairos",
-      "version": "3.0.1-beta.2",
+      "version": "3.0.1-beta.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kairos",
-  "version": "3.0.1-beta.2",
+  "version": "3.0.1-beta.3",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release pipeline

- **Release** (`release.yml`): On tag push `v*.*.*` / `v*.*.*-*`, runs **Publish npm** then **Publish Docker**. Only acceptable final output: npm package in registry, Docker image on Hub.
- **Release tag on version bump** (`release-tag-on-version-bump.yml`): On push to main, if `package.json` version \> latest tag, creates and pushes the tag (triggers Release).
- **Publish npm** / **Publish Docker**: Tag trigger removed; manual `workflow_dispatch` only.

## Version

Bump to **3.0.1-beta.3**.

## After merge

1. Release tag workflow creates `v3.0.1-beta.3`.
2. Release workflow runs: npm publish, then Docker build/push to `debian777/kairos-mcp`.

**Required secrets:** `DOCKER_USERNAME`, `DOCKER_PASSWORD` for Docker Hub.