### PR TITLE
docs: add known issues and limitations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,8 @@ execute end-to-end.
 - [Skills that ship KAIROS protocols](../skills/README.md) —
   how a skill can bundle a protocol, declare requirements, and run
   search → mint if missing → execute.
+- [Known issues and limitations](known-issues-and-limitations.md) —
+  current limitations, upgrade policy, and where to find breaking changes.
 
 ## Examples
 

--- a/docs/known-issues-and-limitations.md
+++ b/docs/known-issues-and-limitations.md
@@ -1,0 +1,20 @@
+# Known issues and limitations
+
+## Known issues
+
+None at this time.
+
+When you fix something that was only tracked informally, add a one-line “Fixed in X.Y.Z” note when you release.
+
+## Limitations
+
+- **Single maintainer; no SLA.** This project is maintained by a single person. There is no formal support or uptime guarantee.
+- **Embedding provider required.** You must use either OpenAI (embeddings API) or a self-hosted TEI-compatible endpoint. See [Install and environment](install/README.md) and `EMBEDDING_PROVIDER` in [config](../src/config.ts).
+- **Keycloak optional but required for multi-tenant auth.** Without Keycloak (or another OIDC provider), the server runs without authentication. Multi-tenant or authenticated access requires Keycloak (or equivalent) configuration.
+- **Qdrant and (for production) Redis.** Vector storage (Qdrant) is always required. Redis is required for production use (proof-of-work state); in-memory backend is for dev only.
+
+## Upgrade and breaking changes
+
+Release notes and version history are published on [GitHub Releases](https://github.com/debian777/kairos-mcp/releases).
+
+We follow [semantic versioning](https://semver.org/). **Patch and minor releases are backward-compatible.** **Major releases may introduce breaking changes** to the protocol, configuration, or APIs; check the release notes before upgrading.


### PR DESCRIPTION
Adds the single doc a production-ready product should have:

- **docs/known-issues-and-limitations.md** — Known issues (none at this time), limitations (single maintainer / no SLA, embedding provider required, Keycloak for multi-tenant auth, Qdrant/Redis), and upgrade/breaking policy (semver, link to GitHub Releases).
- **docs/README.md** — Link under Concepts to the new doc.

Implements the trimmed plan (no runbook, no release-criteria doc).