### PR TITLE
chore: bump version to 3.0.1-beta.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.16",
+  "version": "3.0.1-beta.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.0.1-beta.16",
+      "version": "3.0.1-beta.17",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.16",
+  "version": "3.0.1-beta.17",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",

--- a/src/http/http-mcp-handler.ts
+++ b/src/http/http-mcp-handler.ts
@@ -51,23 +51,6 @@ function mcpErrorToHelp(error: unknown): { message: string; error_code: string; 
   };
 }
 
-/** Help text and error_code for clients; never expose internal error details. */
-function mcpErrorToHelp(error: unknown): { message: string; error_code: string; retry_hint: string } {
-  const msg = error instanceof Error ? error.message : String(error);
-  if (msg.includes('Already connected to a transport')) {
-    return {
-      message: 'Server is busy with another request. Wait a few seconds and retry; if it continues, start a new MCP session.',
-      error_code: 'CONNECTION_CONFLICT',
-      retry_hint: 'Wait a few seconds and retry the same request; if repeated, start a new MCP session.'
-    };
-  }
-  return {
-    message: 'An unexpected error occurred. Please retry. If the problem continues, start a new MCP session.',
-    error_code: 'SERVER_ERROR',
-    retry_hint: 'Retry the request; if it persists, start a new MCP session.'
-  };
-}
-
 /**
  * Set up MCP endpoint handling.
  * Uses a new MCP server instance per request so many requests can be handled


### PR DESCRIPTION
Prerelease version bump. After merge, release tag and publish workflows run automatically.

Made with [Cursor](https://cursor.com)