### PR TITLE
chore: release 3.0.1-beta.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.17",
+  "version": "3.0.1-pre.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.0.1-beta.17",
+      "version": "3.0.1-pre.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-beta.17",
+  "version": "3.0.1-pre.0",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,5 +1,5 @@
 ---
-version: "3.0.1-beta.17"
+version: "3.0.1-pre.0"
 
 title: Create New KAIROS Protocol Chain
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "3.0.1-beta.17"
+version: "3.0.1-pre.0"
 
 title: Get help refining your search
 ---


### PR DESCRIPTION
Pre-release version bump.

- **Version:** 3.0.1-beta.17 → 3.0.1-beta.18
- **Updated:** package.json, package-lock.json, embed-docs mem version refs

After merge, the release-tag-on-version-bump workflow will create tag `v3.0.1-beta.18` and trigger the Release workflow (npm publish with `beta` tag, Docker, GitHub Release).