### PR TITLE
fix: allow-same-version in version-bump publish-npm job

### DIFF
--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -86,7 +86,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Sync version from tag
-        run: npm version ${{ needs.tag-release.outputs.version }} --no-git-tag-version
+        run: npm version ${{ needs.tag-release.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Fixes publish-npm step when checkout ref already has that version in package.json.