### PR TITLE
fix: store memory cache globally by UUID (no space namespace)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,8 @@ function getEnvBoolean(key: string, defaultValue: boolean): boolean {
 export const REDIS_URL = (getEnvString('REDIS_URL', '')).trim();
 export const USE_REDIS = REDIS_URL.length > 0;
 export const KAIROS_REDIS_PREFIX = getEnvString('KAIROS_REDIS_PREFIX', 'kairos:');
+/** Memory cache key prefix; keys starting with this are global (no space namespace). One key per UUID. */
+export const MEMORY_CACHE_KEY_PREFIX = 'mem:';
 export const OPENAI_EMBEDDING_MODEL = getEnvString('OPENAI_EMBEDDING_MODEL', '');
 export const OPENAI_API_KEY = getEnvString('OPENAI_API_KEY', '');
 export const EMBEDDING_PROVIDER = getEnvString('EMBEDDING_PROVIDER', 'auto');

--- a/src/services/memory-store.ts
+++ b/src/services/memory-store.ts
@@ -5,7 +5,7 @@
  */
 
 import { logger } from '../utils/logger.js';
-import { KAIROS_REDIS_PREFIX } from '../config.js';
+import { KAIROS_REDIS_PREFIX, MEMORY_CACHE_KEY_PREFIX } from '../config.js';
 import { getSpaceIdFromStorage } from '../utils/tenant-context.js';
 import type { IKeyValueStore } from './key-value-store.js';
 
@@ -34,6 +34,9 @@ export class MemoryStore implements IKeyValueStore {
   }
 
   private getKey(key: string): string {
+    if (key.startsWith(MEMORY_CACHE_KEY_PREFIX)) {
+      return `${this.prefix}${key}`;
+    }
     const spaceId = getSpaceIdFromStorage();
     return `${this.prefix}${spaceId}:${key}`;
   }

--- a/src/services/redis-cache.ts
+++ b/src/services/redis-cache.ts
@@ -1,7 +1,7 @@
 import type { Memory } from '../types/memory.js';
 import { logger } from '../utils/logger.js';
 import { keyValueStore } from './key-value-store-factory.js';
-import { KAIROS_REDIS_PREFIX } from '../config.js';
+import { KAIROS_REDIS_PREFIX, MEMORY_CACHE_KEY_PREFIX } from '../config.js';
 import { getSpaceIdFromStorage } from '../utils/tenant-context.js';
 
 export interface SearchResult {
@@ -21,7 +21,7 @@ export class RedisCacheService {
   private cachePrefix = 'search:';
   private invalidationChannel = 'cache:invalidation';
   private statsPrefix = 'stats:';
-  private memoryPrefix = 'mem:';
+  private memoryPrefix = MEMORY_CACHE_KEY_PREFIX;
 
   constructor() {
     logger.info('[RedisCacheService] Initialized with RedisService');
@@ -93,7 +93,7 @@ export class RedisCacheService {
     }
   }
 
-  // Remove cached memory by UUID (kb:<prefix>mem:{uuid})
+  // Remove cached memory by UUID. Key is global (prefix+mem:uuid), so one del invalidates for all spaces.
   async invalidateMemoryCache(uuid: string): Promise<void> {
     try {
       if (!uuid || typeof uuid !== 'string') {

--- a/src/services/redis.ts
+++ b/src/services/redis.ts
@@ -8,7 +8,7 @@
 
 import { createClient, RedisClientType } from 'redis';
 import { logger } from '../utils/logger.js';
-import { REDIS_URL, KAIROS_REDIS_PREFIX } from '../config.js';
+import { REDIS_URL, KAIROS_REDIS_PREFIX, MEMORY_CACHE_KEY_PREFIX } from '../config.js';
 import { getSpaceIdFromStorage } from '../utils/tenant-context.js';
 import type { IKeyValueStore } from './key-value-store.js';
 
@@ -94,8 +94,11 @@ export class RedisService implements IKeyValueStore {
         }
     }
 
-    /** Key is namespaced by current space (AsyncLocalStorage) so cache and proof-of-work do not collide across spaces. */
+    /** Key is namespaced by current space (AsyncLocalStorage) so cache and proof-of-work do not collide across spaces. Memory cache keys (mem:*) are global: same UUID, one key. */
     private getKey(key: string): string {
+        if (key.startsWith(MEMORY_CACHE_KEY_PREFIX)) {
+            return `${this.prefix}${key}`;
+        }
         const spaceId = getSpaceIdFromStorage();
         return `${this.prefix}${spaceId}:${key}`;
     }

--- a/tests/integration/redis-pubsub-integration.test.ts
+++ b/tests/integration/redis-pubsub-integration.test.ts
@@ -1,7 +1,7 @@
 import { createClient, RedisClientType } from 'redis';
 import { keyValueStore } from '../../src/services/key-value-store-factory.js';
 import { redisCacheService } from '../../src/services/redis-cache.js';
-import { KAIROS_REDIS_PREFIX, KAIROS_APP_SPACE_ID, USE_REDIS } from '../../src/config.js';
+import { KAIROS_REDIS_PREFIX, KAIROS_APP_SPACE_ID, USE_REDIS, MEMORY_CACHE_KEY_PREFIX } from '../../src/config.js';
 import { runWithSpaceContext } from '../../src/utils/tenant-context.js';
 import type { Memory } from '../../src/types/memory.js';
 
@@ -19,9 +19,14 @@ function withDefaultSpace<T>(fn: () => Promise<T>): Promise<T> {
   );
 }
 
-/** Build full Redis key as the app does: prefix + spaceId + ':' + suffix */
+/** Build full Redis key for space-scoped keys: prefix + spaceId + ':' + suffix */
 function redisKey(suffix: string): string {
   return `${KAIROS_REDIS_PREFIX}${KAIROS_APP_SPACE_ID}:${suffix}`;
+}
+
+/** Build full Redis key for memory cache (global, no space): prefix + mem: + uuid */
+function memoryRedisKey(uuid: string): string {
+  return `${KAIROS_REDIS_PREFIX}${MEMORY_CACHE_KEY_PREFIX}${uuid}`;
 }
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
@@ -151,11 +156,11 @@ describeRedis('Redis Pub/Sub Integration Tests', () => {
           created_at: new Date().toISOString()
         };
 
-        // Store memory (uses RedisService which namespaces by space: prefix + spaceId + logicalKey)
+        // Store memory (uses global key: prefix + mem:uuid, no space namespace)
         await redisCacheService.setMemoryResource(testMemory);
 
-        // Verify key exists in Redis (same key format as app: prefix + KAIROS_APP_SPACE_ID + :mem:uuid)
-        const key = redisKey(`mem:${testMemory.memory_uuid}`);
+        // Verify key exists in Redis (global memory key)
+        const key = memoryRedisKey(testMemory.memory_uuid);
         const exists = await testClient.exists(key);
         expect(exists).toBe(1);
 
@@ -226,8 +231,8 @@ describeRedis('Redis Pub/Sub Integration Tests', () => {
         // Store memory
         await redisCacheService.setMemoryResource(testMemory);
 
-        // Verify it exists (keys are namespaced by space)
-        const key = redisKey(`mem:${testMemory.memory_uuid}`);
+        // Verify it exists (memory keys are global)
+        const key = memoryRedisKey(testMemory.memory_uuid);
         expect(await testClient.exists(key)).toBe(1);
 
         // Invalidate memory cache


### PR DESCRIPTION
## Summary
Memory cache entries are now stored under a **global** key `prefix+mem:uuid` (no space segment). One key per UUID; invalidation is a single `del` and clears cache for all consumers/spaces.

## Problem
- Memory was cached per space (`prefix+spaceId:mem:uuid`), so the same UUID could exist in multiple keys.
- Updates only invalidated the key for the current space; other spaces/agents could keep serving stale content.

## Solution
- **Config:** `MEMORY_CACHE_KEY_PREFIX = 'mem:'`; keys starting with it are global.
- **RedisService / MemoryStore:** `getKey(key)` — if `key.startsWith(MEMORY_CACHE_KEY_PREFIX)`, return `prefix+key` (no spaceId).
- **redis-cache:** Uses config constant; `invalidateMemoryCache(uuid)` deletes the single global key.
- **Tests:** `redis-pubsub-integration.test.ts` updated to expect global memory keys via `memoryRedisKey(uuid)`.

## Verification
- `npm run dev:deploy` ✅
- `npm run dev:test` ✅ (39 suites, 133 passed)