### PR TITLE
fix(release): set prerelease from tag name so betas are not Latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,12 +173,13 @@ jobs:
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.ref }}" ]; then
-            echo "tag_name=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
+            tag_name="${{ github.event.inputs.ref }}"
           else
-            echo "tag_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            tag_name="${{ github.ref_name }}"
           fi
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
           # Tag with hyphen (e.g. v3.1.0-pre.0, v3.0.1-beta.1) => prerelease; GitHub then shows latest stable as "Latest release"
-          case "${{ steps.tag.outputs.tag_name }}" in
+          case "${tag_name}" in
             *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
             *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
           esac


### PR DESCRIPTION
## Problem
Beta releases (e.g. `v3.2.0-beta.0`) were created as normal releases and showed as **Latest** on GitHub.

## Cause
In `create-release`, the step used `${{ steps.tag.outputs.tag_name }}` in the `case` that sets `prerelease`. Outputs from the same step are not available during that step, so the value was empty, the `*-*` pattern never matched, and `prerelease=false` was always set.

## Fix
Use a shell variable `tag_name` set in the same run script and use it in the `case`. Any tag with a hyphen (e.g. `v3.2.0-beta.0`) is now correctly marked as prerelease.

**Manual one-time fix for existing v3.2.0-beta.0:** Edit that release on GitHub and check "Set as a pre-release" so it stops showing as Latest.