### PR TITLE
chore: bump to 3.0.1-beta.4; harden release pipeline (tag→npm→Docker)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,3 +42,27 @@ In the workflow, use `${{ secrets.OPENAI_API_KEY }}` and `${{ vars.MY_VAR }}`. T
 
 - **UI:** Actions → Integration → Run workflow.
 - **CLI:** `gh workflow run integration.yml` (from default branch).
+
+## Release tag on version bump
+
+`release-tag-on-version-bump.yml` runs on **push to main**. If `package.json` version is **greater** than the latest existing tag (e.g. tag `v3.0.0` exists and package is `3.0.1`), it creates and pushes tag `v<version>`. That tag push triggers **Publish npm** and **Publish Docker** workflows, so you get an automatic release after merging a version-bump PR.
+
+**Flow:** Bump version in a PR with `npm version patch --no-git-tag-version` (or edit `package.json`), merge to main → this workflow tags → publish workflows run.
+
+Branch protection does not block tag pushes by default. If you use “Restrict pushes that create matching tags”, allow this repo’s GitHub Actions to create tags or run the tag step with a token that can push tags.
+
+## Release workflow (tag → npm + Docker)
+
+**Release** (`release.yml`) runs on **tag push** `v*.*.*` or `v*.*.*-*` (e.g. `v3.0.1`, `v3.0.1-beta.2`). It runs in order:
+
+1. **Publish npm** — lint, knip, build, `npm publish` (OIDC, no NPM_TOKEN).
+2. **Publish Docker** — only if npm succeeds; builds and pushes `debian777/kairos-mcp:<version>` and `latest` to Docker Hub.
+
+**Required secrets for release:** `DOCKER_USERNAME`, `DOCKER_PASSWORD` (Docker Hub). Without them, the Docker step fails.
+
+Flow: merge a version-bump PR to main → **Release tag on version bump** creates and pushes the tag → **Release** runs (npm then Docker).
+
+## Manual publish workflows
+
+- **Publish npm** (`publish-npm.yml`): **workflow_dispatch** only; uses `package.json` version. For ad-hoc npm publish.
+- **Publish Docker** (`publish-docker.yml`): **workflow_dispatch** only; for ad-hoc Docker Hub push.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,26 +43,30 @@ In the workflow, use `${{ secrets.OPENAI_API_KEY }}` and `${{ vars.MY_VAR }}`. T
 - **UI:** Actions → Integration → Run workflow.
 - **CLI:** `gh workflow run integration.yml` (from default branch).
 
+## Release: only acceptable final output
+
+After a release branch is merged to main, the **only acceptable final output** is: **npm** package in the registry and **Docker** image on Docker Hub (`debian777/kairos-mcp`). Single path: merge version-bump PR → tag created → **Release** workflow (npm then Docker).
+
 ## Release tag on version bump
 
-`release-tag-on-version-bump.yml` runs on **push to main**. If `package.json` version is **greater** than the latest existing tag (e.g. tag `v3.0.0` exists and package is `3.0.1`), it creates and pushes tag `v<version>`. That tag push triggers **Publish npm** and **Publish Docker** workflows, so you get an automatic release after merging a version-bump PR.
+`release-tag-on-version-bump.yml` runs on **push to main**. If `package.json` version is **greater** than the latest existing tag (e.g. tag `v3.0.0` exists and package is `3.0.1`), it creates and pushes tag `v<version>`. That tag push triggers the **Release** workflow (`release.yml`).
 
-**Flow:** Bump version in a PR with `npm version patch --no-git-tag-version` (or edit `package.json`), merge to main → this workflow tags → publish workflows run.
+**Flow:** Bump version in a PR (e.g. `npm version 3.0.1-beta.4 --no-git-tag-version`), merge to main → this workflow creates/pushes the tag → **Release** runs (npm then Docker).
 
 Branch protection does not block tag pushes by default. If you use “Restrict pushes that create matching tags”, allow this repo’s GitHub Actions to create tags or run the tag step with a token that can push tags.
 
 ## Release workflow (tag → npm + Docker)
 
-**Release** (`release.yml`) runs on **tag push** `v*.*.*` or `v*.*.*-*` (e.g. `v3.0.1`, `v3.0.1-beta.2`). It runs in order:
+**Release** (`release.yml`) runs on **tag push** `v*.*.*` or `v*.*.*-*` (e.g. `v3.0.1`, `v3.0.1-beta.4`). It is the **only** path that publishes. Jobs run in order:
 
 1. **Publish npm** — lint, knip, build, `npm publish` (OIDC, no NPM_TOKEN).
-2. **Publish Docker** — only if npm succeeds; builds and pushes `debian777/kairos-mcp:<version>` and `latest` to Docker Hub.
+2. **Publish Docker** — runs only if npm succeeds; builds and pushes `debian777/kairos-mcp:<version>` and `latest` to Docker Hub.
 
