### PR TITLE
chore: scope package @debian777/kairos-mcp, bump to 3.0.1-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "kairos",
-  "version": "3.0.1-beta.5",
+  "name": "@debian777/kairos-mcp",
+  "version": "3.0.1-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kairos",
-      "version": "3.0.1-beta.5",
+      "name": "@debian777/kairos-mcp",
+      "version": "3.0.1-beta.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "kairos",
-  "version": "3.0.1-beta.5",
+  "name": "@debian777/kairos-mcp",
+  "version": "3.0.1-beta.6",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/debian777/kairos-mcp/issues"
   },
-  "homepage": "https://github.com/debian777/kairos#readme",
+  "homepage": "https://github.com/debian777/kairos-mcp#readme",
   "keywords": [
     "mcp",
     "model-context-protocol",


### PR DESCRIPTION
## Summary
- **Package name:** `kairos` → `@debian777/kairos-mcp` (unscoped kairos-mcp taken on npm)
- **Homepage:** fix repo path to kairos-mcp
- **Version:** 3.0.1-beta.6

Merge to main → Release tag on version bump creates v3.0.1-beta.6 and runs publish-npm + publish-docker for @debian777/kairos-mcp.