### PR TITLE
fix(docker): default PORT to 3000 in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p logs storage/qdrant && \
 
 USER kairos
 
-ARG PORT=3500
+ARG PORT=3000
 ENV PORT=${PORT}
 ARG METRICS_PORT=9090
 ENV METRICS_PORT=${METRICS_PORT}


### PR DESCRIPTION
Align Docker image default PORT with `config.ts` (3000) and common compose port mappings. Image previously defaulted to 3500, causing mismatch when compose published 3000:3000.