### PR TITLE
chore: bump prerelease to 3.1.0-pre.1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.1.0-pre.0",
+  "version": "3.1.0-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.1.0-pre.0",
+      "version": "3.1.0-pre.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.1.0-pre.0",
+  "version": "3.1.0-pre.1",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/kairos-ai-docs/SKILL.md
+++ b/skills/kairos-ai-docs/SKILL.md
@@ -3,7 +3,7 @@ name: kairos-ai-docs
 description: Find and run the zero-drift minimal template for writing AI instructions via KAIROS. Use when the user invokes /ai-docs or asks to write, generate, or update AI instructions using the zero-drift template.
 compatibility: Requires KAIROS MCP server to be configured and connected.
 metadata:
-  version: "1.0.0"
+  version: "3.0.1"
   author: kairos-mcp
   protocol: references/KAIROS.md
   protocol_query: write AI instructions zero-drift minimal template

--- a/skills/kairos-ai-docs/references/KAIROS.md
+++ b/skills/kairos-ai-docs/references/KAIROS.md
@@ -1,5 +1,5 @@
 ---
-version: "1.0.0"
+version: "3.0.1"
 
 title: Zero-Drift Minimal Template for AI Instructions
 ---

--- a/skills/kairos-code/SKILL.md
+++ b/skills/kairos-code/SKILL.md
@@ -3,7 +3,7 @@ name: kairos-code
 description: Run the KAIROS ELITE AI CODING STANDARDS protocol. Use when the user invokes /code, asks for AI coding rules, or wants code changes to follow the full protocol (feature branch, baseline tests, full suite, deploy to dev, validate, then promote).
 compatibility: Requires KAIROS MCP server to be configured and connected.
 metadata:
-  version: "1.0.0"
+  version: "3.0.1"
   author: kairos-mcp
   protocol: references/KAIROS.md
   protocol_query: ELITE AI CODING STANDARDS code

--- a/skills/kairos-code/references/KAIROS.md
+++ b/skills/kairos-code/references/KAIROS.md
@@ -1,5 +1,5 @@
 ---
-version: "1.0.0"
+version: "3.0.1"
 
 title: ELITE AI CODING STANDARDS
 ---

--- a/skills/kairos-create-protocol/SKILL.md
+++ b/skills/kairos-create-protocol/SKILL.md
@@ -3,7 +3,7 @@ name: kairos-create-protocol
 description: Run the KAIROS "Create New KAIROS Protocol Chain" protocol. Use when the user invokes /k create new protocol, or asks to create a new protocol, mint a workflow, or build a protocol (when kairos_search found no match and user confirms).
 compatibility: Requires KAIROS MCP server to be configured and connected.
 metadata:
-  version: "1.0.0"
+  version: "3.0.1"
   author: kairos-mcp
   protocol: references/KAIROS.md
   protocol_query: create new KAIROS protocol chain

--- a/skills/kairos-create-protocol/references/KAIROS.md
+++ b/skills/kairos-create-protocol/references/KAIROS.md
@@ -1,5 +1,5 @@
 ---
-version: "1.0.0"
+version: "3.0.1"
 
 title: Create New KAIROS Protocol Chain
 ---

--- a/skills/kairos-create-skill/SKILL.md
+++ b/skills/kairos-create-skill/SKILL.md
@@ -3,7 +3,7 @@ name: kairos-create-skill
 description: Run the KAIROS protocol for creating a KAIROS skill (Agent Skill with optional references/KAIROS.md or multiple references/KAIROS-{alias}.md protocols). Use when the user wants to create a KAIROS skill, create a skill with a KAIROS protocol, write SKILL.md, or asks about skill structure and Agent Skills format (agentskills.io).
 compatibility: Requires KAIROS MCP server to be configured and connected.
 metadata:
-  version: "1.0.0"
+  version: "3.0.1"
   author: kairos-mcp
   protocol: references/KAIROS.md
   protocol_query: create KAIROS skill with KAIROS.md protocol

--- a/skills/kairos-create-skill/references/KAIROS.md
+++ b/skills/kairos-create-skill/references/KAIROS.md
@@ -1,5 +1,5 @@
 ---
-version: "1.0.0"
+version: "3.0.1"
 
 title: Create KAIROS skill (with KAIROS.md protocol)
 ---

--- a/skills/kairos-refine-search/SKILL.md
+++ b/skills/kairos-refine-search/SKILL.md
@@ -3,7 +3,7 @@ name: kairos-refine-search
 description: Run the KAIROS "Get help refining your search" protocol when kairos_search has no strong match (score ≥ 0.5). Use when the response suggests refining the query or improving the search.
 compatibility: Requires KAIROS MCP server to be configured and connected.
 metadata:
-  version: "1.0.0"
+  version: "3.0.1"
   author: kairos-mcp
   protocol: references/KAIROS.md
   protocol_query: get help refining your search

--- a/skills/kairos-refine-search/references/KAIROS.md
+++ b/skills/kairos-refine-search/references/KAIROS.md
@@ -1,5 +1,5 @@
 ---
-version: "1.0.0"
+version: "3.0.1"
 
 title: Get help refining your search
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,5 +1,5 @@
 ---
-version: "3.1.0-pre.0"
+version: "3.1.0-pre.1"
 
 title: Create New KAIROS Protocol Chain
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "3.1.0-pre.0"
+version: "3.1.0-pre.1"
 
 title: Get help refining your search
 ---


### PR DESCRIPTION
Prerelease bump: 3.1.0-pre.0 → 3.1.0-pre.1. Tag and publish will run automatically after merge (release-tag-on-version-bump workflow).