### PR TITLE
fix(release): mark hyphenated tags as prerelease on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
       contents: write
 
     steps:
-      - name: Set tag name
+      - name: Set tag name and prerelease flag
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.ref }}" ]; then
@@ -167,6 +167,11 @@ jobs:
           else
             echo "tag_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
+          # Tag with hyphen (e.g. v3.1.0-pre.0, v3.0.1-beta.1) => prerelease; GitHub then shows latest stable as "Latest release"
+          case "${{ steps.tag.outputs.tag_name }}" in
+            *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
+            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -175,3 +180,4 @@ jobs:
           name: ${{ steps.tag.outputs.tag_name }}
           generate_release_notes: true
           draft: false
+          prerelease: ${{ steps.tag.outputs.prerelease }}


### PR DESCRIPTION
Tags like `v3.1.0-pre.0` or `v3.0.1-beta.1` are now created with `prerelease: true` so GitHub shows the latest **stable** (e.g. 3.0.1) as "Latest release" instead of the prerelease.