### PR TITLE
chore(ci): TypeScript check step + auto-rebase PRs on main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,6 +105,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: TypeScript check
+        run: npx tsc --noEmit
+        # Fail fast on TS errors (e.g. duplicate function); full build runs later.
+
       - name: Knip (compliance)
         run: npm run knip
 

--- a/.github/workflows/rebase-prs-on-main.yml
+++ b/.github/workflows/rebase-prs-on-main.yml
@@ -1,0 +1,53 @@
+# When main is updated, rebase all open PRs targeting main onto latest main.
+# Ensures PRs run CI against the current base and avoids stale-merge conflicts.
+# Uses GITHUB_TOKEN; branch protection may still require "up to date" before merge.
+name: Rebase PRs on main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (fetch all refs)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List open PRs targeting main
+        id: prs
+        run: |
+          gh pr list --base main --state open --json number,headRefName,headRefOid --jq '.[] | "\(.number) \(.headRefName) \(.headRefOid)"' > prs.txt || true
+          echo "Open PRs:"
+          cat prs.txt || true
+
+      - name: Rebase each PR branch onto main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            pr_num=$(echo "$line" | awk '{print $1}')
+            head_ref=$(echo "$line" | awk '{print $2}')
+            echo "Rebasing PR #$pr_num ($head_ref) onto main..."
+            git fetch origin "$head_ref"
+            git checkout "$head_ref"
+            if ! git rebase origin/main; then
+              echo "Rebase failed for PR #$pr_num (conflicts?), aborting"
+              git rebase --abort 2>/dev/null || true
+              git checkout main
+              continue
+            fi
+            git push origin "$head_ref" --force-with-lease
+            git checkout main
+            echo "Rebased PR #$pr_num"
+          done < prs.txt
+          echo "Done (no PRs or all processed)"


### PR DESCRIPTION
## Changes
- **Integration workflow**: Add explicit `TypeScript check` step (`npx tsc --noEmit`) after `npm ci` so TS errors (e.g. duplicate function) fail the job early with a clear step name.
- **Rebase PRs on main**: New workflow `rebase-prs-on-main.yml` runs on every push to `main`. Rebases all open PRs targeting `main` onto latest `main` and force-pushes (skips PRs with rebase conflicts). Ensures PRs run CI against current base.

Made with [Cursor](https://cursor.com)