### PR TITLE
chore: bump version to 3.0.1-beta.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.13",
+  "version": "3.0.1-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.0.1-beta.13",
+      "version": "3.0.1-beta.14",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.13",
+  "version": "3.0.1-beta.14",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Prerelease version bump: 3.0.1-beta.13 → 3.0.1-beta.14. Tag and publish will run automatically after merge.