### PR TITLE
chore: bump version to 3.2.0-pre.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.2.0-beta.0",
+  "version": "3.2.0-pre.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.2.0-beta.0",
+      "version": "3.2.0-pre.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.2.0-beta.0",
+  "version": "3.2.0-pre.0",
   "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
   "type": "module",
   "main": "dist/index.js",

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,5 +1,5 @@
 ---
-version: "3.2.0-beta.0"
+version: "3.2.0-pre.0"
 
 title: Create New KAIROS Protocol Chain
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "3.2.0-beta.0"
+version: "3.2.0-pre.0"
 
 title: Get help refining your search
 ---


### PR DESCRIPTION
Version bump to 3.2.0-pre.0. Mem docs synced via `npm run version:sync-skills`. No git tag (handled by release workflow on merge).