### PR TITLE
fix(ci): surface auth integration test failure and opt into Node 24

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,8 @@ jobs:
   integration:
     name: Infra + dev deploy + integration tests (AUTH on)
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout
@@ -143,6 +145,17 @@ jobs:
 
       - name: Run auth integration test
         run: npm run dev:test
+
+      - name: Show test failure
+        if: failure()
+        run: |
+          echo "--- Last test report (tail) ---"
+          latest=$(ls -t reports/tests/*.log 2>/dev/null | head -n1)
+          if [ -n "$latest" ]; then
+            tail -n 200 "$latest"
+          else
+            echo "No reports/tests/*.log found"
+          fi
 
       - name: Upload kairos log - check
         if: always() && failure()

--- a/scripts/run-env.sh
+++ b/scripts/run-env.sh
@@ -377,11 +377,14 @@ test() {
 
     case "$ENV" in
         dev)
+            # In CI, run without --silent so the step log shows which test failed
+            silent_flag=""
+            [ "${CI:-}" = "true" ] || silent_flag="--silent"
             # deploy - now need to run manually: npm run dev:deploy
             if [ ${#args[@]} -eq 0 ]; then
-                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest --silent --runInBand --detectOpenHandles --testTimeout=30000 --testPathPatterns "tests/integration/" 2>&1  | tee -a "$REPORT_LOG_FILE"
+                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag --runInBand --detectOpenHandles --testTimeout=30000 --testPathPatterns "tests/integration/" 2>&1  | tee -a "$REPORT_LOG_FILE"
             else
-                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest --silent --runInBand --detectOpenHandles --testTimeout=30000 "${args[@]}" 2>&1  | tee -a "$REPORT_LOG_FILE"
+                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag --runInBand --detectOpenHandles --testTimeout=30000 "${args[@]}" 2>&1  | tee -a "$REPORT_LOG_FILE"
             fi
             ;;
         prod)


### PR DESCRIPTION
Makes the failing Integration job (auth integration test) easier to debug and clears the Node 20 deprecation warning.

**Changes:**
- **Jest in CI:** Run without `--silent` when `CI=true` so the step log shows which test failed and the stack trace.
- **Show test failure step:** On failure, print the last 200 lines of the latest `reports/tests/*.log` so the tail of the test report is visible in the Actions log.
- **Node 24:** Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at job level so JS actions use Node 24 and the deprecation warning is resolved.

After merge, the next failure (if any) will show the actual failing test and error in the "Run auth integration test" and "Show test failure" steps.