### PR TITLE
feat: only parse challenge blocks at line start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,8 @@ When minting (`kairos_mint`) or editing (`kairos_update`) a protocol:
 - Use H2 for each step label.
 - End every verifiable step with a trailing ` ```json ` block containing
   `{"challenge": {...}}` (same shape as `kairos_begin`/`kairos_next`).
+- The opening \`\`\`json must be on its own line (line start). Blocks with
+  text on the same line (e.g. `Example: \`\`\`json`) are not parsed as steps.
 - Add a `## Natural Language Triggers` section as the first H2.
 - Add a `## Completion Rule` section as the last H2.
 

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -84,7 +84,7 @@ This protocol can be used for deployments and releases.
 Prefer a challenge on every step; omit only for purely informational steps
 where no verification is possible.
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "comment",
@@ -101,7 +101,7 @@ Place a fenced ` ```json ` block at the end of the step with an object with a
 
 **shell** — Step requires running a command (build, test, deploy script).
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "shell",
@@ -116,7 +116,7 @@ Place a fenced ` ```json ` block at the end of the step with an object with a
 
 **comment** — Step requires a short verification (review, summary, checklist).
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "comment",
@@ -128,7 +128,7 @@ Place a fenced ` ```json ` block at the end of the step with an object with a
 
 **user_input** — Step requires human confirmation (approvals, go/no-go).
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "user_input",
@@ -140,7 +140,7 @@ Place a fenced ` ```json ` block at the end of the step with an object with a
 
 **mcp** — Step requires calling an MCP tool (e.g. kairos_mint, kairos_update).
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "mcp",
@@ -157,7 +157,7 @@ Use H1 for the protocol title, H2 for each step, then step body, then a
 
 **Step 1 — shell:** Run the test suite and linter.
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "shell",
@@ -172,7 +172,7 @@ Use H1 for the protocol title, H2 for each step, then step body, then a
 
 **Step 2 — comment:** Summarize what changed and why (min 50 chars).
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "comment",
@@ -184,7 +184,7 @@ Use H1 for the protocol title, H2 for each step, then step body, then a
 
 **Step 3 — user_input:** Get user approval for merge.
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "user_input",
@@ -196,7 +196,7 @@ Use H1 for the protocol title, H2 for each step, then step body, then a
 
 **Step 4 — mcp:** Call the merge tool.
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "mcp",
@@ -210,7 +210,7 @@ Use H1 for the protocol title, H2 for each step, then step body, then a
 
 Example step format: H2, body, then a trailing ` ```json ` block with `challenge`.
 
-```json
+Format: ```json
 {
   "challenge": {
     "type": "comment",

--- a/src/embed-docs/resources/building-kairos-workflows.md
+++ b/src/embed-docs/resources/building-kairos-workflows.md
@@ -64,7 +64,7 @@ returned by `kairos_begin`/`kairos_next`; it round-trips with
 
 **`shell`:**
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "shell",
@@ -76,7 +76,7 @@ returned by `kairos_begin`/`kairos_next`; it round-trips with
 
 **`mcp`:**
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "mcp",
@@ -88,7 +88,7 @@ returned by `kairos_begin`/`kairos_next`; it round-trips with
 
 **`user_input`:**
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "user_input",
@@ -100,7 +100,7 @@ returned by `kairos_begin`/`kairos_next`; it round-trips with
 
 **`comment`:**
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "comment",
@@ -142,6 +142,9 @@ For agent execution rules (what agents must do per type), see the
 - Place the challenge at the **end** of an H2 section as a single
   trailing ` ```json ` block.
 - Only the **last** code block in a step is parsed as the challenge.
+- Ensure the opening \`\`\`json is at **line start** (on its own line,
+  no prefix). Blocks with text on the same line (e.g. `Example: \`\`\`json`)
+  are not parsed as steps.
 
 **`kairos_mint` usage:**
 

--- a/src/embed-docs/tools/kairos_mint.md
+++ b/src/embed-docs/tools/kairos_mint.md
@@ -13,7 +13,10 @@ H2 steps, and a trailing ` ```json ` challenge block per verifiable step.
 
 **Challenge block format:** Place a single trailing ` ```json ` block at
 the end of each H2 step. The object must have a `challenge` key. Only