-**Required secrets for release:** `DOCKER_USERNAME`, `DOCKER_PASSWORD` (Docker Hub). Without them, the Docker step fails.
+**Required secrets:** `DOCKER_USERNAME`, `DOCKER_PASSWORD` (Docker Hub). Without them, the Docker job fails.
 
-Flow: merge a version-bump PR to main → **Release tag on version bump** creates and pushes the tag → **Release** runs (npm then Docker).
+## Manual publish workflows (ad-hoc only)
 
-## Manual publish workflows
+- **Publish npm** (`publish-npm.yml`): **workflow_dispatch** only; uses `package.json` version.
+- **Publish Docker** (`publish-docker.yml`): **workflow_dispatch** only.
 
-- **Publish npm** (`publish-npm.yml`): **workflow_dispatch** only; uses `package.json` version. For ad-hoc npm publish.
-- **Publish Docker** (`publish-docker.yml`): **workflow_dispatch** only; for ad-hoc Docker Hub push.
+Use only for one-off republish or debugging. Normal releases go through the Release workflow only.

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,9 +1,7 @@
 name: Publish Docker Image
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,9 +1,6 @@
 name: Publish npm Package
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -1,7 +1,8 @@
 # When a merge to main changes package.json version to a value greater than the
-# latest tag, create and push that tag. Publish workflows (npm, Docker) then run
-# on the tag push. Requires branch protection to allow this workflow to push tags
-# (default GITHUB_TOKEN can push; no extra secrets needed).
+# latest existing tag, create and push that tag. The tag push triggers the
+# Release workflow (release.yml): npm publish then Docker Hub push. Only
+# acceptable final output: npm package in registry, Docker image on Hub.
+# Requires branch protection to allow this workflow to push tags.
 name: Release tag on version bump
 
 on:
@@ -31,10 +32,10 @@ jobs:
         id: pkg
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Get latest tag
+      - name: Get latest tag (by version in repo)
         id: tag
         run: |
-          latest=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          latest=$(git tag -l 'v*' --sort=-v:refname | head -1 || echo "v0.0.0")
           echo "tag=${latest}" >> "$GITHUB_OUTPUT"
           echo "version=${latest#v}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -1,0 +1,55 @@
+# When a merge to main changes package.json version to a value greater than the
+# latest tag, create and push that tag. Publish workflows (npm, Docker) then run
+# on the tag push. Requires branch protection to allow this workflow to push tags
+# (default GITHUB_TOKEN can push; no extra secrets needed).
+name: Release tag on version bump
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  tag-release:
+    name: Tag if version bumped
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # push tag
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Get package version
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest tag
+        id: tag
+        run: |
+          latest=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=${latest}" >> "$GITHUB_OUTPUT"
+          echo "version=${latest#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag if version increased
+        run: |
+          pkg="${{ steps.pkg.outputs.version }}"
+          latest="${{ steps.tag.outputs.version }}"
+          higher=$(printf '%s\n' "$latest" "$pkg" | sort -V | tail -n1)
+          if [ "$higher" = "$pkg" ] && [ "$latest" != "$pkg" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            tag="v${pkg}"
+            git tag "$tag"
+            git push origin "$tag"
+            echo "Created and pushed tag $tag"
+          else
+            echo "No tag needed (package version $pkg not greater than latest $latest)"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+# Single release pipeline: on version tag push, publish npm then Docker.
+# Ensures npm package is in registry and Docker image is on Hub (only acceptable final output).
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+jobs:
+  publish-npm:
+    name: Publish npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Sync version from tag
+        run: npm version ${GITHUB_REF#refs/tags/v} --no-git-tag-version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Knip
+        run: npm run knip
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+
+  publish-docker:
+    name: Publish Docker image
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Sync version into package.json
+        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            debian777/kairos-mcp:latest
+            debian777/kairos-mcp:${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 # Single release pipeline: on version tag push, publish npm then Docker.
-# Ensures npm package is in registry and Docker image is on Hub (only acceptable final output).
+# Only acceptable final output: npm package in registry, Docker image on Docker Hub.
+# Triggered by release-tag-on-version-bump after merge of a version-bump PR to main.
 name: Release
 
 on:
@@ -7,6 +8,10 @@ on:
     tags:
       - 'v*.*.*'
       - 'v*.*.*-*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish-npm:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kairos",
-  "version": "3.0.1-beta.3",
+  "version": "3.0.1-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kairos",
-      "version": "3.0.1-beta.3",
+      "version": "3.0.1-beta.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kairos",
-  "version": "3.0.1-beta.2",
+  "version": "3.0.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kairos",
-      "version": "3.0.1-beta.2",
+      "version": "3.0.1-beta.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kairos",
-  "version": "3.0.1-beta.2",
+  "version": "3.0.1-beta.3",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kairos",
-  "version": "3.0.1-beta.3",
+  "version": "3.0.1-beta.4",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump + release pipeline: tag from latest in repo, Release workflow (npm then Docker). After merge, release-tag-on-version-bump will create v3.0.1-beta.4 and Release will publish to npm and Docker Hub.