### PR TITLE
docs(README): cap logo size with HTML img width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KAIROS MCP
 
-![KAIROS MCP logo](logo/kaiiros-mcp.svg)
+<img src="logo/kaiiros-mcp.svg" width="128" alt="KAIROS MCP logo" />
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D24.0.0-brightgreen)](https://nodejs.org/)


### PR DESCRIPTION
Replace markdown image with `<img width="128">` so the SVG displays at 128px on GitHub instead of full 512px.