### PR TITLE
fix(hooks): block commits to main in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,14 @@
 #!/bin/sh
+# Disallow commits on main — use a branch and open a PR.
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$branch" = "main" ]; then
+  echo ""
+  echo "  Commits to main are not allowed. Use a branch and open a PR."
+  echo "  Example: git checkout -b fix/my-change && git commit ..."
+  echo ""
+  exit 1
+fi
+
 # Skip heavy checks for version-bump commits (only package.json + package-lock.json).
 # Real workflow: full build runs in dev:deploy and CI; version bumps need no build on commit.
 staged=$(git diff --cached --name-only)


### PR DESCRIPTION
Pre-commit hook now exits with an error when committing on `main`, so all changes go through a branch and PR. Override with `git commit --no-verify` if needed.