### PR TITLE
Merge queue support and kairos-dev skill

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,7 @@ name: Integration
 on:
   pull_request:
     branches: [main]
+  merge_group:
   push:
     branches: [main]
     tags:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,21 @@ Use these prefixes:
 - Branch is up to date with `main`.
 - PR description states what changed, why, and how to test it.
 
+## Merge queue (repository setting)
+
+To enable a [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) for `main` (GitHub’s equivalent of GitLab merge trains):
+
+1. **Repo** → **Settings** → **Rules** → **Rulesets** → open the ruleset that applies to `main`, or **Branches** → **Branch protection** for `main`.
+2. Enable **Require merge queue**.
+3. Optional settings:
+   - **Merge method:** merge / rebase / squash (e.g. **Squash** for single-commit PRs).
+   - **Build concurrency:** 1–100 (max concurrent `merge_group` runs; e.g. **3**).
+   - **Only merge non-failing pull requests:** on = **ALLGREEN** (every PR in the group must pass); off = **HEADGREEN** (only the combined head must pass).
+   - **Status check timeout:** how long to wait for CI before treating as failed (e.g. 15 min).
+   - **Merge limits:** min/max PRs per merge (e.g. 1–5), and wait time for minimum group size.
+
+The integration workflow (`.github/workflows/integration.yml`) already triggers on `merge_group`, so required checks run when PRs are in the queue. Use `gh pr merge` (no strategy) to add a PR to the queue; use `gh pr merge --admin` to bypass the queue.
+
 ## Code style
 
 - **Language:** TypeScript for all source files.


### PR DESCRIPTION
## Summary

- **Merge queue:** Integration workflow triggers on `merge_group` so required checks run when PRs are in the queue. CONTRIBUTING documents how to enable **Require merge queue** in repo settings and optional settings (merge method, build concurrency, ALLGREEN/HEADGREEN, timeout, merge limits).
- **skills/kairos-dev:** Canonical agent instructions (workflow-test, ai-mcp-integration), SKILL.md with Agent Skills frontmatter, multi-skill install docs in README and skills/README.

## Changes

- `.github/workflows/integration.yml`: add `merge_group:` trigger
- `CONTRIBUTING.md`: Merge queue (repository setting) section
- skills/kairos-dev, README/skills table, docs references (see full diff)