### PR TITLE
fix(release): serve UI from package dist and writable /snapshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ RUN npm install @debian777/kairos-mcp@${PACKAGE_VERSION} && \
     npm cache clean --force && \
     chown -R kairos:nodejs /app
 
-# Create directories for logs and data
-RUN mkdir -p logs storage/qdrant && \
-    chown -R kairos:nodejs /app logs storage
+# Create directories for logs, data, and snapshots (VOLUME mount point; kairos must be able to write)
+RUN mkdir -p logs storage/qdrant /snapshots && \
+    chown -R kairos:nodejs /app logs storage /snapshots
 
 USER kairos
 

--- a/src/http/http-ui-static.ts
+++ b/src/http/http-ui-static.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import express from "express";
 
-/** Always serve the built SPA from dist/ui (dev runs from src via ts-node, so we use cwd). */
-const UI_DIR = path.resolve(process.cwd(), "dist", "ui");
+/** Serve the built SPA from dist/ui. Resolve relative to this module so it works when run from npm-installed package (cwd is /app, UI is in node_modules/.../dist/ui). */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const UI_DIR = path.resolve(__dirname, "..", "ui");
 
 /**
  * Serve the built SPA at URL /ui.


### PR DESCRIPTION
Fixes production errors after release:

1. **ENOENT /app/dist/ui/index.html** — UI_DIR was resolved from `process.cwd()` (`/app`). In the release container the app runs from `node_modules/@debian777/kairos-mcp/dist/index.js`, so the UI lives at `node_modules/.../dist/ui/`. Resolve `UI_DIR` relative to the http-ui-static module (`dist/http` → `../ui`) so it works from the installed package.

2. **EACCES /snapshots** — Dockerfile declared `VOLUME /snapshots` but did not create or chown the directory. Create `/snapshots` and `chown kairos:nodejs` so the snapshot pipeline can write.