### PR TITLE
feat: add kairos agent skill for npx skills add

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KAIROS MCP
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js Version](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen)](https://nodejs.org/)
+[License: MIT](https://opensource.org/licenses/MIT)
+[Node.js Version](https://nodejs.org/)
 
 KAIROS MCP gives AI agents persistent memory and deterministic protocol
 execution. Agents store, retrieve, and run reusable protocol chains across
@@ -15,9 +15,9 @@ primitives:
 
 - **Persistent memory** — store and retrieve protocol chains across sessions
 - **Deterministic execution** — search → begin → next → attest; the server
-  drives `next_action` at every step
-- **Agent-facing design** — tool descriptions and error messages built for
-  programmatic consumption and recovery
+drives `next_action` at every step
+- **Agent-facing design** — tool descriptions and error messages built for  
+programmatic consumption and recovery
 
 ## Quick start
 
@@ -26,51 +26,48 @@ KAIROS runs as a Docker stack. Docker and Docker Compose are required.
 **Minimal (default):** Qdrant + app only. No Redis or auth.
 
 1. Download the Compose file and minimal env example:
-
-   ```bash
+  ```bash
    curl -LO https://raw.githubusercontent.com/debian777/kairos-mcp/main/compose.yaml
    curl -LO https://raw.githubusercontent.com/debian777/kairos-mcp/main/docs/install/env.example.minimal.txt
    cp env.example.minimal.txt .env
-   ```
-
+  ```
 2. Set your embedding provider in `.env` (e.g. `OPENAI_API_KEY=sk-proj-...`).
-
 3. Start the stack:
-
-   ```bash
+  ```bash
    docker compose -p kairos-mcp up -d
-   ```
-
+  ```
 4. Confirm the server is healthy:
-
-   ```bash
+  ```bash
    curl http://localhost:3000/health
-   ```
+  ```
 
 **Full stack (Redis, Postgres, Keycloak):** Use [docs/install/env.example.fullstack.txt](docs/install/env.example.fullstack.txt) as `.env`, set `REDIS_URL=redis://redis:6379` and your secrets, then:
-
-   ```bash
-   docker compose -p kairos-mcp --profile fullstack up -d
-   ```
 
 See [docs/install/README.md](docs/install/README.md) for env variants. Full developer workflow is in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Installation
 
 - **Docker Compose (recommended)** — minimal (Qdrant + app) by default, or
-  full stack with Redis and Keycloak; see the quick start above.
-
+full stack with Redis and Keycloak; see the quick start above.
 - **npm (CLI only)** — install the `kairos` command-line tool globally.
-  Node.js 24 or later is required.
-
+Node.js 24 or later is required.
   ```bash
   npm install -g @debian777/kairos-mcp
   ```
-
   See [KAIROS CLI](docs/CLI.md) for usage.
 
 For development setup and all `npm run` commands, see
 [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Agent skill
+
+Install the KAIROS skill so your agent can run protocols (/k, /apply, /search) without extra prompting:
+
+```bash
+npx skills add debian777/kairos-mcp
+```
+
+Optional: `-g` for global install, `-a cursor` to target Cursor only. Then run the skill or ask your agent to run KAIROS protocols. For server setup and MCP config, see [Install KAIROS MCP in Cursor](docs/INSTALL-MCP.md).
 
 ## Documentation
 

--- a/docs/INSTALL-MCP.md
+++ b/docs/INSTALL-MCP.md
@@ -1,5 +1,7 @@
 # Install KAIROS MCP in Cursor
 
+**Agent skill:** Install the [KAIROS agent skill](../README.md#agent-skill) and ask your agent to run KAIROS protocols; for MCP config the agent can help or use this section. This section is for manual configuration.
+
 This guide shows you how to connect KAIROS to Cursor as an MCP server. Once
 connected, Cursor can call KAIROS tools automatically without prompting for
 each one.

--- a/skills/kairos/SKILL.md
+++ b/skills/kairos/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: kairos
+description: >-
+  Run KAIROS protocols. Use when the user invokes /k, /apply, or /search; the
+  query is everything after the trigger word. Use when the user wants to run a
+  protocol, execute a KAIROS workflow, or work in a KAIROS repo. For first-time
+  install and server setup, use the kairos-install skill instead.
+---
+
+# kairos
+
+**Protocol execution only.** For installing KAIROS (minimal Docker + .env and MCP config), use the **kairos-install** skill.
+
+When the user wants to run a protocol (e.g. after /k, /apply, /search or when the context implies a KAIROS workflow):
+
+1. Use the KAIROS tool `kairos_search` with the query: everything that comes after `/k`, `/apply`, or `/search` (or the user's stated goal).
+2. Choose the protocol that matches the user request.
+3. Follow the protocol to the letter: `kairos_begin` → `kairos_next` (until `next_action` directs to attest) → `kairos_attest`. Echo nonces and proof hashes from the server; never compute them yourself.


### PR DESCRIPTION
Adds the **kairos** agent skill only (protocol execution). Install with:

```bash
npx skills add debian777/kairos-mcp
```

- **skills/kairos/SKILL.md** — run protocols (/k, /apply, /search); kairos_search → begin → next → attest
- README and INSTALL-MCP.md updated for single-skill install

kairos-install skill is not included in this PR (to be tested separately).

Made with [Cursor](https://cursor.com)