### PR TITLE
release: 3.0.1 (promote from 3.0.1-beta.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.8",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.0.1-beta.8",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.8",
+  "version": "3.0.1",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Promote prerelease `3.0.1-beta.8` to normal release `3.0.1`.\n\nAfter merge, release tag and publish workflows run automatically.