### PR TITLE
chore: bump version to 3.0.1-beta.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.15",
+  "version": "3.0.1-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.0.1-beta.15",
+      "version": "3.0.1-beta.16",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.15",
+  "version": "3.0.1-beta.16",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Beta prerelease bump. Tag and publish will run automatically after merge (see .github/workflows/release-tag-on-version-bump.yml).