### PR TITLE
fix: demote noisy and trace-like logs to debug level

### DIFF
--- a/src/services/embedding/providers.ts
+++ b/src/services/embedding/providers.ts
@@ -51,7 +51,7 @@ async function postEmbeddingsOpenAI(input: string[] | string): Promise<number[][
         setResolvedEmbeddingDimension(dim);
     }
     const dim = embeddings.length > 0 && embeddings[0] ? embeddings[0].length : 0;
-    logger.info(`[EmbeddingService] Received ${embeddings.length} embeddings (dim=${dim}) [provider=openai]`);
+    logger.debug(`[EmbeddingService] Received ${embeddings.length} embeddings (dim=${dim}) [provider=openai]`);
     return embeddings;
 }
 
@@ -103,7 +103,7 @@ async function postEmbeddingsTEI(input: string[] | string): Promise<number[][]> 
 
     const dim = embeddings[0].length;
     setResolvedEmbeddingDimension(dim);
-    logger.info(`[EmbeddingService] Received ${embeddings.length} embeddings (dim=${dim}) [provider=tei]`);
+    logger.debug(`[EmbeddingService] Received ${embeddings.length} embeddings (dim=${dim}) [provider=tei]`);
     return embeddings as number[][];
 }
 

--- a/src/services/memory/store-chain-default-handler.ts
+++ b/src/services/memory/store-chain-default-handler.ts
@@ -128,12 +128,11 @@ export async function storeDefaultChain(
   logger.tool(
     'memory-qdrant-store',
     'upsert',
-    `mode=default docs=${normalizedDocs.length} collection=${collection} payload=${JSON.stringify({
-      points
-    })}`
+    `mode=default docs=${normalizedDocs.length} collection=${collection} points=${points.length}`
   );
-
-  logger.debug(`[Qdrant][upsert] collection=${collection} points=${points.length}`);
+  logger.debug(
+    `[Qdrant][upsert] collection=${collection} points=${points.length} payload=${JSON.stringify({ points })}`
+  );
   try {
     await client.upsert(collection, { points });
   } catch (err) {

--- a/src/services/memory/store-chain-header-handler.ts
+++ b/src/services/memory/store-chain-header-handler.ts
@@ -104,12 +104,11 @@ export async function storeHeaderBasedChain(
   logger.tool(
     'memory-qdrant-store',
     'upsert',
-    `mode=h1-h2 sections=${headerChainMemories.length} collection=${collection} payload=${JSON.stringify({
-      points
-    })}`
+    `mode=h1-h2 sections=${headerChainMemories.length} collection=${collection} points=${points.length}`
   );
-
-  logger.debug(`[Qdrant][upsert] collection=${collection} points=${points.length}`);
+  logger.debug(
+    `[Qdrant][upsert] collection=${collection} points=${points.length} payload=${JSON.stringify({ points })}`
+  );
   try {
     await client.upsert(collection, { points });
   } catch (err) {

--- a/src/services/qdrant/memory-store.ts
+++ b/src/services/qdrant/memory-store.ts
@@ -34,18 +34,18 @@ export async function storeMemory(
     if (uuid) {
       // Use provided UUID directly
       qdrantId = uuid;
-      logger.info(`storeMemory: Using provided UUID as qdrantId: ${qdrantId}`);
+      logger.debug(`storeMemory: Using provided UUID as qdrantId: ${qdrantId}`);
     } else {
       // Generate URI and Qdrant ID as before
       if (protocol && protocol.step) {
         humanUri = buildProtocolStepURI(domain, type, task, protocol.step);
-        logger.info(`storeMemory: Built protocol URI for step ${protocol.step}: ${humanUri}`);
+        logger.debug(`storeMemory: Built protocol URI for step ${protocol.step}: ${humanUri}`);
       } else {
         humanUri = buildDomainTypeTaskURI(domain, type, task);
-        logger.info(`storeMemory: Built non-protocol URI: ${humanUri}`);
+        logger.debug(`storeMemory: Built non-protocol URI: ${humanUri}`);
       }
       qdrantId = IDGenerator.buildQdrantId(humanUri);
-      logger.info(`storeMemory: Generated Qdrant ID from URI: ${qdrantId} (from ${humanUri})`);
+      logger.debug(`storeMemory: Generated Qdrant ID from URI: ${qdrantId} (from ${humanUri})`);
     }
 
     let aiWithContext: { model_id: string; memory_uuid?: string } = { model_id: 'unknown' };
@@ -96,9 +96,9 @@ export async function storeMemory(
       }
     };
 
-    logger.info(`storeMemory: About to upsert point with qdrantId: ${qdrantId}, humanUri: ${humanUri}`);
+    logger.debug(`storeMemory: About to upsert point with qdrantId: ${qdrantId}, humanUri: ${humanUri}`);
     const upsertResult = await sanitizeAndUpsert(conn.client, conn.collectionName, [point]);
-    logger.info(`storeMemory: Upsert result for qdrantId ${qdrantId}: ${JSON.stringify(upsertResult)}`);
+    logger.debug(`storeMemory: Upsert result for qdrantId ${qdrantId}: ${JSON.stringify(upsertResult)}`);
     
     // Invalidate cache after creation (publishes invalidation events internally)
     await redisCacheService.invalidateMemoryCache(qdrantId);

--- a/src/services/qdrant/utils.ts
+++ b/src/services/qdrant/utils.ts
@@ -15,7 +15,7 @@ export function isValidUUID(uuid: string): boolean {
 export function convertTestIdToUUID(testId: string): string {
   if (isValidUUID(testId)) return testId;
   const deterministicUUID = uuidv4();
-  logger.info(`Converted test ID "${testId}" to UUID: ${deterministicUUID}`);
+  logger.debug(`Converted test ID "${testId}" to UUID: ${deterministicUUID}`);
   return deterministicUUID;
 }
 

--- a/src/services/redis-cache.ts
+++ b/src/services/redis-cache.ts
@@ -70,7 +70,7 @@ export class RedisCacheService {
 
   async invalidateSearchCache(): Promise<void> {
     try {
-      logger.info(`[RedisCacheService] Search cache invalidation requested`);
+      logger.debug(`[RedisCacheService] Search cache invalidation requested`);
       // Delete keys matching search cache pattern (all collapse modes)
       const keys = await keyValueStore.keys(`${this.cachePrefix}*`);
       if (!keys || keys.length === 0) {
@@ -85,7 +85,7 @@ export class RedisCacheService {
         k.startsWith(keyPrefix) ? k.slice(keyPrefix.length) : k
       );
       await Promise.all(stripped.map(k => keyValueStore.del(k)));
-      logger.info(`[RedisCacheService] Invalidated ${stripped.length} search cache keys`);
+      logger.debug(`[RedisCacheService] Invalidated ${stripped.length} search cache keys`);
       // Publish invalidation event
       await this.publishInvalidation('search');
     } catch (error) {
@@ -185,7 +185,7 @@ export class RedisCacheService {
   // Invalidate begin cache (kairos_begin tool results)
   async invalidateBeginCache(): Promise<void> {
     try {
-      logger.info(`[RedisCacheService] Begin cache invalidation requested`);
+      logger.debug(`[RedisCacheService] Begin cache invalidation requested`);
       // Delete keys matching begin cache pattern
       const keys = await keyValueStore.keys('begin:*');
       if (!keys || keys.length === 0) {
@@ -198,7 +198,7 @@ export class RedisCacheService {
         k.startsWith(keyPrefix) ? k.slice(keyPrefix.length) : k
       );
       await Promise.all(stripped.map(k => keyValueStore.del(k)));
-      logger.info(`[RedisCacheService] Invalidated ${stripped.length} begin cache keys`);
+      logger.debug(`[RedisCacheService] Invalidated ${stripped.length} begin cache keys`);
     } catch (error) {
       logger.error('[RedisCacheService] Failed to invalidate begin cache:', error);
     }
@@ -207,7 +207,7 @@ export class RedisCacheService {
   // For atomic operations as per plan
   // System is mostly read-heavy, so invalidate aggressively on writes
   async invalidateAfterUpdate(): Promise<void> {
-    logger.info('[RedisCacheService] Cache invalidation after Qdrant update - clearing all search and begin caches');
+    logger.debug('[RedisCacheService] Cache invalidation after Qdrant update - clearing all search and begin caches');
     await Promise.all([
       this.invalidateSearchCache(),
       this.invalidateBeginCache()

--- a/src/services/stats/model-stats.ts
+++ b/src/services/stats/model-stats.ts
@@ -43,18 +43,18 @@ function ensureStatsStateShape(state?: Partial<StatsState>): StatsState {
 function addRecentDiscovery(state: StatsState, discovery: RecentDiscovery): void {
     state.recentDiscoveries.unshift(discovery);
     state.recentDiscoveries = state.recentDiscoveries.slice(0, 20);
-    logger.info(`Added recent discovery by ${discovery.agent} (${discovery.score}pts)`);
+    logger.debug(`Added recent discovery by ${discovery.agent} (${discovery.score}pts)`);
 }
 
 async function updateImplementationBonusHelper(state: StatsState, llm_model_id: string, bonusPoints: number): Promise<void> {
     state.implementationBonuses[llm_model_id] = (state.implementationBonuses[llm_model_id] || 0) + bonusPoints;
-    logger.info(`Implementation bonus: ${llm_model_id} earned ${bonusPoints} points`);
+    logger.debug(`Implementation bonus: ${llm_model_id} earned ${bonusPoints} points`);
     await saveStatsState(state);
 }
 
 async function updateHealerBonusHelper(state: StatsState, llm_model_id: string, bonusPoints: number): Promise<void> {
     state.healerBonuses[llm_model_id] = (state.healerBonuses[llm_model_id] || 0) + bonusPoints;
-    logger.info(`Healer bonus: ${llm_model_id} earned ${bonusPoints} points`);
+    logger.debug(`Healer bonus: ${llm_model_id} earned ${bonusPoints} points`);
     await saveStatsState(state);
 }
 


### PR DESCRIPTION
## Summary
- **memory-qdrant-store**: Info now logs only a short summary (mode, sections/docs, collection, points count). Full payload is logged only at `debug` (was dumping vectors at info).
- **EmbeddingService**: "Received N embeddings" → `debug` (per-call, very frequent).
- **RedisCacheService**: Cache invalidation messages (requested, invalidated N keys, after Qdrant update) → `debug`.
- **model-stats**: "Added recent discovery", "Implementation bonus", "Healer bonus" → `debug`.
- **qdrant/utils**: "Converted test ID to UUID" → `debug`.
- **memory-store** `storeMemory`: Step-by-step logs (UUID/URI/upsert/result) → `debug`.

With default `LOG_LEVEL=info`, production logs are less noisy. Set `LOG_LEVEL=debug` when troubleshooting.