-the last code block in a step is parsed as the challenge.
+the last code block in a step is parsed as the challenge. **The opening
+\`\`\`json must be at line start** (on its own line with no text before
+it). Blocks with text on the same line (e.g. `Example: \`\`\`json`) are
+not parsed as steps.
 
 Add a challenge to every step that can be verified. Omit challenges only
 for purely informational steps where no verification is possible.
@@ -22,7 +25,7 @@ for purely informational steps where no verification is possible.
 
 `shell` — run a command:
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "shell",
@@ -34,7 +37,7 @@ for purely informational steps where no verification is possible.
 
 `comment` — verification text:
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "comment",
@@ -46,7 +49,7 @@ for purely informational steps where no verification is possible.
 
 `user_input` — human confirmation:
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "user_input",
@@ -58,7 +61,7 @@ for purely informational steps where no verification is possible.
 
 `mcp` — call an MCP tool:
 
-```json
+Example: ```json
 {
   "challenge": {
     "type": "mcp",

--- a/src/services/memory/chain-builder-proof.ts
+++ b/src/services/memory/chain-builder-proof.ts
@@ -1,10 +1,11 @@
 import type { ProofOfWorkDefinition } from '../../types/memory.js';
 
 /** Match the last fenced code block (```json or ```) at end of step body. Captures prefix (group 1) and block content (group 2). */
+// Note: Requires \n before the fence, so only matches line-start blocks (aligns with line-start-only rule).
 const TRAILING_JSON_BLOCK_REGEX = /([\s\S]*)\n```(?:json)?\s*\n([\s\S]*?)```\s*$/;
 
-/** Match a single fenced ```json or ``` block (for finding all blocks in content). */
-const ANY_JSON_BLOCK_REGEX = /```(?:json)?\s*\n([\s\S]*?)```/g;
+/** Match a single fenced ```json or ``` block (for finding all blocks in content). Only matches when opening fence is at line start (after ^ or \n). */
+const ANY_JSON_BLOCK_REGEX = /(^|\n)(```(?:json)?\s*\n([\s\S]*?)```)/gm;
 
 export interface ChallengeBlockMatch {
   /** Start index of the opening ``` in content. */
@@ -23,7 +24,10 @@ export function findAllChallengeBlocks(content: string): ChallengeBlockMatch[] {
   let match: RegExpExecArray | null;
   ANY_JSON_BLOCK_REGEX.lastIndex = 0;
   while ((match = ANY_JSON_BLOCK_REGEX.exec(content)) !== null) {
-    const blockContent = match[1]!.trim();
+    // match[1] = (^|\n) - the line start prefix
+    // match[2] = the full block (```...```)
+    // match[3] = the block content (JSON)
+    const blockContent = match[3]!.trim();
     let parsed: { challenge?: unknown };
     try {
       parsed = JSON.parse(blockContent) as { challenge?: unknown };
@@ -36,9 +40,13 @@ export function findAllChallengeBlocks(content: string): ChallengeBlockMatch[] {
     const challenge = parsed.challenge as Record<string, unknown>;
     const required = typeof challenge['required'] === 'boolean' ? challenge['required'] : true;
     const proof: ProofOfWorkDefinition = { ...challenge, required } as ProofOfWorkDefinition;
+    // Calculate start/end: start is the opening ``` position (after the line-start prefix)
+    const lineStartPrefixLength = match[1]!.length;
+    const blockStart = match.index! + lineStartPrefixLength;
+    const blockLength = match[2]!.length;
     results.push({
-      start: match.index,
-      end: match.index + match[0].length,
+      start: blockStart,
+      end: blockStart + blockLength,
       proof
     });
   }

--- a/tests/unit/chain-builder-proof.test.ts
+++ b/tests/unit/chain-builder-proof.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for chain-builder-proof.ts: challenge block parsing.
+ * Tests that only line-start ```json blocks are parsed as steps.
+ */
+
+import { findAllChallengeBlocks } from '../../src/services/memory/chain-builder-proof.js';
+
+describe('chain-builder-proof', () => {
+  describe('findAllChallengeBlocks', () => {
+    test('finds challenge block at line start (after newline)', () => {
+      const content = `Some text
+\`\`\`json
+{"challenge":{"type":"comment","comment":{"min_length":10},"required":true}}
+\`\`\`
+More text`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(1);
+      expect(results[0]!.proof.type).toBe('comment');
+      expect(results[0]!.start).toBeGreaterThan(0);
+      expect(results[0]!.end).toBeGreaterThan(results[0]!.start);
+    });
+
+    test('finds challenge block at content start', () => {
+      const content = `\`\`\`json
+{"challenge":{"type":"shell","shell":{"cmd":"echo test"},"required":true}}
+\`\`\`
+More text`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(1);
+      expect(results[0]!.proof.type).toBe('shell');
+      expect(results[0]!.start).toBe(0);
+    });
+
+    test('does NOT find challenge block with inline prefix', () => {
+      const content = `Some text
+Example: \`\`\`json
+{"challenge":{"type":"comment","comment":{"min_length":10},"required":true}}
+\`\`\`
+More text`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(0);
+    });
+
+    test('finds multiple line-start challenge blocks', () => {
+      const content = `Step 1 content
+\`\`\`json
+{"challenge":{"type":"comment","comment":{"min_length":10},"required":true}}
+\`\`\`
+Step 2 content
+\`\`\`json
+{"challenge":{"type":"shell","shell":{"cmd":"npm test"},"required":true}}
+\`\`\`
+Step 3 content`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(2);
+      expect(results[0]!.proof.type).toBe('comment');
+      expect(results[1]!.proof.type).toBe('shell');
+      // Verify indices are correct (second block starts after first ends)
+      expect(results[1]!.start).toBeGreaterThan(results[0]!.end);
+    });
+
+    test('ignores inline-prefixed blocks but finds line-start blocks', () => {
+      const content = `Reference section:
+Example: \`\`\`json
+{"challenge":{"type":"comment","comment":{"min_length":10},"required":true}}
+\`\`\`
+
+## Step 1
+Do something
+\`\`\`json
+{"challenge":{"type":"shell","shell":{"cmd":"echo done"},"required":true}}
+\`\`\``;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(1);
+      expect(results[0]!.proof.type).toBe('shell');
+    });
+
+    test('handles blocks with ``` (no json) at line start', () => {
+      const content = `Some text
+\`\`\`
+{"challenge":{"type":"comment","comment":{"min_length":10},"required":true}}
+\`\`\`
+More text`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(1);
+      expect(results[0]!.proof.type).toBe('comment');
+    });
+
+    test('ignores blocks without challenge key', () => {
+      const content = `Some text
+\`\`\`json
+{"not_a_challenge":true}
+\`\`\`
+More text`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(0);
+    });
+
+    test('ignores invalid JSON blocks', () => {
+      const content = `Some text
+\`\`\`json
+{invalid json}
+\`\`\`
+More text`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(0);
+    });
+
+    test('preserves correct start/end indices for segment slicing', () => {
+      const content = `Prefix text
+\`\`\`json
+{"challenge":{"type":"comment","comment":{"min_length":10},"required":true}}
+\`\`\`
+Suffix text`;
+
+      const results = findAllChallengeBlocks(content);
+      expect(results).toHaveLength(1);
+      
+      // Verify the indices allow correct slicing
+      const beforeBlock = content.slice(0, results[0]!.start);
+      const afterBlock = content.slice(results[0]!.end);
+      
+      expect(beforeBlock.trim()).toBe('Prefix text');
+      expect(afterBlock.trim()).toBe('Suffix text');
+    });
+  });
+});


### PR DESCRIPTION
- Update ANY_JSON_BLOCK_REGEX to only match when opening fence is at line start
- Preserve correct start/end indices for segment slicing in findAllChallengeBlocks
- Add unit tests for line-start-only behavior
- Prefix example blocks in mem 2001 and building-kairos-workflows.md
- Update documentation to require line-start challenge blocks

This allows reference docs to use prefixed examples without creating extra steps.