### PR TITLE
chore: release 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-pre.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.0.1-pre.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.0.1-pre.0",
+  "version": "3.0.1",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,5 +1,5 @@
 ---
-version: "3.0.1-pre.0"
+version: "3.0.1"
 
 title: Create New KAIROS Protocol Chain
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "3.0.1-pre.0"
+version: "3.0.1"
 
 title: Get help refining your search
 ---


### PR DESCRIPTION
Normal release (3.0.1 from 3.0.1-pre.0).

**Version:** 3.0.1  
**Updated:** package.json, package-lock.json, embed-docs mem version refs

After merge, the release-tag-on-version-bump workflow will create tag `v3.0.1` and trigger the Release workflow (npm publish, Docker, GitHub Release).