### PR TITLE
fix(release): consider only stable tags when deciding to create release tag

### DIFF
--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -39,10 +39,11 @@ jobs:
         id: pkg
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Get latest tag (by version in repo)
+      - name: Get latest stable tag (by version in repo)
         id: tag
         run: |
-          latest=$(git tag -l 'v*' --sort=-v:refname | head -1 || echo "v0.0.0")
+          # Only consider stable tags (vX.Y.Z); prereleases (v3.0.1-pre.0) must not block creating v3.0.1
+          latest=$(git tag -l 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "v0.0.0")
           echo "tag=${latest}" >> "$GITHUB_OUTPUT"
           echo "version=${latest#v}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
**Problem:** When merging a normal release (e.g. 3.0.1), the "Release tag on version bump" workflow did not create the tag. Prerelease tags (e.g. `v3.0.1-pre.0`) were taken as "latest", and `sort -V` ranks `3.0.1-pre.0` > `3.0.1`, so the condition failed and no tag was created.

**Fix:** Only consider **stable** tags (`vX.Y.Z` with no hyphen) when computing "latest". Prereleases no longer block creating the matching stable tag.