### PR TITLE
release: 3.0.1-beta.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.11",
+  "version": "3.0.1-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.0.1-beta.11",
+      "version": "3.0.1-beta.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.11",
+  "version": "3.0.1-beta.12",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Beta bump to test Release workflow trigger (GH_PAT). Merge to main → Release tag on version bump runs → tag v3.0.1-beta.12 pushed with GH_PAT → Release workflow runs.