### PR TITLE
fix(kairos_next): PROOF_HASH_MISMATCH when client uses next_action URI

### DIFF
--- a/src/http/http-api-next.ts
+++ b/src/http/http-api-next.ts
@@ -7,7 +7,7 @@ import { extractMemoryBody } from '../utils/memory-body.js';
 import { proofOfWorkStore } from '../services/proof-of-work-store.js';
 import { buildChallenge, handleProofSubmission, GENESIS_HASH, type HandleProofResult } from '../tools/kairos_next-pow-helpers.js';
 import { updateStepQuality } from '../tools/kairos_next.js';
-import { tryApplySolutionToPreviousStep } from '../tools/kairos_next-previous-step.js';
+import { tryApplySolutionToPreviousStep, tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious } from '../tools/kairos_next-previous-step.js';
 
 /**
  * Set up API route for kairos_next (V2: no next_step/protocol_status/attest_required/final_challenge,
@@ -114,6 +114,54 @@ export function setupNextRoute(app: express.Express, memoryStore: MemoryQdrantSt
 
             let submissionOutcome: HandleProofResult | undefined;
             if (memory?.proof_of_work) {
+                // PROOF_HASH_MISMATCH fix: client may call with next_action URI (next step) and submit
+                // solution for the step we just showed (previous). Apply to previous when solution matches.
+                const prevResultWhenMatch = await tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious(
+                    memory,
+                    solution,
+                    (id) => memoryStore.getMemory(id),
+                    qdrantService
+                );
+                if (prevResultWhenMatch.applied) {
+                    if (prevResultWhenMatch.outcome.blockedPayload) {
+                        await updateStepQuality(qdrantService, prevResultWhenMatch.prevMemory, 'failure', 'http');
+                        const duration = Date.now() - startTime;
+                        return res.status(200).json({
+                            ...prevResultWhenMatch.outcome.blockedPayload,
+                            metadata: { duration_ms: duration }
+                        });
+                    }
+                    if (!prevResultWhenMatch.outcome.alreadyRecorded) {
+                        await updateStepQuality(qdrantService, prevResultWhenMatch.prevMemory, 'success', 'http');
+                    }
+                    const nextFromRequested = await resolveChainNextStep(memory, qdrantService);
+                    const nextStepUri = nextFromRequested?.uuid
+                        ? `kairos://mem/${nextFromRequested.uuid}`
+                        : null;
+                    const current_step = {
+                        uri: requestedUri,
+                        content: memory ? extractMemoryBody(memory.text) : '',
+                        mimeType: 'text/markdown' as const
+                    };
+                    const nextMemory = nextFromRequested ? await memoryStore.getMemory(nextFromRequested.uuid) : null;
+                    const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
+                    const challenge = await buildChallenge(memory, challengeProof);
+                    const output: any = {
+                        must_obey: true,
+                        current_step,
+                        challenge
+                    };
+                    if (nextStepUri) {
+                        output.next_action = `call kairos_next with ${nextStepUri} and solution matching challenge`;
+                    } else {
+                        output.message = 'Protocol steps complete. Call kairos_attest to finalize.';
+                        output.next_action = `call kairos_attest with ${requestedUri} and outcome (success or failure) and message to complete the protocol`;
+                    }
+                    if (prevResultWhenMatch.outcome.proofHash) output.proof_hash = prevResultWhenMatch.outcome.proofHash;
+                    const duration = Date.now() - startTime;
+                    return res.status(200).json({ ...output, metadata: { duration_ms: duration } });
+                }
+
                 const isStep1 = !memory.chain || memory.chain.step_index <= 1;
                 let expectedPreviousHash: string;
                 if (isStep1) {

--- a/src/tools/kairos_next-previous-step.ts
+++ b/src/tools/kairos_next-previous-step.ts
@@ -49,6 +49,47 @@ export async function tryApplySolutionToPreviousStep(
   return { applied: true, outcome, prevMemory };
 }
 
+/**
+ * PROOF_HASH_MISMATCH fix: when the client calls kairos_next with the URI from next_action (the *next*
+ * step), they are submitting the solution for the step we just showed (the previous step). If the
+ * requested step has proof_of_work but the previous step has none stored yet and the solution type
+ * matches the previous step's challenge, apply the solution to the previous step and return applied.
+ * This prevents PROOF_HASH_MISMATCH because we expect the hash from the previous response, not
+ * the hash of the previous step (which is not stored yet).
+ */
+export async function tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious(
+  requestedMemory: Memory,
+  solution: ProofOfWorkSubmission,
+  loadMemory: (uuid: string) => Promise<Memory | null>,
+  qdrantService: QdrantService | undefined
+): Promise<TryApplyToPreviousResult> {
+  if (!requestedMemory.proof_of_work) return { applied: false };
+  const prevInfo = await resolveChainPreviousStep(requestedMemory, qdrantService);
+  if (!prevInfo?.uuid) return { applied: false };
+  const prevMemory = await loadMemory(prevInfo.uuid);
+  if (!prevMemory?.proof_of_work?.required) return { applied: false };
+
+  const storedResult = await proofOfWorkStore.getResult(prevInfo.uuid);
+  if (storedResult) return { applied: false };
+
+  const requiredType = prevMemory.proof_of_work.type || 'shell';
+  const solutionType = solution.type || 'shell';
+  if (solutionType !== requiredType) return { applied: false };
+
+  const prevIsStep1 = !prevMemory.chain || prevMemory.chain.step_index <= 1;
+  const expectedPrevHash = prevIsStep1
+    ? GENESIS_HASH
+    : (await (async () => {
+        const p = await resolveChainPreviousStep(prevMemory, qdrantService);
+        return p?.uuid ? await proofOfWorkStore.getProofHash(p.uuid) : null;
+      })()) ?? GENESIS_HASH;
+
+  const outcome = await handleProofSubmission(solution, prevMemory, {
+    expectedPreviousHash: expectedPrevHash
+  });
+  return { applied: true, outcome, prevMemory };
+}
+
 export async function ensurePreviousProofCompleted(
   memory: Memory,
   loadMemory: (uuid: string) => Promise<Memory | null>,

--- a/src/tools/kairos_next.ts
+++ b/src/tools/kairos_next.ts
@@ -11,7 +11,7 @@ import { redisCacheService } from '../services/redis-cache.js';
 import { extractMemoryBody } from '../utils/memory-body.js';
 import { proofOfWorkStore } from '../services/proof-of-work-store.js';
 import { buildChallenge, handleProofSubmission, tryUserInputElicitation, GENESIS_HASH, type ProofOfWorkSubmission, type HandleProofResult } from './kairos_next-pow-helpers.js';
-import { tryApplySolutionToPreviousStep, ensurePreviousProofCompleted } from './kairos_next-previous-step.js';
+import { tryApplySolutionToPreviousStep, tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious, ensurePreviousProofCompleted } from './kairos_next-previous-step.js';
 import { modelStats } from '../services/stats/model-stats.js';
 import { kairosQualityUpdateErrors } from '../services/metrics/mcp-metrics.js';
 
@@ -229,6 +229,35 @@ export function registerKairosNextTool(server: any, memoryStore: MemoryQdrantSto
                 if (prevResult.outcome.proofHash) output.proof_hash = prevResult.outcome.proofHash;
                 return respond(output);
               }
+            }
+          }
+
+          if (memory.proof_of_work && solutionToUse) {
+            const prevResultWhenMatch = await tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious(
+              memory,
+              solutionToUse,
+              (id) => loadMemoryWithCache(memoryStore, id),
+              options.qdrantService
+            );
+            if (prevResultWhenMatch.applied) {
+              if (prevResultWhenMatch.outcome.blockedPayload) {
+                if (options.qdrantService) {
+                  await updateStepQuality(options.qdrantService, prevResultWhenMatch.prevMemory, 'failure', tenantId);
+                }
+                return respond(prevResultWhenMatch.outcome.blockedPayload);
+              }
+              if (options.qdrantService && !prevResultWhenMatch.outcome.alreadyRecorded) {
+                await updateStepQuality(options.qdrantService, prevResultWhenMatch.prevMemory, 'success', tenantId);
+              }
+              const nextFromRequested = await resolveChainNextStep(memory, options.qdrantService);
+              const nextStepUri = nextFromRequested?.uuid
+                ? `kairos://mem/${nextFromRequested.uuid}`
+                : null;
+              const nextMemory = nextFromRequested ? await loadMemoryWithCache(memoryStore, nextFromRequested.uuid) : null;
+              const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
+              const output = await buildKairosNextPayload(memory, requestedUri, nextStepUri, challengeProof);
+              if (prevResultWhenMatch.outcome.proofHash) output.proof_hash = prevResultWhenMatch.outcome.proofHash;
+              return respond(output);
             }
           }
 


