### PR TITLE
fix: run npm and Docker publish from version-bump; add Release workflow_dispatch

### DIFF
--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -40,6 +40,7 @@ jobs:
           echo "version=${latest#v}" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag if version increased
+        id: push_tag
         run: |
           pkg="${{ steps.pkg.outputs.version }}"
           latest="${{ steps.tag.outputs.version }}"
@@ -50,7 +51,98 @@ jobs:
             tag="v${pkg}"
             git tag "$tag"
             git push origin "$tag"
+            echo "tag_created=true" >> "$GITHUB_OUTPUT"
+            echo "version=${pkg}" >> "$GITHUB_OUTPUT"
             echo "Created and pushed tag $tag"
           else
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
             echo "No tag needed (package version $pkg not greater than latest $latest)"
           fi
+    outputs:
+      tag_created: ${{ steps.push_tag.outputs.tag_created }}
+      version: ${{ steps.push_tag.outputs.version }}
+
+  publish-npm:
+    name: Publish npm
+    needs: tag-release
+    if: needs.tag-release.outputs.tag_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ needs.tag-release.outputs.version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Sync version from tag
+        run: npm version ${{ needs.tag-release.outputs.version }} --no-git-tag-version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Knip
+        run: npm run knip
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+
+  publish-docker:
+    name: Publish Docker image
+    needs: [tag-release, publish-npm]
+    if: needs.tag-release.outputs.tag_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ needs.tag-release.outputs.version }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            debian777/kairos-mcp:latest
+            debian777/kairos-mcp:${{ needs.tag-release.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
     tags:
       - 'v*.*.*'
       - 'v*.*.*-*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag to release (e.g. v3.0.1-beta.5). Leave empty when triggered by tag push.'
+        required: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -24,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -32,8 +39,18 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Set version from tag
+        id: version
+        run: |
+          ref="${{ github.event.inputs.ref }}"
+          if [ -n "$ref" ]; then
+            echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Sync version from tag
-        run: npm version ${GITHUB_REF#refs/tags/v} --no-git-tag-version
+        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
 
       - name: Install dependencies
         run: npm ci
@@ -60,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -69,7 +88,13 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        run: |
+          ref="${{ github.event.inputs.ref }}"
+          if [ -n "$ref" ]; then
+            echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Sync version into package.json
         run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version


### PR DESCRIPTION
Makes release pipeline work without relying on tag push triggering Release workflow:

- **release-tag-on-version-bump**: When a tag is created, run publish-npm and publish-docker in the same workflow (checkout tag, publish). No dependency on 'Allow actions to trigger other workflows'.
- **release.yml**: Add `workflow_dispatch` with optional `ref` input so we can manually run Release for an existing tag (e.g. v3.0.1-beta.5).

After merge we can trigger Release for v3.0.1-beta.5 to satisfy acceptance (npm + Docker published).