### PR TITLE
fix(ci): opt all workflows into Node 24

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
       id-token: write  # Required for npm Trusted Publishing (OIDC)

--- a/.github/workflows/rebase-prs-on-main.yml
+++ b/.github/workflows/rebase-prs-on-main.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   rebase:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout (fetch all refs)
         uses: actions/checkout@v4

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -16,6 +16,8 @@ jobs:
     name: Tag if version bumped
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: write  # push tag
       actions: write  # trigger Release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
   publish-npm:
     name: Publish npm
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     # If you set an "Environment" in npm Trusted Publisher, set it here too (e.g. environment: production)
     permissions:
       contents: read
@@ -89,6 +91,8 @@ jobs:
     name: Publish Docker image
     needs: publish-npm
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
 
@@ -149,6 +153,8 @@ jobs:
     needs: [publish-npm, publish-docker]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.ref != '')
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: write
 


### PR DESCRIPTION
Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in every workflow that uses JS actions so the Node.js 20 deprecation warning is cleared.

**Workflows updated:**
- release-tag-on-version-bump (Tag if version bumped)
- rebase-prs-on-main
- publish-container
- publish-npm
- release (publish-npm, publish-docker, create-release jobs)

Integration already had this from a previous PR.