### PR DESCRIPTION
## Problem

When advancing after an MCP (or other) challenge step, the server returns `next_action` with the **next** step's URI (e.g. `555ff5ad`) and a top-level `proof_hash`. The client correctly calls `kairos_next(555ff5ad, solution)` with that `proof_hash`. The server was validating for the requested step and expecting `getProofHash(previous)` = null → GENESIS_HASH, causing **PROOF_HASH_MISMATCH**.

Ref: [mcp-bug-user-KAIROS-kairos-next-proof-hash-mismatch-2026-03-04.md](https://gitlab.bsdevops.io/bsdigital/development/gitlab/gitlab-ci/reports/mcp-bug-user-KAIROS-kairos-next-proof-hash-mismatch-2026-03-04.md) (summary in plan).

## Solution

When the **requested** step has `proof_of_work` but the **previous** step has no stored proof yet and the **solution type matches the previous step's challenge type**, treat the call as "submit solution for the previous step". Validate and store the solution against the previous step with the correct `expectedPreviousHash`, then return the next-step response.

## Changes

- **src/tools/kairos_next-previous-step.ts**: Add `tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious` (conditions: requested has proof_of_work, previous has required proof and no stored result, solution.type matches previous challenge; then `handleProofSubmission` for previous step).
- **src/http/http-api-next.ts**: When `memory?.proof_of_work` and `solution` exist, call the new helper before computing `expectedPreviousHash` for the requested step; if applied, return next-step response with `proof_hash` from outcome.
- **src/tools/kairos_next.ts**: Same logic for MCP `kairos_next` handler.

## Verification

1. `kairos_begin` with a protocol that has step1 comment → step2 mcp → step3.
2. `kairos_next(step1_uri, comment solution)`.
3. `kairos_next(uri_from_next_action, mcp solution)` with `proof_hash` from the previous response.
4. **Expected:** Server accepts and returns next step; no PROOF_HASH_MISMATCH.