### PR TITLE
fix(api): API–MCP sync, canonical schemas, @exodus/bytes for auth

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -26,6 +26,8 @@ const config: KnipConfig = {
         'src/resources/embedded-mcp-resources.ts',
         // Vite ambient types and module declarations; not imported by source
         'src/ui/vite-env.d.ts',
+        // Schema files: exported *Input/*Output types are for UI/CLI (Phase 2); schemas used by tools and tests
+        'src/tools/kairos_*_schema.ts',
     ],
     ignoreDependencies: [
         // Runtime tools used in scripts/shell, not imported directly

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.2.0-beta.0",
       "license": "MIT",
       "dependencies": {
+        "@exodus/bytes": "^1.15.0",
         "@modelcontextprotocol/sdk": "^1.27.0",
         "@qdrant/js-client-rest": "^1.17.0",
         "@tanstack/react-query": "^5.62.0",
@@ -1358,6 +1359,23 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "publish": "npm run prepare:publish && npm publish ./dist/debian777-kairos-mcp-$(node -p \"require('./package.json').version\").tgz --access public"
   },
   "dependencies": {
+    "@exodus/bytes": "^1.15.0",
     "@modelcontextprotocol/sdk": "^1.27.0",
     "@qdrant/js-client-rest": "^1.17.0",
     "@tanstack/react-query": "^5.62.0",

--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -1,153 +1,117 @@
 /**
- * API Client for KAIROS REST API
+ * API Client for KAIROS REST API.
+ * Returns canonical response shapes (no metadata wrapper).
  */
 
 import { getApiUrl } from './config.js';
-
-export interface ApiResponse<T = any> {
-    data?: T;
-    error?: string;
-    message?: string;
-    metadata?: {
-        duration_ms?: number;
-        cached?: boolean;
-    };
-}
+import type { SearchOutput } from '../tools/kairos_search_schema.js';
+import type { BeginOutput } from '../tools/kairos_begin.js';
+import type { NextOutput } from '../tools/kairos_next.js';
+import type { AttestOutput } from '../tools/kairos_attest_schema.js';
+import type { MintOutput } from '../tools/kairos_mint_schema.js';
+import type { UpdateOutput } from '../tools/kairos_update_schema.js';
+import type { DeleteOutput } from '../tools/kairos_delete_schema.js';
 
 export class ApiClient {
-    private baseUrl: string;
+  private baseUrl: string;
 
-    constructor(baseUrl?: string) {
-        // Check environment variable first (set by CLI hook), then parameter, then default
-        this.baseUrl = process.env['KAIROS_API_URL'] || baseUrl || getApiUrl();
-        // Remove trailing slash
-        this.baseUrl = this.baseUrl.replace(/\/$/, '');
+  constructor(baseUrl?: string) {
+    this.baseUrl = process.env['KAIROS_API_URL'] || baseUrl || getApiUrl();
+    this.baseUrl = this.baseUrl.replace(/\/$/, '');
+  }
+
+  private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const defaultHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+    const bearer = process.env['KAIROS_BEARER_TOKEN'];
+    if (bearer) defaultHeaders['Authorization'] = `Bearer ${bearer}`;
+
+    const response = await fetch(url, {
+      ...options,
+      headers: { ...defaultHeaders, ...(options.headers as Record<string, string> || {}) },
+    });
+
+    const data = await response.json().catch(() => {
+      throw new Error(`Failed to parse response from ${url}`);
+    });
+
+    if (!response.ok) {
+      const err = data as { message?: string; error?: string };
+      throw new Error(err.message || err.error || `HTTP ${response.status}: ${response.statusText}`);
     }
 
-    private async request<T>(
-        endpoint: string,
-        options: RequestInit = {}
-    ): Promise<ApiResponse<T>> {
-        const url = `${this.baseUrl}${endpoint}`;
-        const defaultHeaders: Record<string, string> = {
-            'Content-Type': 'application/json',
-        };
-        const bearer = process.env['KAIROS_BEARER_TOKEN'];
-        if (bearer) {
-            defaultHeaders['Authorization'] = `Bearer ${bearer}`;
-        }
+    return data as T;
+  }
 
-        const response = await fetch(url, {
-            ...options,
-            headers: {
-                ...defaultHeaders,
-                ...(options.headers as Record<string, string> || {}),
-            },
-        });
+  async search(query: string): Promise<SearchOutput> {
+    return this.request<SearchOutput>('/api/kairos_search', {
+      method: 'POST',
+      body: JSON.stringify({ query }),
+    });
+  }
 
-        const data = await response.json().catch(() => {
-            throw new Error(`Failed to parse response from ${url}`);
-        }) as ApiResponse<T>;
+  async begin(uri: string): Promise<BeginOutput> {
+    return this.request<BeginOutput>('/api/kairos_begin', {
+      method: 'POST',
+      body: JSON.stringify({ uri }),
+    });
+  }
 
-        if (!response.ok) {
-            const errorData = data as any;
-            throw new Error(
-                errorData.message || errorData.error || `HTTP ${response.status}: ${response.statusText}`
-            );
-        }
+  async next(uri: string, solution?: unknown): Promise<NextOutput> {
+    return this.request<NextOutput>('/api/kairos_next', {
+      method: 'POST',
+      body: JSON.stringify({ uri, solution }),
+    });
+  }
 
-        return data;
+  async mint(markdown: string, options?: { llmModelId?: string; force?: boolean }): Promise<MintOutput> {
+    const url = `${this.baseUrl}/api/kairos_mint/raw`;
+    const headers: Record<string, string> = { 'Content-Type': 'text/markdown' };
+    const bearer = process.env['KAIROS_BEARER_TOKEN'];
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
+    if (options?.llmModelId) headers['x-llm-model-id'] = options.llmModelId;
+    if (options?.force) headers['x-force-update'] = 'true';
+
+    const response = await fetch(url, { method: 'POST', headers, body: markdown });
+    const data = await response.json().catch(() => {
+      throw new Error(`Failed to parse response from ${url}`);
+    });
+    if (!response.ok) {
+      const err = data as { message?: string; error?: string };
+      throw new Error(err.message || err.error || `HTTP ${response.status}: ${response.statusText}`);
     }
+    return data as MintOutput;
+  }
 
-    async search(query: string): Promise<ApiResponse> {
-        return this.request('/api/kairos_search', {
-            method: 'POST',
-            body: JSON.stringify({ query }),
-        });
-    }
+  async update(uris: string[], markdownDoc?: string[], updates?: Record<string, unknown>): Promise<UpdateOutput> {
+    return this.request<UpdateOutput>('/api/kairos_update', {
+      method: 'POST',
+      body: JSON.stringify({ uris, markdown_doc: markdownDoc, updates }),
+    });
+  }
 
-    async begin(uri: string): Promise<ApiResponse> {
-        return this.request('/api/kairos_begin', {
-            method: 'POST',
-            body: JSON.stringify({ uri }),
-        });
-    }
+  async delete(uris: string[]): Promise<DeleteOutput> {
+    return this.request<DeleteOutput>('/api/kairos_delete', {
+      method: 'POST',
+      body: JSON.stringify({ uris }),
+    });
+  }
 
-    async next(uri: string, solution?: any): Promise<ApiResponse> {
-        return this.request('/api/kairos_next', {
-            method: 'POST',
-            body: JSON.stringify({ uri, solution }),
-        });
-    }
-
-    async mint(markdown: string, options?: { llmModelId?: string; force?: boolean }): Promise<ApiResponse> {
-        const url = `${this.baseUrl}/api/kairos_mint/raw`;
-        const headers: Record<string, string> = {
-            'Content-Type': 'text/markdown',
-        };
-        const bearer = process.env['KAIROS_BEARER_TOKEN'];
-        if (bearer) {
-            headers['Authorization'] = `Bearer ${bearer}`;
-        }
-
-        if (options?.llmModelId) {
-            headers['x-llm-model-id'] = options.llmModelId;
-        }
-
-        if (options?.force) {
-            headers['x-force-update'] = 'true';
-        }
-
-        const response = await fetch(url, {
-            method: 'POST',
-            headers,
-            body: markdown,
-        });
-
-        const data = await response.json().catch(() => {
-            throw new Error(`Failed to parse response from ${url}`);
-        }) as ApiResponse;
-
-        if (!response.ok) {
-            const errorData = data as any;
-            throw new Error(
-                errorData.message || errorData.error || `HTTP ${response.status}: ${response.statusText}`
-            );
-        }
-
-        return data;
-    }
-
-    async update(uris: string[], markdownDoc?: string[], updates?: Record<string, any>): Promise<ApiResponse> {
-        return this.request('/api/kairos_update', {
-            method: 'POST',
-            body: JSON.stringify({ uris, markdown_doc: markdownDoc, updates }),
-        });
-    }
-
-    async delete(uris: string[]): Promise<ApiResponse> {
-        return this.request('/api/kairos_delete', {
-            method: 'POST',
-            body: JSON.stringify({ uris }),
-        });
-    }
-
-    async attest(
-        uri: string,
-        outcome: 'success' | 'failure',
-        message: string,
-        options?: { qualityBonus?: number; llmModelId?: string }
-    ): Promise<ApiResponse> {
-        return this.request('/api/kairos_attest', {
-            method: 'POST',
-            body: JSON.stringify({
-                uri,
-                outcome,
-                message,
-                quality_bonus: options?.qualityBonus || 0,
-                llm_model_id: options?.llmModelId,
-            }),
-        });
-    }
+  async attest(
+    uri: string,
+    outcome: 'success' | 'failure',
+    message: string,
+    options?: { qualityBonus?: number; llmModelId?: string }
+  ): Promise<AttestOutput> {
+    return this.request<AttestOutput>('/api/kairos_attest', {
+      method: 'POST',
+      body: JSON.stringify({
+        uri,
+        outcome,
+        message,
+        quality_bonus: options?.qualityBonus ?? 0,
+        llm_model_id: options?.llmModelId,
+      }),
+    });
+  }
 }
-

--- a/src/cli/commands/attest.ts
+++ b/src/cli/commands/attest.ts
@@ -49,16 +49,6 @@ export function attestCommand(program: Command): void {
                     message,
                     attestOptions
                 );
-
-                if (response.error) {
-                    writeError(response.error);
-                    if (response.message) {
-                        writeError(response.message);
-                    }
-                    process.exit(1);
-                    return;
-                }
-
                 writeJson(response);
             } catch (error) {
                 writeError(error instanceof Error ? error.message : String(error));

--- a/src/cli/commands/begin.ts
+++ b/src/cli/commands/begin.ts
@@ -15,17 +15,6 @@ export function beginCommand(program: Command): void {
             try {
                 const client = new ApiClient();
                 const response = await client.begin(uri);
-
-                if (response.error) {
-                    writeError(response.error);
-                    if (response.message) {
-                        writeError(response.message);
-                    }
-                    process.exit(1);
-                    return;
-                }
-
-                // Pretty print the response
                 writeJson(response);
             } catch (error) {
                 writeError(error instanceof Error ? error.message : String(error));

--- a/src/cli/commands/delete.ts
+++ b/src/cli/commands/delete.ts
@@ -15,17 +15,6 @@ export function deleteCommand(program: Command): void {
             try {
                 const client = new ApiClient();
                 const response = await client.delete(uris);
-
-                if (response.error) {
-                    writeError(response.error);
-                    if (response.message) {
-                        writeError(response.message);
-                    }
-                    process.exit(1);
-                    return;
-                }
-
-                // Pretty print the response
                 writeJson(response);
             } catch (error) {
                 writeError(error instanceof Error ? error.message : String(error));

--- a/src/cli/commands/mint.ts
+++ b/src/cli/commands/mint.ts
@@ -26,17 +26,6 @@ export function mintCommand(program: Command): void {
                     mintOptions.force = options.force;
                 }
                 const response = await client.mint(markdown, mintOptions);
-
-                if (response.error) {
-                    writeError(response.error);
-                    if (response.message) {
-                        writeError(response.message);
-                    }
-                    process.exit(1);
-                    return;
-                }
-
-                // Pretty print the response
                 writeJson(response);
             } catch (error) {
                 if (error instanceof Error && error.message.includes('ENOENT')) {

--- a/src/cli/commands/next.ts
+++ b/src/cli/commands/next.ts
@@ -40,27 +40,13 @@ export function nextCommand(program: Command): void {
 
                 do {
                     const response = await client.next(currentUri, solutionResult);
-
-                    if (response.error) {
-                        writeError(response.error);
-                        if (response.message) {
-                            writeError(response.message);
-                        }
-                        process.exit(1);
-                        return;
-                    }
-
-                    // Store the step
                     allSteps.push(response);
 
-                    // Output based on format
                     if (outputFormat === 'md') {
-                        const currentStep = (response as any).current_step;
+                        const currentStep = response.current_step;
                         if (currentStep?.content) {
                             writeMarkdown(currentStep.content);
-                            // Add separator between steps if following
-                            const nextAct = (response as any).next_action as string | undefined;
-                            if (options.follow && nextAct?.includes('kairos_next')) {
+                            if (options.follow && response.next_action?.includes('kairos_next')) {
                                 writeMarkdown('\n---\n\n');
                             }
                         }
@@ -68,11 +54,10 @@ export function nextCommand(program: Command): void {
                         writeJson(response);
                     }
 
-                    // Check if we should continue following
                     if (options.follow) {
-                        const nextAction = (response as any).next_action as string | undefined;
+                        const nextAction = response.next_action;
                         // Extract URI from next_action if it mentions kairos_next
-                        const nextUriMatch = nextAction?.match(/kairos_next\s+with\s+(kairos:\/\/mem\/[0-9a-f-]{36})/i);
+                        const nextUriMatch = typeof nextAction === 'string' ? nextAction.match(/kairos_next\s+with\s+(kairos:\/\/mem\/[0-9a-f-]{36})/i) : null;
                         if (nextUriMatch?.[1]) {
                             currentUri = nextUriMatch[1];
                             solutionResult = undefined;

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -15,17 +15,6 @@ export function searchCommand(program: Command): void {
             try {
                 const client = new ApiClient();
                 const response = await client.search(query.join(' '));
-
-                if (response.error) {
-                    writeError(response.error);
-                    if (response.message) {
-                        writeError(response.message);
-                    }
-                    process.exit(1);
-                    return;
-                }
-
-                // Pretty print the response
                 writeJson(response);
             } catch (error) {
                 writeError(error instanceof Error ? error.message : String(error));

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -48,17 +48,6 @@ export function updateCommand(program: Command): void {
                 }
 
                 const response = await client.update(uris, markdownDoc, updates);
-
-                if (response.error) {
-                    writeError(response.error);
-                    if (response.message) {
-                        writeError(response.message);
-                    }
-                    process.exit(1);
-                    return;
-                }
-
-                // Pretty print the response
                 writeJson(response);
             } catch (error) {
                 if (error instanceof Error && error.message.includes('ENOENT')) {

--- a/src/http/http-api-attest.ts
+++ b/src/http/http-api-attest.ts
@@ -1,142 +1,37 @@
 import express from 'express';
 import { structuredLogger } from '../utils/structured-logger.js';
 import type { QdrantService } from '../services/qdrant/service.js';
-import { IDGenerator } from '../services/id-generator.js';
-import { modelStats } from '../services/stats/model-stats.js';
+import { attestInputSchema } from '../tools/kairos_attest_schema.js';
+import { executeAttest } from '../tools/kairos_attest.js';
 
 /**
- * Set up API route for kairos_attest (V2: no final_solution required)
+ * Set up API route for kairos_attest (V2: no final_solution required).
+ * Validates with canonical schema and returns executeAttest result only (no metadata).
  */
 export function setupAttestRoute(app: express.Express, qdrantService: QdrantService) {
-    app.post('/api/kairos_attest', async (req, res) => {
-        const startTime = Date.now();
+  app.post('/api/kairos_attest', async (req, res) => {
+    try {
+      const parsed = attestInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        const first = parsed.error.flatten().fieldErrors;
+        const msg = Object.keys(first).length
+          ? Object.entries(first)
+              .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`)
+              .join('; ')
+          : parsed.error.message;
+        res.status(400).json({ error: 'INVALID_INPUT', message: msg });
+        return;
+      }
 
-        try {
-            const { uri, outcome, quality_bonus = 0, message, llm_model_id } = req.body;
-
-            if (!uri || typeof uri !== 'string') {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'uri is required and must be a string'
-                });
-                return;
-            }
-
-            if (!outcome || !['success', 'failure'].includes(outcome)) {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'outcome is required and must be "success" or "failure"'
-                });
-                return;
-            }
-
-            if (!message || typeof message !== 'string') {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'message is required and must be a string'
-                });
-                return;
-            }
-
-            structuredLogger.info(`-> POST /api/kairos_attest (uri: ${uri}, outcome: ${outcome})`);
-
-            const modelIdentity = {
-                modelId: llm_model_id || 'http-api-attest',
-                provider: 'unknown',
-                family: 'unknown'
-            };
-
-            const qdrantUuid = IDGenerator.qdrantIdFromUri(uri);
-            const basicQualityBonus = outcome === 'success' ? 1 : -0.2;
-
-            const currentPoint = await qdrantService.retrieveById(qdrantUuid);
-            if (!currentPoint) {
-                res.status(404).json({
-                    error: 'NOT_FOUND',
-                    message: `Memory not found: ${uri}`
-                });
-                return;
-            }
-
-            const currentMetrics = currentPoint.payload?.quality_metrics || {};
-            const implementationBonus = await modelStats.calculateImplementationBonus(
-                currentMetrics,
-                modelIdentity.modelId,
-                outcome
-            );
-
-            const totalQualityBonus = basicQualityBonus + implementationBonus + quality_bonus;
-
-            const metricsUpdate: any = {
-                retrievalCount: 1,
-                successCount: outcome === 'success' ? 1 : 0,
-                failureCount: outcome === 'failure' ? 1 : 0,
-                lastRated: new Date().toISOString(),
-                lastRater: modelIdentity.modelId,
-                qualityBonus: totalQualityBonus
-            };
-
-            if (message) {
-                metricsUpdate.usageContext = message;
-            }
-
-            await qdrantService.updateQualityMetrics(qdrantUuid, metricsUpdate);
-            await qdrantService.propagateAttestToChainHead(qdrantUuid, metricsUpdate);
-
-            if (currentPoint.payload) {
-                const { description_short, domain, task, type, tags } = currentPoint.payload;
-                const updatedQualityMetadata = modelStats.calculateStepQualityMetadata(
-                    description_short || 'Knowledge step',
-                    domain || 'general',
-                    task || 'general',
-                    type || 'context',
-                    tags || [],
-                    outcome
-                );
-
-                await qdrantService.updateQualityMetadata(qdrantUuid, {
-                    step_quality_score: updatedQualityMetadata.step_quality_score,
-                    step_quality: updatedQualityMetadata.step_quality
-                });
-            }
-
-            await modelStats.processQualityFeedback(
-                modelIdentity.modelId,
-                uri,
-                outcome,
-                totalQualityBonus
-            );
-
-            if (implementationBonus > 0) {
-                await modelStats.updateImplementationBonus(modelIdentity.modelId, implementationBonus);
-            }
-
-            const result = {
-                uri: uri,
-                outcome: outcome,
-                quality_bonus: totalQualityBonus,
-                message,
-                rated_at: new Date().toISOString()
-            };
-
-            const duration = Date.now() - startTime;
-            structuredLogger.info(`kairos_attest completed in ${duration}ms`);
-
-            res.status(200).json({
-                results: [result],
-                total_rated: 1,
-                total_failed: 0,
-                metadata: { duration_ms: duration }
-            });
-
-        } catch (error) {
-            const duration = Date.now() - startTime;
-            structuredLogger.error(`kairos_attest failed in ${duration}ms`, error);
-            res.status(500).json({
-                error: 'ATTEST_FAILED',
-                message: error instanceof Error ? error.message : 'Failed to attest step completion',
-                duration_ms: duration
-            });
-        }
-    });
+      structuredLogger.info(`-> POST /api/kairos_attest (uri: ${parsed.data.uri}, outcome: ${parsed.data.outcome})`);
+      const result = await executeAttest(qdrantService, parsed.data);
+      res.status(200).json(result);
+    } catch (error) {
+      structuredLogger.error('kairos_attest failed', error);
+      res.status(500).json({
+        error: 'ATTEST_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to attest step completion'
+      });
+    }
+  });
 }

--- a/src/http/http-api-begin-step.ts
+++ b/src/http/http-api-begin-step.ts
@@ -2,125 +2,36 @@ import express from 'express';
 import { MemoryQdrantStore } from '../services/memory/store.js';
 import { structuredLogger } from '../utils/structured-logger.js';
 import type { QdrantService } from '../services/qdrant/service.js';
-import { resolveChainNextStep, resolveChainFirstStep } from '../services/chain-utils.js';
-import { extractMemoryBody } from '../utils/memory-body.js';
-import { redisCacheService } from '../services/redis-cache.js';
-import type { Memory } from '../types/memory.js';
-import { buildChallenge } from '../tools/kairos_next-pow-helpers.js';
+import { beginInputSchema, executeBegin } from '../tools/kairos_begin.js';
 
 /**
- * Set up API route for kairos_begin (V2: auto-redirect, no next_step/protocol_status/attest_required)
+ * Set up API route for kairos_begin (V2: auto-redirect, no next_step/protocol_status/attest_required).
+ * Validates with canonical schema and returns executeBegin result only (no metadata).
  */
 export function setupBeginStepRoute(app: express.Express, memoryStore: MemoryQdrantStore, qdrantService: QdrantService): void {
-    app.post('/api/kairos_begin', async (req, res) => {
-        const startTime = Date.now();
+  app.post('/api/kairos_begin', async (req, res) => {
+    try {
+      const parsed = beginInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        const first = parsed.error.flatten().fieldErrors;
+        const msg = Object.keys(first).length
+          ? Object.entries(first)
+              .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`)
+              .join('; ')
+          : parsed.error.message;
+        res.status(400).json({ error: 'INVALID_INPUT', message: msg });
+        return;
+      }
 
-        try {
-            const { uri } = req.body;
-
-            if (!uri || typeof uri !== 'string') {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'uri is required and must be a string'
-                });
-                return;
-            }
-
-            structuredLogger.info(`-> POST /api/kairos_begin (uri: ${uri})`);
-
-            const normalizeMemoryUri = (value: string): { uuid: string; uri: string } => {
-                const normalized = (value || '').trim();
-                const uuid = normalized.split('/').pop()!;
-                if (!uuid) {
-                    throw new Error('Invalid kairos://mem URI');
-                }
-                const memUri = normalized.startsWith('kairos://mem/') ? normalized : `kairos://mem/${uuid}`;
-                return { uuid, uri: memUri };
-            };
-
-            const { uuid, uri: requestedUri } = normalizeMemoryUri(uri);
-
-            // Load memory with cache
-            let memory: Memory | null = null;
-            const cached = await redisCacheService.getMemoryResource(uuid);
-            if (cached) {
-                memory = cached;
-            } else {
-                memory = await memoryStore.getMemory(uuid);
-                if (memory) {
-                    await redisCacheService.setMemoryResource(memory);
-                }
-            }
-
-            let redirectMessage: string | undefined;
-
-            // Auto-redirect: if not step 1, resolve and present step 1
-            if (memory?.chain && memory.chain.step_index !== 1) {
-                const firstStep = await resolveChainFirstStep(memory, qdrantService);
-                if (firstStep?.uuid) {
-                    const step1Cached = await redisCacheService.getMemoryResource(firstStep.uuid);
-                    const step1Memory = step1Cached || await memoryStore.getMemory(firstStep.uuid);
-                    if (step1Memory) {
-                        if (!step1Cached) await redisCacheService.setMemoryResource(step1Memory);
-                        memory = step1Memory;
-                        redirectMessage = 'Redirected to step 1 of this protocol chain.';
-                    }
-                }
-            }
-
-            const nextStepInfo = memory
-                ? await resolveChainNextStep(memory, qdrantService)
-                : undefined;
-
-            const current_step = {
-                uri: memory ? `kairos://mem/${memory.memory_uuid}` : requestedUri,
-                content: memory ? extractMemoryBody(memory.text) : '',
-                mimeType: 'text/markdown' as const
-            };
-
-            const challenge = await buildChallenge(memory, memory?.proof_of_work);
-
-            const output: any = {
-                must_obey: true,
-                current_step,
-                challenge
-            };
-
-            if (redirectMessage) {
-                output.message = redirectMessage;
-            }
-
-            const nextStepUri = nextStepInfo?.uuid
-                ? `kairos://mem/${nextStepInfo.uuid}`
-                : null;
-            const currentStepUri = current_step.uri;
-
-            if (nextStepUri) {
-                output.next_action = `call kairos_next with ${currentStepUri} and solution matching challenge`;
-            } else {
-                const attestUri = memory ? `kairos://mem/${memory.memory_uuid}` : requestedUri;
-                output.message = 'Single-step protocol. Call kairos_attest to finalize.';
-                output.next_action = `call kairos_attest with ${attestUri} and outcome (success or failure) and message to complete the protocol`;
-            }
-
-            const duration = Date.now() - startTime;
-            structuredLogger.info(`kairos_begin completed in ${duration}ms`);
-
-            res.status(200).json({
-                ...output,
-                metadata: { duration_ms: duration }
-            });
-            return;
-
-        } catch (error) {
-            const duration = Date.now() - startTime;
-            structuredLogger.error(`kairos_begin failed in ${duration}ms`, error);
-            res.status(500).json({
-                error: 'BEGIN_FAILED',
-                message: error instanceof Error ? error.message : 'Failed to get step 1',
-                duration_ms: duration
-            });
-            return;
-        }
-    });
+      structuredLogger.info(`-> POST /api/kairos_begin (uri: ${parsed.data.uri})`);
+      const result = await executeBegin(memoryStore, qdrantService, parsed.data);
+      res.status(200).json(result);
+    } catch (error) {
+      structuredLogger.error('kairos_begin failed', error);
+      res.status(500).json({
+        error: 'BEGIN_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to get step 1'
+      });
+    }
+  });
 }

--- a/src/http/http-api-begin.ts
+++ b/src/http/http-api-begin.ts
@@ -2,212 +2,37 @@ import express from 'express';
 import { MemoryQdrantStore } from '../services/memory/store.js';
 import { structuredLogger } from '../utils/structured-logger.js';
 import type { QdrantService } from '../services/qdrant/service.js';
-import { SCORE_THRESHOLD, KAIROS_ENABLE_GROUP_COLLAPSE } from '../config.js';
-import { resolveFirstStep } from '../services/chain-utils.js';
-import { redisCacheService } from '../services/redis-cache.js';
-import type { Memory } from '../types/memory.js';
-
-const CREATION_PROTOCOL_UUID = '00000000-0000-0000-0000-000000002001';
-const CREATION_PROTOCOL_URI = `kairos://mem/${CREATION_PROTOCOL_UUID}`;
-const REFINING_PROTOCOL_UUID = '00000000-0000-0000-0000-000000002002';
-const REFINING_PROTOCOL_URI = `kairos://mem/${REFINING_PROTOCOL_UUID}`;
-const REFINING_NEXT_ACTION = `call kairos_begin with ${REFINING_PROTOCOL_URI} to get step-by-step help turning the user's request into a better search query`;
-const CREATE_NEXT_ACTION = `call kairos_begin with ${CREATION_PROTOCOL_URI} to create a new protocol`;
-
-/** Strip built-in protocol URIs and UUIDs from query so they are not used for search or cache key. */
-function queryForSearch(query: string): string {
-  let q = (query || '').trim();
-  for (const token of [REFINING_PROTOCOL_URI, REFINING_PROTOCOL_UUID, CREATION_PROTOCOL_URI, CREATION_PROTOCOL_UUID]) {
-    q = q.replace(new RegExp(escapeRegex(token), 'gi'), ' ');
-  }
-  return q.replace(/\s+/g, ' ').trim();
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-interface UnifiedChoice {
-    uri: string;
-    label: string;
-    chain_label: string | null;
-    score: number | null;
-    role: 'match' | 'refine' | 'create';
-    tags: string[];
-    next_action: string;
-    protocol_version: string | null;
-}
+import { searchInputSchema } from '../tools/kairos_search_schema.js';
+import { executeSearch } from '../tools/kairos_search.js';
 
 /**
- * Set up API route for kairos_search (V2 unified response)
+ * Set up API route for kairos_search (V2 unified response).
+ * Validates with canonical schema and returns executeSearch result only (no metadata).
  */
 export function setupBeginRoute(app: express.Express, memoryStore: MemoryQdrantStore, qdrantService: QdrantService): void {
-    app.post('/api/kairos_search', async (req, res) => {
-        const startTime = Date.now();
+  app.post('/api/kairos_search', async (req, res) => {
+    try {
+      const parsed = searchInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        const first = parsed.error.flatten().fieldErrors;
+        const msg = Object.keys(first).length
+          ? Object.entries(first)
+              .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`)
+              .join('; ')
+          : parsed.error.message;
+        res.status(400).json({ error: 'INVALID_INPUT', message: msg });
+        return;
+      }
 
-        try {
-            const { query } = req.body;
-
-            if (!query || typeof query !== 'string' || query.trim().length === 0) {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'query is required and must be a non-empty string'
-                });
-                return;
-            }
-
-            structuredLogger.info(`-> POST /api/kairos_search (query: ${query})`);
-
-            const searchQuery = queryForSearch(query);
-            const normalizedQuery = searchQuery.toLowerCase();
-            const cacheKey = `begin:v3:${normalizedQuery}:${KAIROS_ENABLE_GROUP_COLLAPSE}`;
-
-            const cachedResult = await redisCacheService.get(cacheKey);
-            if (cachedResult) {
-                const parsed = JSON.parse(cachedResult);
-                const duration = Date.now() - startTime;
-                return res.status(200).json({
-                    ...parsed,
-                    metadata: { cached: true, duration_ms: duration }
-                });
-            }
-
-            const { memories, scores } = await memoryStore.searchMemories(searchQuery, 40, KAIROS_ENABLE_GROUP_COLLAPSE);
-            const candidateMap = new Map<string, { memory: Memory; score: number }>();
-
-            const addCandidate = (memory: Memory, score: number) => {
-                if (!memory) return;
-                const key = memory.chain?.id || memory.memory_uuid;
-                const existing = candidateMap.get(key);
-                const incomingIsHead = memory.chain?.step_index === 1;
-                if (!existing) {
-                    candidateMap.set(key, { memory, score });
-                    return;
-                }
-                const existingIsHead = existing.memory.chain?.step_index === 1;
-                if (incomingIsHead && !existingIsHead) {
-                    candidateMap.set(key, { memory, score });
-                    return;
-                }
-                if (incomingIsHead === existingIsHead && score > existing.score) {
-                    candidateMap.set(key, { memory, score });
-                }
-            };
-
-            memories.forEach((memory, idx) => addCandidate(memory, scores[idx] ?? 0));
-
-            if (candidateMap.size < 10 && KAIROS_ENABLE_GROUP_COLLAPSE) {
-                const { memories: moreMemories, scores: moreScores } = await memoryStore.searchMemories(searchQuery, 80, false);
-                moreMemories.forEach((memory, idx) => addCandidate(memory, moreScores[idx] ?? 0));
-            }
-
-            let headCandidates = Array.from(candidateMap.values())
-                .sort((a, b) => (b.score - a.score));
-
-            if (headCandidates.length > 10) {
-                headCandidates = headCandidates.slice(0, 10);
-            }
-
-            const results = headCandidates
-                .map(({ memory, score }) => ({
-                    memory,
-                    score,
-                    uri: `kairos://mem/${memory.memory_uuid}`,
-                    label: memory.label,
-                    tags: memory.tags || [],
-                    total_steps: memory.chain?.step_count || 1
-                }))
-                .filter(r => r.score >= SCORE_THRESHOLD);
-
-            // Build unified choices: matches with per-choice next_action, then refine (if 0 or >1 matches), then create (if 0 or >1)
-            const choices: UnifiedChoice[] = [];
-            const matchCount = results.length;
-
-            for (const result of results) {
-                const head = (await resolveFirstStep(result.memory, qdrantService)) ?? {
-                    uri: result.uri,
-                    label: result.label
-                };
-                choices.push({
-                    uri: head.uri,
-                    label: head.label || result.label,
-                    chain_label: result.memory.chain?.label || null,
-                    score: result.score,
-                    role: 'match',
-                    tags: result.tags,
-                    next_action: `call kairos_begin with ${head.uri} to execute this protocol`,
-                    protocol_version: result.memory.chain?.protocol_version ?? null
-                });
-            }
-
-            if (matchCount !== 1) {
-                choices.push(
-                    {
-                        uri: REFINING_PROTOCOL_URI,
-                        label: 'Get help refining your search',
-                        chain_label: 'Run protocol to turn vague user request into a better kairos_search query',
-                        score: null,
-                        role: 'refine',
-                        tags: ['meta', 'refine'],
-                        next_action: REFINING_NEXT_ACTION,
-                        protocol_version: null
-                    },
-                    {
-                        uri: CREATION_PROTOCOL_URI,
-                        label: 'Create New KAIROS Protocol Chain',
-                        chain_label: 'Create New KAIROS Protocol Chain',
-                        score: null,
-                        role: 'create',
-                        tags: ['meta', 'creation'],
-                        next_action: CREATE_NEXT_ACTION,
-                        protocol_version: null
-                    }
-                );
-            }
-
-            let message: string;
-            let nextAction: string;
-
-            if (matchCount === 0) {
-                message = 'No existing protocol matched your query. Refine your search or create a new one.';
-                nextAction = "Pick one choice and follow that choice's next_action.";
-            } else if (matchCount === 1) {
-                message = 'Found 1 match.';
-                nextAction = "Follow the choice's next_action.";
-            } else {
-                const topMatch = choices[0]!;
-                const confidencePercent = Math.round((topMatch.score || 0) * 100);
-                message = `Found ${matchCount} matches (top confidence: ${confidencePercent}%). Choose one, refine your search, or create a new protocol.`;
-                nextAction = "Pick one choice and follow that choice's next_action.";
-            }
-
-            const output = {
-                must_obey: true,
-                message,
-                next_action: nextAction,
-                choices
-            };
-
-            await redisCacheService.set(cacheKey, JSON.stringify(output), 300);
-
-            const duration = Date.now() - startTime;
-            structuredLogger.info(`kairos_search completed in ${duration}ms`);
-
-            res.status(200).json({
-                ...output,
-                metadata: { duration_ms: duration }
-            });
-            return;
-
-        } catch (error) {
-            const duration = Date.now() - startTime;
-            structuredLogger.error(`kairos_search failed in ${duration}ms`, error);
-            res.status(500).json({
-                error: 'SEARCH_FAILED',
-                message: error instanceof Error ? error.message : 'Failed to search for chain heads',
-                duration_ms: duration
-            });
-            return;
-        }
-    });
+      structuredLogger.info(`-> POST /api/kairos_search (query: ${parsed.data.query})`);
+      const result = await executeSearch(memoryStore, qdrantService, parsed.data);
+      res.status(200).json(result);
+    } catch (error) {
+      structuredLogger.error('kairos_search failed', error);
+      res.status(500).json({
+        error: 'SEARCH_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to search for chain heads'
+      });
+    }
+  });
 }

--- a/src/http/http-api-delete.ts
+++ b/src/http/http-api-delete.ts
@@ -1,79 +1,36 @@
 import express from 'express';
 import { structuredLogger } from '../utils/structured-logger.js';
 import type { QdrantService } from '../services/qdrant/service.js';
+import { executeDelete } from '../tools/kairos_delete.js';
+import { deleteInputSchema } from '../tools/kairos_delete_schema.js';
 
 /**
- * Set up API route for kairos_delete
- * @param app Express application instance
- * @param qdrantService Qdrant service instance
+ * Set up API route for kairos_delete. Uses shared executeDelete; returns same shape as MCP (no metadata).
  */
 export function setupDeleteRoute(app: express.Express, qdrantService: QdrantService) {
-    app.post('/api/kairos_delete', async (req, res) => {
-        const startTime = Date.now();
+  app.post('/api/kairos_delete', async (req, res) => {
+    try {
+      const input = deleteInputSchema.safeParse(req.body);
+      if (!input.success) {
+        res.status(400).json({
+          error: 'INVALID_INPUT',
+          message: input.error.message ?? 'uris is required and must be a non-empty array'
+        });
+        return;
+      }
 
-        try {
-            const { uris } = req.body;
-
-            if (!uris || !Array.isArray(uris) || uris.length === 0) {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'uris is required and must be a non-empty array'
-                });
-                return;
-            }
-
-            structuredLogger.info(`→ POST /api/kairos_delete (${uris.length} URI(s))`);
-
-            const results: any[] = [];
-            let totalDeleted = 0;
-            let totalFailed = 0;
-
-            for (const uri of uris) {
-                try {
-                    const uuid = typeof uri === 'string' ? uri.split('/').pop() : undefined;
-                    if (!uuid) {
-                        throw new Error('Invalid URI format');
-                    }
-
-                    await qdrantService.deleteMemory(uuid);
-
-                    results.push({
-                        uri,
-                        status: 'deleted',
-                        message: `Memory ${uri} deleted successfully`
-                    });
-                    totalDeleted++;
-                } catch (error) {
-                    const errorMessage = error instanceof Error ? error.message : String(error);
-                    results.push({
-                        uri,
-                        status: 'error',
-                        message: `Failed to delete memory: ${errorMessage}`
-                    });
-                    totalFailed++;
-                }
-            }
-
-            const duration = Date.now() - startTime;
-            structuredLogger.info(`✓ kairos_delete completed in ${duration}ms (${totalDeleted} deleted, ${totalFailed} failed)`);
-
-            res.status(200).json({
-                results,
-                total_deleted: totalDeleted,
-                total_failed: totalFailed,
-                metadata: { duration_ms: duration }
-            });
-
-        } catch (error) {
-            const duration = Date.now() - startTime;
-            structuredLogger.error(`✗ kairos_delete failed in ${duration}ms`, error);
-            res.status(500).json({
-                error: 'DELETE_FAILED',
-                message: error instanceof Error ? error.message : 'Failed to delete memories',
-                duration_ms: duration
-            });
-        }
-    });
+      structuredLogger.info(`→ POST /api/kairos_delete (${input.data.uris.length} URI(s))`);
+      const result = await executeDelete(qdrantService, input.data);
+      structuredLogger.info(`✓ kairos_delete completed (${result.total_deleted} deleted, ${result.total_failed} failed)`);
+      res.status(200).json(result);
+    } catch (error) {
+      structuredLogger.error('✗ kairos_delete failed', error);
+      res.status(500).json({
+        error: 'DELETE_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to delete memories'
+      });
+    }
+  });
 }
 
 

--- a/src/http/http-api-dump.ts
+++ b/src/http/http-api-dump.ts
@@ -13,7 +13,6 @@ export function setupDumpRoute(
   qdrantService: QdrantService
 ): void {
   app.post('/api/kairos_dump', async (req, res) => {
-    const startTime = Date.now();
     try {
       const { uri, protocol } = req.body;
       if (!uri || typeof uri !== 'string' || uri.trim().length === 0) {
@@ -28,8 +27,7 @@ export function setupDumpRoute(
         uri: uri.trim(),
         protocol: Boolean(protocol)
       });
-      const duration = Date.now() - startTime;
-      res.status(200).json({ ...payload, metadata: { duration_ms: duration } });
+      res.status(200).json(payload);
     } catch (error: unknown) {
       const statusCode = (error as { statusCode?: number }).statusCode ?? 500;
       const message = error instanceof Error ? error.message : String(error);

--- a/src/http/http-api-mint.ts
+++ b/src/http/http-api-mint.ts
@@ -3,114 +3,92 @@ import express from 'express';
 import { kairosMintSimilarMemoryFound } from '../services/metrics/mcp-metrics.js';
 import { MemoryQdrantStore } from '../services/memory/store.js';
 import { structuredLogger } from '../utils/structured-logger.js';
+import { executeMint, MintError } from '../tools/kairos_mint.js';
+import { mintInputSchema } from '../tools/kairos_mint_schema.js';
 
 /**
- * Set up API route for raw markdown ingestion
- * @param app Express application instance
- * @param memoryStore Memory store instance
+ * Set up API route for raw markdown ingestion.
+ * Builds MintInput from raw body + query/headers and returns executeMint result only (no metadata).
  */
 export function setupMintRoute(app: express.Express, memoryStore: MemoryQdrantStore) {
-    app.post('/api/kairos_mint/raw', async (req, res) => {
-        const startTime = Date.now();
+  app.post('/api/kairos_mint/raw', async (req, res) => {
+    try {
+      const contentLength = req.headers['content-length'] ? parseInt(req.headers['content-length'], 10) : null;
+      const rawBody = await getRawBody(req, {
+        limit: '10mb',
+        encoding: 'utf8',
+        ...(contentLength !== null && { length: contentLength })
+      });
+      const markdown = String(rawBody).trim();
+      if (!markdown) {
+        res.status(400).json({ error: 'INVALID_INPUT', message: 'Empty markdown content' });
+        return;
+      }
 
-        try {
-            // Parse raw markdown body
-            const contentLength = req.headers['content-length'] ? parseInt(req.headers['content-length'], 10) : null;
-            const options: any = {
-                limit: '10mb',
-                encoding: 'utf8'
-            };
-            if (contentLength !== null) {
-                options.length = contentLength;
-            }
-            const rawBody = await getRawBody(req, options);
+      const llm_model_id =
+        (req.query['llm_model_id'] as string) ||
+        (req.headers['x-llm-model-id'] as string) ||
+        req.headers['user-agent'] ||
+        'http-api';
+      const force_update =
+        req.query['force'] === 'true' || req.headers['x-force-update'] === 'true';
+      const protocol_version = (req.query['protocol_version'] as string) || (req.headers['x-protocol-version'] as string) || undefined;
 
-            const markdown = String(rawBody);
+      const bodyInput = { markdown_doc: markdown, llm_model_id, force_update, ...(protocol_version && { protocol_version }) };
+      const parsed = mintInputSchema.safeParse(bodyInput);
+      if (!parsed.success) {
+        const first = parsed.error.flatten().fieldErrors;
+        const msg = Object.keys(first).length
+          ? Object.entries(first)
+              .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`)
+              .join('; ')
+          : parsed.error.message;
+        res.status(400).json({ error: 'INVALID_INPUT', message: msg });
+        return;
+      }
 
-            if (!markdown || markdown.trim().length === 0) {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'Empty markdown content'
-                });
-                return;
-            }
-
-            // Extract parameters from query string or headers
-            const llm_model_id = (req.query['llm_model_id'] as string) ||
-                req.headers['x-llm-model-id'] as string ||
-                req.headers['user-agent'] ||
-                'http-api';
-
-            const force_update = req.query['force'] === 'true' ||
-                req.headers['x-force-update'] === 'true';
-
-            structuredLogger.info(`→ POST /api/kairos_mint/raw (${markdown.length} bytes, model: ${llm_model_id}, force: ${force_update})`);
-
-            // Store using the same logic as kairos_mint MCP tool
-            const memories = await memoryStore.storeChain([markdown], llm_model_id, {
-                forceUpdate: force_update
-            } as any);
-
-            const duration = Date.now() - startTime;
-            structuredLogger.info(`✓ Stored ${memories.length} memories in ${duration}ms`);
-
-            // Return success response
-            res.status(200).json({
-                status: 'stored',
-                items: memories.map(memory => ({
-                    uri: `kairos://mem/${memory.memory_uuid}`,
-                    memory_uuid: memory.memory_uuid,
-                    label: memory.label,
-                    tags: memory.tags
-                })),
-                metadata: {
-                    count: memories.length,
-                    duration_ms: duration,
-                    llm_model_id
-                }
-            });
-
-        } catch (error) {
-            const duration = Date.now() - startTime;
-            const err = error as any;
-
-            // Handle duplicate chain error
-            if (err && (err.code === 'DUPLICATE_CHAIN' || err.code === 'DUPLICATE_KEY')) {
-                structuredLogger.warn(`✗ Duplicate chain in ${duration}ms: ${err.message}`);
-                res.status(409).json({
-                    error: 'DUPLICATE_CHAIN',
-                    message: 'Memory chain with this label already exists. Use --force flag to overwrite.',
-                    ...(err.details || {})
-                });
-                return;
-            }
-
-            // Handle similar memory found by title (spec: must_obey, next_action, content_preview)
-            if (err && err.code === 'SIMILAR_MEMORY_FOUND') {
-                kairosMintSimilarMemoryFound.inc({ transport: 'http', tenant_id: 'http' });
-                structuredLogger.warn(`✗ Similar memory found in ${duration}ms: ${err.message}`);
-                const d = err.details || {};
-                res.status(409).json({
-                    error: 'SIMILAR_MEMORY_FOUND',
-                    existing_memory: d.existing_memory,
-                    similarity_score: d.similarity_score,
-                    message: d.message ?? 'A very similar memory already exists by title. Verify it before overwriting.',
-                    must_obey: d.must_obey ?? true,
-                    next_action: d.next_action,
-                    ...(d.content_preview !== undefined && { content_preview: d.content_preview })
-                });
-                return;
-            }
-
-            // Handle other errors
-            structuredLogger.error(`✗ Store failed in ${duration}ms`, error);
-            res.status(500).json({
-                error: 'STORE_FAILED',
-                message: err?.message || 'Failed to store markdown',
-                duration_ms: duration
-            });
-        }
-    });
+      structuredLogger.info(`→ POST /api/kairos_mint/raw (${markdown.length} bytes, model: ${parsed.data.llm_model_id}, force: ${parsed.data.force_update})`);
+      const result = await executeMint(memoryStore, parsed.data, (fn) => fn());
+      res.status(200).json(result);
+    } catch (error) {
+      const err = error as { code?: string; details?: Record<string, unknown>; message?: string };
+      if (error instanceof MintError) {
+        res.status(400).json({
+          error: error.code,
+          message: error.message,
+          ...error.details
+        });
+        return;
+      }
+      if (err?.code === 'DUPLICATE_CHAIN' || err?.code === 'DUPLICATE_KEY') {
+        structuredLogger.warn(`✗ Duplicate chain: ${err.message}`);
+        res.status(409).json({
+          error: 'DUPLICATE_CHAIN',
+          message: 'Memory chain with this label already exists. Use --force flag to overwrite.',
+          ...(err.details || {})
+        });
+        return;
+      }
+      if (err?.code === 'SIMILAR_MEMORY_FOUND') {
+        kairosMintSimilarMemoryFound.inc({ transport: 'http', tenant_id: 'http' });
+        structuredLogger.warn(`✗ Similar memory found: ${err.message}`);
+        const d = err.details || {};
+        res.status(409).json({
+          error: 'SIMILAR_MEMORY_FOUND',
+          existing_memory: (d as any).existing_memory,
+          similarity_score: (d as any).similarity_score,
+          message: (d as any).message ?? 'A very similar memory already exists by title. Verify it before overwriting.',
+          must_obey: (d as any).must_obey ?? true,
+          next_action: (d as any).next_action,
+          ...((d as any).content_preview !== undefined && { content_preview: (d as any).content_preview })
+        });
+        return;
+      }
+      structuredLogger.error('✗ Store failed', error);
+      res.status(500).json({
+        error: 'STORE_FAILED',
+        message: err?.message ?? 'Failed to store markdown'
+      });
+    }
+  });
 }
-
-

--- a/src/http/http-api-next.ts
+++ b/src/http/http-api-next.ts
@@ -2,264 +2,51 @@ import express from 'express';
 import { MemoryQdrantStore } from '../services/memory/store.js';
 import { structuredLogger } from '../utils/structured-logger.js';
 import type { QdrantService } from '../services/qdrant/service.js';
-import { resolveChainNextStep, resolveChainPreviousStep } from '../services/chain-utils.js';
-import { extractMemoryBody } from '../utils/memory-body.js';
-import { proofOfWorkStore } from '../services/proof-of-work-store.js';
-import { buildChallenge, handleProofSubmission, GENESIS_HASH, type HandleProofResult } from '../tools/kairos_next-pow-helpers.js';
-import { updateStepQuality } from '../tools/kairos_next.js';
-import { tryApplySolutionToPreviousStep, tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious } from '../tools/kairos_next-previous-step.js';
+import { kairosNextInputSchema } from '../tools/kairos_next_schema.js';
+import { executeNext, buildMissingSolutionPayload } from '../tools/kairos_next.js';
 
 /**
- * Set up API route for kairos_next (V2: no next_step/protocol_status/attest_required/final_challenge,
- * proof_hash replaces last_proof_hash, two-phase retry escalation)
+ * Set up API route for kairos_next (V2: no next_step/protocol_status/attest_required/final_challenge).
+ * Validates with canonical schema and returns executeNext result only (no metadata).
  */
 export function setupNextRoute(app: express.Express, memoryStore: MemoryQdrantStore, qdrantService: QdrantService): void {
-    app.post('/api/kairos_next', async (req, res) => {
-        const startTime = Date.now();
+  app.post('/api/kairos_next', async (req, res) => {
+    try {
+      const uri = req.body?.uri;
+      if (!uri || typeof uri !== 'string') {
+        res.status(400).json({ error: 'INVALID_INPUT', message: 'uri is required and must be a string' });
+        return;
+      }
 
-        try {
-            const { uri, solution } = req.body;
+      if (req.body?.solution == null) {
+        structuredLogger.info(`-> POST /api/kairos_next (uri: ${uri}, no solution)`);
+        const result = await buildMissingSolutionPayload(memoryStore, uri);
+        res.status(200).json(result);
+        return;
+      }
 
-            if (!uri || typeof uri !== 'string') {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'uri is required and must be a string'
-                });
-                return;
-            }
+      const parsed = kairosNextInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        const first = parsed.error.flatten().fieldErrors;
+        const msg = Object.keys(first).length
+          ? Object.entries(first)
+              .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`)
+              .join('; ')
+          : parsed.error.message;
+        res.status(400).json({ error: 'INVALID_INPUT', message: msg });
+        return;
+      }
 
-            structuredLogger.info(`-> POST /api/kairos_next (uri: ${uri})`);
-
-            const normalizeMemoryUri = (value: string): { uuid: string; uri: string } => {
-                const normalized = (value || '').trim();
-                const uuid = normalized.split('/').pop()!;
-                if (!uuid) {
-                    throw new Error('Invalid kairos://mem URI');
-                }
-                const memUri = normalized.startsWith('kairos://mem/') ? normalized : `kairos://mem/${uuid}`;
-                return { uuid, uri: memUri };
-            };
-
-            const { uuid, uri: requestedUri } = normalizeMemoryUri(uri);
-
-            const memory = await memoryStore.getMemory(uuid);
-
-            // When requested step has no proof_of_work (e.g. last step), apply solution to previous step (MISSING_PROOF fix)
-            if (memory && !memory.proof_of_work && solution) {
-                const prevResult = await tryApplySolutionToPreviousStep(
-                    memory,
-                    solution,
-                    (id) => memoryStore.getMemory(id),
-                    qdrantService
-                );
-                if (prevResult.applied) {
-                    if (prevResult.outcome.blockedPayload) {
-                        await updateStepQuality(qdrantService, prevResult.prevMemory, 'failure', 'http');
-                        const duration = Date.now() - startTime;
-                        return res.status(200).json({
-                            ...prevResult.outcome.blockedPayload,
-                            metadata: { duration_ms: duration }
-                        });
-                    }
-                    if (!prevResult.outcome.alreadyRecorded) {
-                        await updateStepQuality(qdrantService, prevResult.prevMemory, 'success', 'http');
-                    }
-                    const nextFromRequested = await resolveChainNextStep(memory, qdrantService);
-                    const nextStepUri = nextFromRequested?.uuid
-                        ? `kairos://mem/${nextFromRequested.uuid}`
-                        : null;
-                    const current_step = {
-                        uri: requestedUri,
-                        content: memory ? extractMemoryBody(memory.text) : '',
-                        mimeType: 'text/markdown' as const
-                    };
-                    const challenge = await buildChallenge(memory, undefined);
-                    const output: any = {
-                        must_obey: true,
-                        current_step,
-                        challenge
-                    };
-                    if (nextStepUri) {
-                        output.next_action = `call kairos_next with ${nextStepUri} and solution matching challenge`;
-                    } else {
-                        output.message = 'Protocol steps complete. Call kairos_attest to finalize.';
-                        output.next_action = `call kairos_attest with ${requestedUri} and outcome (success or failure) and message to complete the protocol`;
-                    }
-                    if (prevResult.outcome.proofHash) output.proof_hash = prevResult.outcome.proofHash;
-                    const duration = Date.now() - startTime;
-                    return res.status(200).json({ ...output, metadata: { duration_ms: duration } });
-                }
-            }
-
-            // Solution is required for steps 2+
-            if (!solution) {
-                const retryCount = await proofOfWorkStore.incrementRetry(uuid);
-                const noSolChallenge = await buildChallenge(null, undefined);
-                const duration = Date.now() - startTime;
-                return res.status(200).json({
-                    must_obey: retryCount < 3,
-                    current_step: {
-                        uri: requestedUri,
-                        content: memory ? extractMemoryBody(memory.text) : '',
-                        mimeType: 'text/markdown'
-                    },
-                    challenge: noSolChallenge,
-                    message: 'Solution is required for steps 2+. Use kairos_begin for step 1.',
-                    next_action: `retry kairos_next with ${requestedUri} -- include solution matching challenge`,
-                    error_code: 'MISSING_FIELD',
-                    retry_count: retryCount,
-                    metadata: { duration_ms: duration }
-                });
-            }
-
-            let submissionOutcome: HandleProofResult | undefined;
-            if (memory?.proof_of_work) {
-                // PROOF_HASH_MISMATCH fix: client may call with next_action URI (next step) and submit
-                // solution for the step we just showed (previous). Apply to previous when solution matches.
-                const prevResultWhenMatch = await tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious(
-                    memory,
-                    solution,
-                    (id) => memoryStore.getMemory(id),
-                    qdrantService
-                );
-                if (prevResultWhenMatch.applied) {
-                    if (prevResultWhenMatch.outcome.blockedPayload) {
-                        await updateStepQuality(qdrantService, prevResultWhenMatch.prevMemory, 'failure', 'http');
-                        const duration = Date.now() - startTime;
-                        return res.status(200).json({
-                            ...prevResultWhenMatch.outcome.blockedPayload,
-                            metadata: { duration_ms: duration }
-                        });
-                    }
-                    if (!prevResultWhenMatch.outcome.alreadyRecorded) {
-                        await updateStepQuality(qdrantService, prevResultWhenMatch.prevMemory, 'success', 'http');
-                    }
-                    const nextFromRequested = await resolveChainNextStep(memory, qdrantService);
-                    const nextStepUri = nextFromRequested?.uuid
-                        ? `kairos://mem/${nextFromRequested.uuid}`
-                        : null;
-                    const current_step = {
-                        uri: requestedUri,
-                        content: memory ? extractMemoryBody(memory.text) : '',
-                        mimeType: 'text/markdown' as const
-                    };
-                    const nextMemory = nextFromRequested ? await memoryStore.getMemory(nextFromRequested.uuid) : null;
-                    const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
-                    const challenge = await buildChallenge(memory, challengeProof);
-                    const output: any = {
-                        must_obey: true,
-                        current_step,
-                        challenge
-                    };
-                    if (nextStepUri) {
-                        output.next_action = `call kairos_next with ${nextStepUri} and solution matching challenge`;
-                    } else {
-                        output.message = 'Protocol steps complete. Call kairos_attest to finalize.';
-                        output.next_action = `call kairos_attest with ${requestedUri} and outcome (success or failure) and message to complete the protocol`;
-                    }
-                    if (prevResultWhenMatch.outcome.proofHash) output.proof_hash = prevResultWhenMatch.outcome.proofHash;
-                    const duration = Date.now() - startTime;
-                    return res.status(200).json({ ...output, metadata: { duration_ms: duration } });
-                }
-
-                const isStep1 = !memory.chain || memory.chain.step_index <= 1;
-                let expectedPreviousHash: string;
-                if (isStep1) {
-                    expectedPreviousHash = GENESIS_HASH;
-                } else {
-                    const prev = await resolveChainPreviousStep(memory, qdrantService);
-                    const prevHash = prev?.uuid ? await proofOfWorkStore.getProofHash(prev.uuid) : null;
-                    expectedPreviousHash = prevHash ?? GENESIS_HASH;
-                }
-                submissionOutcome = await handleProofSubmission(solution, memory, { expectedPreviousHash });
-                if (submissionOutcome.blockedPayload) {
-                    await updateStepQuality(qdrantService, memory, 'failure', 'http');
-                    const duration = Date.now() - startTime;
-                    return res.status(200).json({
-                        ...submissionOutcome.blockedPayload,
-                        metadata: { duration_ms: duration }
-                    });
-                }
-            }
-
-            if (!memory) {
-                const duration = Date.now() - startTime;
-                return res.status(200).json({
-                    must_obey: true,
-                    current_step: {
-                        uri: requestedUri,
-                        content: '',
-                        mimeType: 'text/markdown'
-                    },
-                    challenge: await buildChallenge(null, undefined),
-                    message: 'Protocol steps complete. Call kairos_attest to finalize.',
-                    next_action: `call kairos_attest with ${requestedUri} and outcome (success or failure) and message to complete the protocol`,
-                    metadata: { duration_ms: duration }
-                });
-            }
-
-            if (memory.proof_of_work && submissionOutcome?.proofHash && !submissionOutcome.alreadyRecorded) {
-                await updateStepQuality(qdrantService, memory, 'success', 'http');
-            }
-
-            // Resolve next step for display
-            const nextStepInfo = await resolveChainNextStep(memory, qdrantService);
-            const nextMemory = nextStepInfo
-                ? await memoryStore.getMemory(nextStepInfo.uuid)
-                : null;
-            const displayMemory = nextMemory ?? memory;
-            const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
-            const displayUri = nextStepInfo ? `kairos://mem/${nextStepInfo.uuid}` : requestedUri;
-
-            // Resolve the step AFTER display to get next_action URI
-            const nextFromDisplay = displayMemory ? await resolveChainNextStep(displayMemory, qdrantService) : undefined;
-            const nextStepUri = nextFromDisplay?.uuid
-                ? `kairos://mem/${nextFromDisplay.uuid}`
-                : null;
-
-            const current_step = {
-                uri: displayUri,
-                content: displayMemory ? extractMemoryBody(displayMemory.text) : '',
-                mimeType: 'text/markdown' as const
-            };
-
-            const challenge = await buildChallenge(displayMemory, challengeProof);
-
-            const output: any = {
-                must_obey: true,
-                current_step,
-                challenge
-            };
-
-            if (nextStepUri) {
-                output.next_action = `call kairos_next with ${nextStepUri} and solution matching challenge`;
-            } else {
-                output.message = 'Protocol steps complete. Call kairos_attest to finalize.';
-                output.next_action = `call kairos_attest with ${requestedUri} and outcome (success or failure) and message to complete the protocol`;
-            }
-
-            if (submissionOutcome?.proofHash) {
-                output.proof_hash = submissionOutcome.proofHash;
-            }
-
-            const duration = Date.now() - startTime;
-            structuredLogger.info(`kairos_next completed in ${duration}ms`);
-
-            res.status(200).json({
-                ...output,
-                metadata: { duration_ms: duration }
-            });
-            return;
-
-        } catch (error) {
-            const duration = Date.now() - startTime;
-            structuredLogger.error(`kairos_next failed in ${duration}ms`, error);
-            res.status(500).json({
-                error: 'NEXT_FAILED',
-                message: error instanceof Error ? error.message : 'Failed to get next step',
-                duration_ms: duration
-            });
-            return;
-        }
-    });
+      structuredLogger.info(`-> POST /api/kairos_next (uri: ${parsed.data.uri})`);
+      const result = await executeNext(memoryStore, qdrantService, parsed.data, 'http');
+      res.status(200).json(result);
+      return;
+    } catch (error) {
+      structuredLogger.error('kairos_next failed', error);
+      res.status(500).json({
+        error: 'NEXT_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to get next step'
+      });
+    }
+  });
 }

--- a/src/http/http-api-spaces.ts
+++ b/src/http/http-api-spaces.ts
@@ -8,12 +8,10 @@ import { structuredLogger } from "../utils/structured-logger.js";
  */
 export function setupSpacesRoute(app: express.Express, memoryStore: MemoryQdrantStore): void {
   app.post("/api/kairos_spaces", async (req, res) => {
-    const startTime = Date.now();
     try {
       structuredLogger.info("-> POST /api/kairos_spaces");
       const payload = await executeSpaces(memoryStore, { include_chain_titles: false });
-      const duration = Date.now() - startTime;
-      res.status(200).json({ ...payload, metadata: { duration_ms: duration } });
+      res.status(200).json(payload);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       structuredLogger.debug(`kairos_spaces HTTP error: ${message}`);

--- a/src/http/http-api-update.ts
+++ b/src/http/http-api-update.ts
@@ -1,115 +1,35 @@
 import express from 'express';
 import { structuredLogger } from '../utils/structured-logger.js';
 import type { QdrantService } from '../services/qdrant/service.js';
+import { executeUpdate } from '../tools/kairos_update.js';
+import { updateInputSchema } from '../tools/kairos_update_schema.js';
 
 /**
- * Set up API route for kairos_update
- * @param app Express application instance
- * @param qdrantService Qdrant service instance
+ * Set up API route for kairos_update. Uses shared executeUpdate; returns same shape as MCP (no metadata).
  */
 export function setupUpdateRoute(app: express.Express, qdrantService: QdrantService) {
-    app.post('/api/kairos_update', async (req, res) => {
-        const startTime = Date.now();
-
-        try {
-            const { uris, markdown_doc, updates } = req.body;
-
-            if (!uris || !Array.isArray(uris) || uris.length === 0) {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'uris is required and must be a non-empty array'
-                });
-                return;
-            }
-
-            if (markdown_doc && (!Array.isArray(markdown_doc) || markdown_doc.length !== uris.length)) {
-                res.status(400).json({
-                    error: 'INVALID_INPUT',
-                    message: 'markdown_doc array length must match uris array length'
-                });
-                return;
-            }
-
-            structuredLogger.info(`→ POST /api/kairos_update (${uris.length} URI(s))`);
-
-            const extractBody = (text: string): string => {
-                const start = /<!--\s*KAIROS:BODY-START\s*-->/i;
-                const end = /<!--\s*KAIROS:BODY-END\s*-->/i;
-                const s = text.search(start);
-                const e = text.search(end);
-                if (s >= 0 && e > s) {
-                    const startMatch = text.match(start);
-                    if (!startMatch) return text;
-                    const startIdx = (startMatch.index || 0) + startMatch[0].length;
-                    return text.slice(startIdx, e).trim();
-                }
-                return text;
-            };
-
-            const results: any[] = [];
-            let totalUpdated = 0;
-            let totalFailed = 0;
-
-            for (let i = 0; i < uris.length; i++) {
-                const uri = uris[i];
-                try {
-                    const uuid = typeof uri === 'string' ? uri.split('/').pop() : undefined;
-                    if (!uuid) {
-                        throw new Error('Invalid URI format');
-                    }
-
-                    const mk = Array.isArray(markdown_doc) ? markdown_doc[i] : undefined;
-                    if (typeof mk === 'string' && mk.trim().length > 0) {
-                        const body = extractBody(mk);
-                        await qdrantService.updateMemory(uuid, { text: body });
-                    } else if (updates && Object.keys(updates).length > 0) {
-                        if (typeof updates['text'] === 'string' && updates['text'].indexOf('<!-- KAIROS:BODY-START') !== -1 && updates['text'].indexOf('<!-- KAIROS:BODY-END') !== -1) {
-                            const body = extractBody(updates['text']);
-                            await qdrantService.updateMemory(uuid, { text: body });
-                        } else {
-                            await qdrantService.updateMemory(uuid, updates);
-                        }
-                    } else {
-                        throw new Error('Provide markdown_doc or updates');
-                    }
-
-                    results.push({
-                        uri,
-                        status: 'updated',
-                        message: `Memory ${uri} updated successfully`
-                    });
-                    totalUpdated++;
-                } catch (error) {
-                    const errorMessage = error instanceof Error ? error.message : String(error);
-                    results.push({
-                        uri,
-                        status: 'error',
-                        message: `Failed to update memory: ${errorMessage}`
-                    });
-                    totalFailed++;
-                }
-            }
-
-            const duration = Date.now() - startTime;
-            structuredLogger.info(`✓ kairos_update completed in ${duration}ms (${totalUpdated} updated, ${totalFailed} failed)`);
-
-            res.status(200).json({
-                results,
-                total_updated: totalUpdated,
-                total_failed: totalFailed,
-                metadata: { duration_ms: duration }
-            });
-
-        } catch (error) {
-            const duration = Date.now() - startTime;
-            structuredLogger.error(`✗ kairos_update failed in ${duration}ms`, error);
-            res.status(500).json({
-                error: 'UPDATE_FAILED',
-                message: error instanceof Error ? error.message : 'Failed to update memories',
-                duration_ms: duration
-            });
-        }
-    });
+  app.post('/api/kairos_update', async (req, res) => {
+    try {
+      const input = updateInputSchema.safeParse(req.body);
+      if (!input.success) {
+        res.status(400).json({
+          error: 'INVALID_INPUT',
+          message: input.error.message ?? 'uris is required and must be a non-empty array'
+        });
+        return;
+      }
+      structuredLogger.info(`→ POST /api/kairos_update (${input.data.uris.length} URI(s))`);
+      const result = await executeUpdate(qdrantService, input.data);
+      structuredLogger.info(`✓ kairos_update completed (${result.total_updated} updated, ${result.total_failed} failed)`);
+      res.status(200).json(result);
+    } catch (error) {
+      structuredLogger.error('✗ kairos_update failed', error);
+      res.status(500).json({
+        error: 'UPDATE_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to update memories'
+      });
+    }
+  });
 }
 
 

--- a/src/http/http-auth-callback.ts
+++ b/src/http/http-auth-callback.ts
@@ -4,6 +4,8 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 import crypto from 'crypto';
+import { fromBase64url, toBase64url } from '@exodus/bytes/base64.js';
+import { utf8fromString, utf8toString } from '@exodus/bytes/utf8.js';
 import {
   AUTH_ENABLED,
   KEYCLOAK_URL,
@@ -24,8 +26,10 @@ function signSession(payload: {
   group_ids?: string[];
   exp: number;
 }): string {
-  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  const sig = crypto.createHmac('sha256', SESSION_SECRET).update(payloadB64).digest('base64url');
+  const payloadB64 = toBase64url(utf8fromString(JSON.stringify(payload)));
+  const sig = toBase64url(
+    new Uint8Array(crypto.createHmac('sha256', SESSION_SECRET).update(payloadB64).digest())
+  );
   return `${payloadB64}.${sig}`;
 }
 
@@ -168,7 +172,7 @@ export function setupAuthCallback(app: express.Express): void {
     try {
       const segment = tokenToDecode.split('.')[1];
       const payload = segment
-        ? (JSON.parse(Buffer.from(segment, 'base64url').toString()) as {
+        ? (JSON.parse(utf8toString(fromBase64url(segment))) as {
             sub?: string;
             iss?: string;
             groups?: string[];

--- a/src/http/http-auth-middleware.ts
+++ b/src/http/http-auth-middleware.ts
@@ -5,6 +5,8 @@
  */
 import type { Request, Response, NextFunction } from 'express';
 import crypto from 'crypto';
+import { fromBase64url, toBase64url } from '@exodus/bytes/base64.js';
+import { utf8toString } from '@exodus/bytes/utf8.js';
 import {
   AUTH_ENABLED,
   KEYCLOAK_URL,
@@ -75,9 +77,11 @@ function getSessionPayload(req: Request): AuthPayload | null {
   try {
     const [payloadB64, sig] = cookie.split('.');
     if (!payloadB64 || !sig) return null;
-    const expectedSig = crypto.createHmac('sha256', SESSION_SECRET).update(payloadB64).digest('base64url');
+    const expectedSig = toBase64url(
+      new Uint8Array(crypto.createHmac('sha256', SESSION_SECRET).update(payloadB64).digest())
+    );
     if (sig !== expectedSig) return null;
-    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString()) as {
+    const payload = JSON.parse(utf8toString(fromBase64url(payloadB64))) as {
       sub?: string;
       groups?: string[];
       realm?: string;

--- a/src/tools/kairos_attest.ts
+++ b/src/tools/kairos_attest.ts
@@ -1,11 +1,103 @@
-import { z } from 'zod';
-import { QdrantService } from '../services/qdrant/service.js';
+import type { QdrantService } from '../services/qdrant/service.js';
 import { IDGenerator } from '../services/id-generator.js';
 import { modelStats } from '../services/stats/model-stats.js';
 import { logger } from '../utils/logger.js';
 import { getToolDoc } from '../resources/embedded-mcp-resources.js';
 import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
 import { getTenantId, getSpaceContextFromStorage } from '../utils/tenant-context.js';
+import { attestInputSchema, attestOutputSchema, type AttestInput, type AttestOutput } from './kairos_attest_schema.js';
+
+/** Shared execute: rate protocol step completion. Used by MCP tool and HTTP route. */
+export async function executeAttest(
+  qdrantService: QdrantService,
+  input: AttestInput
+): Promise<AttestOutput> {
+  const { uri, outcome, quality_bonus = 0, message, llm_model_id } = input;
+  const modelIdentity = {
+    modelId: llm_model_id || 'kairos-attest',
+    provider: 'unknown',
+    family: 'unknown'
+  };
+  const uris = [uri];
+  const results: AttestOutput['results'] = [];
+  let totalRated = 0;
+  let totalFailed = 0;
+
+  logger.tool('rate', 'rate', `single rating of ${uri} with outcome="${outcome}" model="${modelIdentity.modelId}"`);
+
+  for (const u of uris) {
+    try {
+      const qdrantUuid = IDGenerator.qdrantIdFromUri(u);
+      const basicQualityBonus = outcome === 'success' ? 1 : -0.2;
+      const currentPoint = await qdrantService.retrieveById(qdrantUuid);
+      const currentMetrics = currentPoint?.payload?.quality_metrics || {};
+      const implementationBonus = await modelStats.calculateImplementationBonus(
+        currentMetrics,
+        modelIdentity.modelId,
+        outcome
+      );
+      const totalQualityBonus = basicQualityBonus + implementationBonus + quality_bonus;
+      const metricsUpdate: Record<string, unknown> = {
+        retrievalCount: 1,
+        successCount: outcome === 'success' ? 1 : 0,
+        failureCount: outcome === 'failure' ? 1 : 0,
+        lastRated: new Date().toISOString(),
+        lastRater: modelIdentity.modelId,
+        qualityBonus: totalQualityBonus
+      };
+      if (message) {
+        metricsUpdate['usageContext'] = message;
+      }
+      await qdrantService.updateQualityMetrics(qdrantUuid, metricsUpdate);
+      await qdrantService.propagateAttestToChainHead(qdrantUuid, metricsUpdate);
+
+      if (currentPoint?.payload) {
+        const { description_short, domain, task, type, tags } = currentPoint.payload;
+        const updatedQualityMetadata = modelStats.calculateStepQualityMetadata(
+          description_short || 'Knowledge step',
+          domain || 'general',
+          task || 'general',
+          type || 'context',
+          tags || [],
+          outcome
+        );
+        await qdrantService.updateQualityMetadata(qdrantUuid, {
+          step_quality_score: updatedQualityMetadata.step_quality_score,
+          step_quality: updatedQualityMetadata.step_quality
+        });
+        logger.info(`attest: Updated quality metadata for ${u} with execution ${outcome} - score: ${updatedQualityMetadata.step_quality_score} (${updatedQualityMetadata.step_quality})`);
+      }
+
+      await modelStats.processQualityFeedback(modelIdentity.modelId, u, outcome, totalQualityBonus);
+      if (implementationBonus > 0) {
+        await modelStats.updateImplementationBonus(modelIdentity.modelId, implementationBonus);
+      }
+
+      results.push({
+        uri: u,
+        outcome,
+        quality_bonus: totalQualityBonus,
+        message,
+        rated_at: new Date().toISOString()
+      });
+      totalRated++;
+      logger.success('rate', `rated ${u} with ${outcome} (${totalQualityBonus} bonus)`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      results.push({
+        uri: u,
+        outcome,
+        quality_bonus: 0,
+        message: `Failed to rate ${u}: ${errorMessage}`,
+        rated_at: new Date().toISOString()
+      });
+      totalFailed++;
+      logger.error(`rate failed for ${u}`, error);
+    }
+  }
+
+  return { results, total_rated: totalRated, total_failed: totalFailed };
+}
 
 interface RegisterAttestOptions {
   toolName?: string;
@@ -13,222 +105,40 @@ interface RegisterAttestOptions {
 
 export function registerKairosAttestTool(server: any, qdrantService: QdrantService, options: RegisterAttestOptions = {}) {
   const toolName = options.toolName || 'kairos_attest';
-  const memoryUriSchema = z
-    .string()
-    .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
-
-  const inputSchema = z.object({
-    uri: memoryUriSchema.describe('URI of the last step in the protocol'),
-    outcome: z.enum(['success', 'failure']).describe('Execution outcome'),
-    message: z.string().min(1).describe('Short summary of how the protocol went'),
-    quality_bonus: z.number().optional().default(0).describe('Additional quality bonus to apply'),
-    llm_model_id: z.string().optional().describe('Optional model identifier for attribution')
-  });
-
-  const outputSchema = z.object({
-    results: z.array(z.object({
-      uri: memoryUriSchema,
-      outcome: z.string(),
-      quality_bonus: z.number(),
-      message: z.string(),
-      rated_at: z.string()
-    })),
-    total_rated: z.number(),
-    total_failed: z.number()
-  });
-
-  logger.debug(`kairos_attest registration inputSchema: ${JSON.stringify(inputSchema)}`);
-  logger.debug(`kairos_attest registration outputSchema: ${JSON.stringify(outputSchema)}`);
+  logger.debug(`kairos_attest registration inputSchema: ${JSON.stringify(attestInputSchema)}`);
+  logger.debug(`kairos_attest registration outputSchema: ${JSON.stringify(attestOutputSchema)}`);
   server.registerTool(
     toolName,
     {
       title: 'Finalize protocol execution',
       description: getToolDoc('kairos_attest') || 'Stamp of completion. Call after the last step is solved via kairos_next. No final_solution required.',
-      inputSchema,
-      outputSchema
+      inputSchema: attestInputSchema,
+      outputSchema: attestOutputSchema
     },
-    async (params: any) => {
+    async (params: unknown) => {
       const tenantId = getTenantId();
       const spaceId = getSpaceContextFromStorage()?.defaultWriteSpaceId ?? 'default';
       logger.debug(`kairos_attest space_id=${spaceId}`);
-      const inputSize = JSON.stringify(params).length;
-      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, inputSize);
-      
-      const timer = mcpToolDuration.startTimer({ 
-        tool: toolName,
-        tenant_id: tenantId 
-      });
-      
-      let result: any;
-      
+      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(params).length);
+      const timer = mcpToolDuration.startTimer({ tool: toolName, tenant_id: tenantId });
+
       try {
-        const { uri, outcome, quality_bonus = 0, message, llm_model_id } = params;
-
-      const modelIdentity = {
-        modelId: llm_model_id || 'kairos-attest',
-        provider: 'unknown',
-        family: 'unknown'
-      };
-
-      if (!uri) {
-        throw new Error('uri must be a string');
-      }
-      const uris = [uri];
-      const uriArray: string[] = uris;
-
-      logger.tool('rate', 'rate', `single rating of ${uri} with outcome="${outcome}" model="${modelIdentity.modelId}"`);
-
-        const results: any[] = [];
-        let totalRated = 0;
-        let totalFailed = 0;
-
-        for (const uri of uriArray) {
-          try {
-            const qdrantUuid = IDGenerator.qdrantIdFromUri(uri);
-            const basicQualityBonus = outcome === 'success' ? 1 : -0.2;
-
-            const currentPoint = await qdrantService.retrieveById(qdrantUuid);
-            const currentMetrics = currentPoint?.payload?.quality_metrics || {};
-
-            const implementationBonus = await modelStats.calculateImplementationBonus(
-              currentMetrics,
-              modelIdentity.modelId,
-              outcome
-            );
-
-            const totalQualityBonus = basicQualityBonus + implementationBonus + quality_bonus;
-
-            const metricsUpdate: any = {
-              retrievalCount: 1,
-              successCount: outcome === 'success' ? 1 : 0,
-              failureCount: outcome === 'failure' ? 1 : 0,
-              lastRated: new Date().toISOString(),
-              lastRater: modelIdentity.modelId,
-              qualityBonus: totalQualityBonus
-            };
-
-            if (message) {
-              metricsUpdate.usageContext = message;
-            }
-
-            await qdrantService.updateQualityMetrics(qdrantUuid, metricsUpdate);
-            await qdrantService.propagateAttestToChainHead(qdrantUuid, metricsUpdate);
-
-            if (currentPoint?.payload) {
-              const { description_short, domain, task, type, tags } = currentPoint.payload;
-
-              const updatedQualityMetadata = modelStats.calculateStepQualityMetadata(
-                description_short || 'Knowledge step',
-                domain || 'general',
-                task || 'general',
-                type || 'context',
-                tags || [],
-                outcome
-              );
-
-              await qdrantService.updateQualityMetadata(qdrantUuid, {
-                step_quality_score: updatedQualityMetadata.step_quality_score,
-                step_quality: updatedQualityMetadata.step_quality
-              });
-
-              logger.info(`attest: Updated quality metadata for ${uri} with execution ${outcome} - score: ${updatedQualityMetadata.step_quality_score} (${updatedQualityMetadata.step_quality})`);
-            }
-
-            await modelStats.processQualityFeedback(
-              modelIdentity.modelId,
-              uri,
-              outcome,
-              totalQualityBonus
-            );
-
-            if (implementationBonus > 0) {
-              await modelStats.updateImplementationBonus(modelIdentity.modelId, implementationBonus);
-            }
-
-            results.push({
-              uri: uri,
-              outcome: outcome,
-              quality_bonus: totalQualityBonus,
-              message,
-              rated_at: new Date().toISOString()
-            });
-            totalRated++;
-
-            logger.success('rate', `rated ${uri} with ${outcome} (${totalQualityBonus} bonus)`);
-          } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            // Keep result shape strictly within outputSchema (no extra properties) so MCP clients do not reject with -32602.
-            results.push({
-              uri: uri,
-              outcome: outcome,
-              quality_bonus: 0,
-              message: `Failed to rate ${uri}: ${errorMessage}`,
-              rated_at: new Date().toISOString()
-            });
-            totalFailed++;
-
-            logger.error(`rate failed for ${uri}`, error);
-          }
-        }
-
-        result = {
-          results,
-          total_rated: totalRated,
-          total_failed: totalFailed
-        };
-
-        const finalResult = {
-          content: [{
-            type: 'text',
-            text: JSON.stringify(result, null, 2)
-          }],
+        const input = attestInputSchema.parse(params);
+        const result = await executeAttest(qdrantService, input);
+        mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
+        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(result).length);
+        timer({ tool: toolName, status: 'success', tenant_id: tenantId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
           structuredContent: result
         };
-        
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        
-        const outputSize = JSON.stringify(finalResult).length;
-        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, outputSize);
-        
-        timer({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        
-        return finalResult;
       } catch (error) {
         logger.error('attest failed', error);
-        
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        mcpToolErrors.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        timer({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-
+        mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        timer({ tool: toolName, status: 'error', tenant_id: tenantId });
         return {
-          content: [{
-            type: 'text',
-            text: `Rate failed: ${error instanceof Error ? error.message : String(error)}`
-          }],
-          contents: [{
-            type: 'text',
-            text: `Rate failed: ${error instanceof Error ? error.message : String(error)}`
-          }],
+          content: [{ type: 'text' as const, text: `Rate failed: ${error instanceof Error ? error.message : String(error)}` }],
           isError: true
         };
       }

--- a/src/tools/kairos_attest_schema.ts
+++ b/src/tools/kairos_attest_schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const memoryUriSchema = z
+  .string()
+  .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
+
+export const attestInputSchema = z.object({
+  uri: memoryUriSchema.describe('URI of the last step in the protocol'),
+  outcome: z.enum(['success', 'failure']).describe('Execution outcome'),
+  message: z.string().min(1).describe('Short summary of how the protocol went'),
+  quality_bonus: z.number().optional().default(0).describe('Additional quality bonus to apply'),
+  llm_model_id: z.string().optional().describe('Optional model identifier for attribution')
+});
+
+export const attestOutputSchema = z.object({
+  results: z.array(z.object({
+    uri: memoryUriSchema,
+    outcome: z.string(),
+    quality_bonus: z.number(),
+    message: z.string(),
+    rated_at: z.string()
+  })),
+  total_rated: z.number(),
+  total_failed: z.number()
+});
+
+export type AttestInput = z.infer<typeof attestInputSchema>;
+export type AttestOutput = z.infer<typeof attestOutputSchema>;

--- a/src/tools/kairos_begin.ts
+++ b/src/tools/kairos_begin.ts
@@ -79,100 +79,81 @@ function buildKairosBeginPayload(
   return payload;
 }
 
+import { z } from 'zod';
 import { buildBeginSchemas } from './kairos_begin_schema.js';
+
+const beginSchemas = buildBeginSchemas();
+export const beginInputSchema = beginSchemas.inputSchema;
+export const beginOutputSchema = beginSchemas.outputSchema;
+export type BeginInput = z.infer<typeof beginInputSchema>;
+export type BeginOutput = z.infer<typeof beginOutputSchema>;
+
+/**
+ * Shared execute: load step 1 (with auto-redirect) and return challenge/next_action. Used by MCP tool and HTTP route.
+ */
+export async function executeBegin(
+  memoryStore: MemoryQdrantStore,
+  qdrantService: QdrantService | undefined,
+  input: BeginInput
+): Promise<BeginOutput> {
+  const { uuid, uri: requestedUri } = normalizeMemoryUri(input.uri);
+  let memory = await loadMemoryWithCache(memoryStore, uuid);
+  let redirectMessage: string | undefined;
+
+  if (memory?.chain && memory.chain.step_index !== 1) {
+    const firstStep = await resolveChainFirstStep(memory, qdrantService);
+    if (firstStep?.uuid) {
+      const step1Memory = await loadMemoryWithCache(memoryStore, firstStep.uuid);
+      if (step1Memory) {
+        memory = step1Memory;
+        redirectMessage = 'Redirected to step 1 of this protocol chain.';
+      }
+    }
+  }
+
+  const nextStepInfo = memory
+    ? await resolveChainNextStep(memory, qdrantService)
+    : undefined;
+  const nextStepUri = nextStepInfo?.uuid ? `kairos://mem/${nextStepInfo.uuid}` : null;
+  const challenge = await buildChallenge(memory, memory?.proof_of_work);
+  return buildKairosBeginPayload(memory, requestedUri, nextStepUri, challenge, redirectMessage) as BeginOutput;
+}
 
 export function registerBeginTool(server: any, memoryStore: MemoryQdrantStore, options: RegisterBeginOptions = {}) {
   const toolName = options.toolName || 'kairos_begin';
-  const { inputSchema, outputSchema } = buildBeginSchemas();
-
-  structuredLogger.debug(`kairos_begin registration inputSchema: ${JSON.stringify(inputSchema)}`);
-  structuredLogger.debug(`kairos_begin registration outputSchema: ${JSON.stringify(outputSchema)}`);
+  structuredLogger.debug(`kairos_begin registration inputSchema: ${JSON.stringify(beginInputSchema)}`);
+  structuredLogger.debug(`kairos_begin registration outputSchema: ${JSON.stringify(beginOutputSchema)}`);
   server.registerTool(
     toolName,
     {
       title: 'Start protocol execution',
       description: getToolDoc('kairos_begin') || 'Loads step 1 and returns the first challenge. Auto-redirects to step 1 if non-step-1 URI is provided.',
-      inputSchema,
-      outputSchema
+      inputSchema: beginInputSchema,
+      outputSchema: beginOutputSchema
     },
-    async (params: any) => {
+    async (params: unknown) => {
       const tenantId = getTenantId();
       const spaceId = getSpaceContextFromStorage()?.defaultWriteSpaceId ?? 'default';
       structuredLogger.debug(`kairos_begin space_id=${spaceId}`);
-      const inputSize = JSON.stringify(params).length;
-      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, inputSize);
-      
-      const timer = mcpToolDuration.startTimer({ 
-        tool: toolName,
-        tenant_id: tenantId 
-      });
-      const respond = (payload: any) => {
-        const structured = {
-          content: [{
-            type: 'text', text: JSON.stringify(payload)
-          }],
+      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(params).length);
+      const timer = mcpToolDuration.startTimer({ tool: toolName, tenant_id: tenantId });
+      const respond = (payload: BeginOutput) => {
+        mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
+        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(payload).length);
+        timer({ tool: toolName, status: 'success', tenant_id: tenantId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
           structuredContent: payload
         };
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        const outputSize = JSON.stringify(structured).length;
-        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, outputSize);
-        timer({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        return structured;
       };
       try {
-        const { uri } = params as { uri: string };
-        const { uuid, uri: requestedUri } = normalizeMemoryUri(uri);
-
-        let memory = await loadMemoryWithCache(memoryStore, uuid);
-        let redirectMessage: string | undefined;
-        
-        // Auto-redirect: if not step 1, resolve and present step 1
-        if (memory?.chain && memory.chain.step_index !== 1) {
-          const firstStep = await resolveChainFirstStep(memory, options.qdrantService);
-          if (firstStep?.uuid) {
-            const step1Memory = await loadMemoryWithCache(memoryStore, firstStep.uuid);
-            if (step1Memory) {
-              memory = step1Memory;
-              redirectMessage = 'Redirected to step 1 of this protocol chain.';
-            }
-          }
-        }
-
-        // Resolve next step URI
-        const nextStepInfo = memory
-          ? await resolveChainNextStep(memory, options.qdrantService)
-          : undefined;
-        const nextStepUri = nextStepInfo?.uuid
-          ? `kairos://mem/${nextStepInfo.uuid}`
-          : null;
-
-        const challenge = await buildChallenge(memory, memory?.proof_of_work);
-        const output = buildKairosBeginPayload(memory, requestedUri, nextStepUri, challenge, redirectMessage);
+        const input = beginInputSchema.parse(params);
+        const output = await executeBegin(memoryStore, options.qdrantService, input);
         return respond(output);
       } catch (error) {
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        mcpToolErrors.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        timer({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
+        mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        timer({ tool: toolName, status: 'error', tenant_id: tenantId });
         throw error;
       }
     }

--- a/src/tools/kairos_delete.ts
+++ b/src/tools/kairos_delete.ts
@@ -1,128 +1,83 @@
-import { z } from 'zod';
-import { qdrantService } from '../services/qdrant/index.js';
+import type { QdrantService } from '../services/qdrant/service.js';
+import { qdrantService as qdrantServiceSingleton } from '../services/qdrant/index.js';
 import { getToolDoc } from '../resources/embedded-mcp-resources.js';
 import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
 import { getTenantId } from '../utils/tenant-context.js';
+import { deleteInputSchema, deleteOutputSchema, type DeleteInput, type DeleteOutput } from './kairos_delete_schema.js';
+
+/** Shared execute: delete memories by URIs. Used by MCP tool and HTTP route. */
+export async function executeDelete(
+  qdrantService: QdrantService,
+  input: DeleteInput
+): Promise<DeleteOutput> {
+  const { uris } = input;
+  const results: DeleteOutput['results'] = [];
+  let totalDeleted = 0;
+  let totalFailed = 0;
+
+  for (const uri of uris) {
+    try {
+      const uuid = typeof uri === 'string' ? uri.split('/').pop() : undefined;
+      if (!uuid) {
+        throw new Error('Invalid URI format');
+      }
+      await qdrantService.deleteMemory(uuid);
+      results.push({
+        uri,
+        status: 'deleted',
+        message: `Memory ${uri} deleted successfully`
+      });
+      totalDeleted++;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      results.push({
+        uri,
+        status: 'error',
+        message: `Failed to delete memory: ${errorMessage}`
+      });
+      totalFailed++;
+    }
+  }
+
+  return {
+    results,
+    total_deleted: totalDeleted,
+    total_failed: totalFailed
+  };
+}
 
 export function registerKairosDeleteTool(server: any, toolName = 'kairos_delete') {
-    const memoryUriSchema = z
-        .string()
-        .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
-    server.registerTool(
-        toolName,
-        {
-            title: 'Delete KAIROS Memory',
-            description: getToolDoc('kairos_delete'),
-            inputSchema: z.object({
-                uris: z
-                    .array(memoryUriSchema)
-                    .nonempty()
-                    .describe('Non-empty array of kairos://mem/{uuid} URIs to delete')
-            }),
-            outputSchema: z.object({
-                results: z.array(z.object({
-                    uri: memoryUriSchema,
-                    status: z.enum(['deleted', 'error']),
-                    message: z.string()
-                })),
-                total_deleted: z.number(),
-                total_failed: z.number()
-            })
-        },
-        async (params: any) => {
-            const tenantId = getTenantId();
-            const inputSize = JSON.stringify(params).length;
-            mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, inputSize);
-            
-            const timer = mcpToolDuration.startTimer({ 
-              tool: toolName,
-              tenant_id: tenantId 
-            });
-            
-            let result: any;
-            
-            try {
-                const { uris } = params || {};
-                if (!Array.isArray(uris) || uris.length === 0) {
-                    throw new Error('uris must be a non-empty array of strings');
-                }
-                const uriArray: string[] = uris;
+  const qdrantService = qdrantServiceSingleton;
+  server.registerTool(
+    toolName,
+    {
+      title: 'Delete KAIROS Memory',
+      description: getToolDoc('kairos_delete'),
+      inputSchema: deleteInputSchema,
+      outputSchema: deleteOutputSchema
+    },
+    async (params: unknown) => {
+      const tenantId = getTenantId();
+      const inputSize = JSON.stringify(params).length;
+      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, inputSize);
+      const timer = mcpToolDuration.startTimer({ tool: toolName, tenant_id: tenantId });
 
-            const results: any[] = [];
-            let totalDeleted = 0;
-            let totalFailed = 0;
-
-            for (const uri of uriArray) {
-                try {
-                    const uuid = typeof uri === 'string' ? uri.split('/').pop() : undefined;
-                    if (!uuid) {
-                        throw new Error('Invalid URI format');
-                    }
-
-                    await qdrantService.deleteMemory(uuid);
-
-                    results.push({
-                        uri,
-                        status: 'deleted' as const,
-                        message: `Memory ${uri} deleted successfully`
-                    });
-                    totalDeleted++;
-                } catch (error) {
-                    const errorMessage = error instanceof Error ? error.message : String(error);
-                    results.push({
-                        uri,
-                        status: 'error' as const,
-                        message: `Failed to delete memory: ${errorMessage}`
-                    });
-                    totalFailed++;
-                }
-            }
-
-            result = {
-                results,
-                total_deleted: totalDeleted,
-                total_failed: totalFailed
-            };
-
-            const finalResult = {
-                content: [{ type: 'text', text: JSON.stringify(result) }],
-                structuredContent: result
-            };
-            
-            mcpToolCalls.inc({ 
-              tool: toolName, 
-              status: 'success',
-              tenant_id: tenantId 
-            });
-            
-            const outputSize = JSON.stringify(finalResult).length;
-            mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, outputSize);
-            
-            timer({ 
-              tool: toolName, 
-              status: 'success',
-              tenant_id: tenantId 
-            });
-            
-            return finalResult;
-            } catch (error) {
-                mcpToolCalls.inc({ 
-                  tool: toolName, 
-                  status: 'error',
-                  tenant_id: tenantId 
-                });
-                mcpToolErrors.inc({ 
-                  tool: toolName, 
-                  status: 'error',
-                  tenant_id: tenantId 
-                });
-                timer({ 
-                  tool: toolName, 
-                  status: 'error',
-                  tenant_id: tenantId 
-                });
-                throw error;
-            }
-        }
-    );
+      try {
+        const input = deleteInputSchema.parse(params);
+        const result = await executeDelete(qdrantService, input);
+        mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
+        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(result).length);
+        timer({ tool: toolName, status: 'success', tenant_id: tenantId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: result
+        };
+      } catch (error) {
+        mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        timer({ tool: toolName, status: 'error', tenant_id: tenantId });
+        throw error;
+      }
+    }
+  );
 }

--- a/src/tools/kairos_delete_schema.ts
+++ b/src/tools/kairos_delete_schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+const memoryUriSchema = z
+  .string()
+  .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
+
+export const deleteInputSchema = z.object({
+  uris: z
+    .array(memoryUriSchema)
+    .nonempty()
+    .describe('Non-empty array of kairos://mem/{uuid} URIs to delete')
+});
+
+export const deleteOutputSchema = z.object({
+  results: z.array(z.object({
+    uri: memoryUriSchema,
+    status: z.enum(['deleted', 'error']),
+    message: z.string()
+  })),
+  total_deleted: z.number(),
+  total_failed: z.number()
+}).strict();
+
+export type DeleteInput = z.infer<typeof deleteInputSchema>;
+export type DeleteOutput = z.infer<typeof deleteOutputSchema>;

--- a/src/tools/kairos_dump.ts
+++ b/src/tools/kairos_dump.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import type { MemoryQdrantStore } from '../services/memory/store.js';
 import type { QdrantService } from '../services/qdrant/service.js';
 import type { Memory, ProofOfWorkDefinition } from '../types/memory.js';
@@ -10,13 +9,9 @@ import { buildChallengeShapeForDisplay } from './kairos_next-pow-helpers.js';
 import { resolveChainFirstStep } from '../services/chain-utils.js';
 import { redisCacheService } from '../services/redis-cache.js';
 import { structuredLogger } from '../utils/structured-logger.js';
+import { dumpInputSchema, dumpOutputSchema } from './kairos_dump_schema.js';
 
 const DUMP_TOOL_NAME = 'kairos_dump';
-
-const dumpInputSchema = z.object({
-  uri: z.string().min(1).describe('kairos://mem/{uuid}'),
-  protocol: z.boolean().optional().default(false).describe('If true, return full chain as one markdown document')
-});
 
 function normalizeUri(value: string): { uuid: string; uri: string } {
   const normalized = (value || '').trim();
@@ -167,7 +162,8 @@ export function registerKairosDumpTool(
     {
       title: 'Inspect memory or protocol (read-only)',
       description: getToolDoc('kairos_dump') ?? 'Returns markdown_doc for use with kairos_update or kairos_mint.',
-      inputSchema: dumpInputSchema
+      inputSchema: dumpInputSchema,
+      outputSchema: dumpOutputSchema
     },
     async (params: any) => {
       const tenantId = getTenantId();

--- a/src/tools/kairos_dump_schema.ts
+++ b/src/tools/kairos_dump_schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const dumpInputSchema = z.object({
+  uri: z.string().min(1).describe('kairos://mem/{uuid}'),
+  protocol: z.boolean().optional().default(false).describe('If true, return full chain as one markdown document')
+});
+
+const positionSchema = z.object({
+  step_index: z.number(),
+  step_count: z.number()
+});
+
+/** Output shape for single-step dump (no protocol=true). */
+export const dumpOutputSchema = z.object({
+  markdown_doc: z.string(),
+  uri: z.string(),
+  label: z.string(),
+  chain_label: z.string().nullable(),
+  step_count: z.number().optional(),
+  protocol_version: z.string().optional(),
+  position: positionSchema.optional(),
+  challenge: z.record(z.string(), z.unknown()).optional()
+}).strict();
+
+export type DumpInput = z.infer<typeof dumpInputSchema>;
+export type DumpOutput = z.infer<typeof dumpOutputSchema>;

--- a/src/tools/kairos_mint.ts
+++ b/src/tools/kairos_mint.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import type { MemoryQdrantStore } from '../services/memory/store.js';
 import type { Memory } from '../types/memory.js';
 import { logger } from '../utils/logger.js';
@@ -7,6 +6,53 @@ import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpTool
 import { getTenantId, getSpaceContextFromStorage, runWithSpaceContextAsync } from '../utils/tenant-context.js';
 import { KAIROS_APP_SPACE_DISPLAY_NAME } from '../utils/space-display.js';
 import { validateProtocolStructure, CREATION_PROTOCOL_URI } from '../services/memory/validate-protocol-structure.js';
+import { mintInputSchema, mintOutputSchema, type MintInput, type MintOutput } from './kairos_mint_schema.js';
+
+/** Thrown by executeMint on validation or store errors. */
+export class MintError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'MintError';
+  }
+}
+
+/**
+ * Shared execute: validate and store markdown chain. Used by MCP tool and HTTP route.
+ * @param runStore Runs the store call (e.g. with space context). Signature: (fn: () => Promise<Memory[]>) => Promise<Memory[]>
+ */
+export async function executeMint(
+  memoryStore: MemoryQdrantStore,
+  input: MintInput,
+  runStore: (fn: () => Promise<Memory[]>) => Promise<Memory[]>
+): Promise<MintOutput> {
+  const validation = validateProtocolStructure(input.markdown_doc);
+  if (!validation.valid) {
+    throw new MintError('PROTOCOL_STRUCTURE_INVALID', validation.message, {
+      missing: validation.missing,
+      must_obey: true,
+      next_action: `call kairos_begin with ${CREATION_PROTOCOL_URI} for guided protocol creation`
+    });
+  }
+  const memories = await runStore(() =>
+    memoryStore.storeChain([input.markdown_doc], input.llm_model_id, {
+      forceUpdate: !!input.force_update,
+      ...(input.protocol_version && { protocolVersion: input.protocol_version })
+    })
+  );
+  return {
+    items: memories.map((memory) => ({
+      uri: `kairos://mem/${memory.memory_uuid}`,
+      memory_uuid: memory.memory_uuid,
+      label: memory.label,
+      tags: memory.tags
+    })),
+    status: 'stored'
+  };
+}
 
 interface RegisterKairosMintOptions {
   toolName?: string;
@@ -14,37 +60,15 @@ interface RegisterKairosMintOptions {
 
 export function registerKairosMintTool(server: any, memoryStore: MemoryQdrantStore, options: RegisterKairosMintOptions = {}) {
   const toolName = options.toolName || 'kairos_mint';
-  const memoryUriSchema = z
-    .string()
-    .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
-
-  const inputSchema = z.object({
-    markdown_doc: z.string().min(1).describe('Markdown document to store'),
-    llm_model_id: z.string().min(1).describe('LLM model ID'),
-    force_update: z.boolean().optional().default(false).describe('Overwrite existing memory chain with the same label'),
-    protocol_version: z.string().optional().describe('Protocol version (e.g. semver). Overrides or supplies version when document has no frontmatter.'),
-    space: z.enum(['personal']).or(z.string()).optional().describe('Target space: "personal" (default) or group name to mint into that group space')
-  });
-
-  const outputSchema = z.object({
-    items: z.array(z.object({
-      uri: memoryUriSchema,
-      memory_uuid: z.string(),
-      label: z.string(),
-      tags: z.array(z.string())
-    })),
-    status: z.literal('stored')
-  });
-
-  logger.debug(`kairos_mint registration inputSchema: ${JSON.stringify(inputSchema)}`);
-  logger.debug(`kairos_mint registration outputSchema: ${JSON.stringify(outputSchema)}`);
+  logger.debug(`kairos_mint registration inputSchema: ${JSON.stringify(mintInputSchema)}`);
+  logger.debug(`kairos_mint registration outputSchema: ${JSON.stringify(mintOutputSchema)}`);
   server.registerTool(
     toolName,
     {
       title: 'Store memory or chain',
       description: getToolDoc('kairos_mint'),
-      inputSchema,
-      outputSchema
+      inputSchema: mintInputSchema,
+      outputSchema: mintOutputSchema
     },
     async (params: any) => {
       const tenantId = getTenantId();
@@ -102,175 +126,69 @@ export function registerKairosMintTool(server: any, memoryStore: MemoryQdrantSto
         defaultWriteSpaceId: resolvedSpaceId
       };
 
-      let result: any;
+      const respond = (output: MintOutput) => {
+        mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
+        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(output).length);
+        timer({ tool: toolName, status: 'success', tenant_id: tenantId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(output) }],
+          structuredContent: output
+        };
+      };
 
       try {
-        const { markdown_doc, llm_model_id, force_update, protocol_version } = params as {
-          markdown_doc: string;
-          llm_model_id: string;
-          force_update?: boolean;
-          protocol_version?: string;
-        };
-        const validation = validateProtocolStructure(markdown_doc);
-        if (!validation.valid) {
-          const body = {
-            error: 'PROTOCOL_STRUCTURE_INVALID',
-            message: validation.message,
-            missing: validation.missing,
-            must_obey: true,
-            next_action: `call kairos_begin with ${CREATION_PROTOCOL_URI} for guided protocol creation`
-          };
+        const input = mintInputSchema.parse(params);
+        const output = await executeMint(memoryStore, input, (fn) =>
+          runWithSpaceContextAsync(narrowedContext, fn)
+        );
+        return respond(output);
+      } catch (error) {
+        const err = error as { code?: string; details?: Record<string, unknown>; message?: string };
+        if (error instanceof MintError) {
           mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
           mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
           timer({ tool: toolName, status: 'error', tenant_id: tenantId });
           return {
             isError: true,
-            content: [{ type: 'text', text: JSON.stringify(body) }]
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: error.code, message: error.message, ...error.details }) }]
           };
         }
-        const docs = [markdown_doc];
-        let memories: Memory[] = [];
-        try {
-          memories = await runWithSpaceContextAsync(narrowedContext, () =>
-            memoryStore.storeChain(docs, llm_model_id, {
-              forceUpdate: !!force_update,
-              ...(protocol_version && { protocolVersion: protocol_version })
-            })
-          );
-        } catch (error) {
-          // Handle duplicate chain error explicitly
-          const err = error as any;
-          if (err && (err.code === 'DUPLICATE_CHAIN' || err.code === 'DUPLICATE_KEY')) {
-            const body = {
-              error: 'DUPLICATE_CHAIN',
-              ...(err.details || {})
-            };
-            result = {
-              isError: true,
-              content: [{ type: 'text', text: JSON.stringify(body) }]
-            } as any;
-            mcpToolCalls.inc({ 
-              tool: toolName, 
-              status: 'error',
-              tenant_id: tenantId 
-            });
-            mcpToolErrors.inc({ 
-              tool: toolName, 
-              status: 'error',
-              tenant_id: tenantId 
-            });
-            timer({ 
-              tool: toolName, 
-              status: 'error',
-              tenant_id: tenantId 
-            });
-            return result;
-          }
-          // Handle similar memory found by title (spec: must_obey, next_action, content_preview)
-          if (err && err.code === 'SIMILAR_MEMORY_FOUND') {
-            kairosMintSimilarMemoryFound.inc({ transport: 'mcp', tenant_id: tenantId });
-            const d = err.details || {};
-            const body = {
-              error: 'SIMILAR_MEMORY_FOUND',
-              existing_memory: d.existing_memory,
-              similarity_score: d.similarity_score,
-              message: d.message ?? 'A very similar memory already exists. Verify it before overwriting.',
-              must_obey: d.must_obey ?? true,
-              next_action: d.next_action,
-              ...(d.content_preview !== undefined && { content_preview: d.content_preview })
-            };
-            result = {
-              isError: true,
-              content: [{ type: 'text', text: JSON.stringify(body) }]
-            } as any;
-            mcpToolCalls.inc({ 
-              tool: toolName, 
-              status: 'error',
-              tenant_id: tenantId 
-            });
-            mcpToolErrors.inc({ 
-              tool: toolName, 
-              status: 'error',
-              tenant_id: tenantId 
-            });
-            timer({ 
-              tool: toolName, 
-              status: 'error',
-              tenant_id: tenantId 
-            });
-            return result;
-          }
-          logger.error(`[kairos_mint] Failed to store memory chain space_id=${resolvedSpaceId} (len=${markdown_doc?.length || 0}, model=${llm_model_id})`, error);
-          result = {
+        if (err?.code === 'DUPLICATE_CHAIN' || err?.code === 'DUPLICATE_KEY') {
+          mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+          mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+          timer({ tool: toolName, status: 'error', tenant_id: tenantId });
+          return {
             isError: true,
-            content: [{ type: 'text', text: JSON.stringify({ error: 'STORE_FAILED', message: err?.message || String(err) }) }]
-          } as any;
-          mcpToolCalls.inc({ 
-            tool: toolName, 
-            status: 'error',
-            tenant_id: tenantId 
-          });
-          mcpToolErrors.inc({ 
-            tool: toolName, 
-            status: 'error',
-            tenant_id: tenantId 
-          });
-          timer({ 
-            tool: toolName, 
-            status: 'error',
-            tenant_id: tenantId 
-          });
-          return result;
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'DUPLICATE_CHAIN', ...(err.details || {}) }) }]
+          };
         }
-        const output = {
-          items: memories.map(memory => ({
-            uri: `kairos://mem/${memory.memory_uuid}`,
-            memory_uuid: memory.memory_uuid,
-            label: memory.label,
-            tags: memory.tags
-          })),
-          status: 'stored'
+        if (err?.code === 'SIMILAR_MEMORY_FOUND') {
+          kairosMintSimilarMemoryFound.inc({ transport: 'mcp', tenant_id: tenantId });
+          const d = err.details || {};
+          mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+          mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+          timer({ tool: toolName, status: 'error', tenant_id: tenantId });
+          return {
+            isError: true,
+            content: [{ type: 'text' as const, text: JSON.stringify({
+              error: 'SIMILAR_MEMORY_FOUND',
+              existing_memory: (d as any).existing_memory,
+              similarity_score: (d as any).similarity_score,
+              message: (d as any).message ?? 'A very similar memory already exists. Verify it before overwriting.',
+              must_obey: (d as any).must_obey ?? true,
+              next_action: (d as any).next_action,
+              ...((d as any).content_preview !== undefined && { content_preview: (d as any).content_preview })
+            }) }]
+          };
+        }
+        logger.error(`[kairos_mint] Failed to store memory chain space_id=${resolvedSpaceId}`, error);
+        mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        timer({ tool: toolName, status: 'error', tenant_id: tenantId });
+        return {
+          isError: true,
+          content: [{ type: 'text' as const, text: JSON.stringify({ error: 'STORE_FAILED', message: err?.message ?? String(error) }) }]
         };
-        result = {
-          content: [{ type: 'text', text: JSON.stringify(output) }],
-          structuredContent: output
-        };
-        
-        // Track success
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        
-        // Track output size
-        const outputSize = JSON.stringify(result).length;
-        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, outputSize);
-        
-        timer({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        
-        return result;
-      } catch (error) {
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        mcpToolErrors.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        timer({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        throw error;
       }
     }
   );

--- a/src/tools/kairos_mint_schema.ts
+++ b/src/tools/kairos_mint_schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+const memoryUriSchema = z
+  .string()
+  .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
+
+export const mintInputSchema = z.object({
+  markdown_doc: z.string().min(1).describe('Markdown document to store'),
+  llm_model_id: z.string().min(1).describe('LLM model ID'),
+  force_update: z.boolean().optional().default(false).describe('Overwrite existing memory chain with the same label'),
+  protocol_version: z.string().optional().describe('Protocol version (e.g. semver). Overrides or supplies version when document has no frontmatter.'),
+  space: z.union([z.literal('personal'), z.string()]).optional().describe('Target space: "personal" (default) or group name to mint into that group space')
+});
+
+export const mintOutputSchema = z.object({
+  items: z.array(z.object({
+    uri: memoryUriSchema,
+    memory_uuid: z.string(),
+    label: z.string(),
+    tags: z.array(z.string())
+  })),
+  status: z.literal('stored')
+});
+
+export type MintInput = z.infer<typeof mintInputSchema>;
+export type MintOutput = z.infer<typeof mintOutputSchema>;

--- a/src/tools/kairos_next.ts
+++ b/src/tools/kairos_next.ts
@@ -1,5 +1,9 @@
 import type { MemoryQdrantStore } from '../services/memory/store.js';
+import { z } from 'zod';
 import { kairosNextInputSchema, kairosNextOutputSchema } from './kairos_next_schema.js';
+
+export type NextInput = z.infer<typeof kairosNextInputSchema>;
+export type NextOutput = z.infer<typeof kairosNextOutputSchema>;
 import type { QdrantService } from '../services/qdrant/service.js';
 import { structuredLogger } from '../utils/structured-logger.js';
 import { resolveChainNextStep, resolveChainPreviousStep } from '../services/chain-utils.js';
@@ -125,6 +129,163 @@ export async function updateStepQuality(
   }
 }
 
+/** Build payload when solution is missing (MISSING_FIELD). Shared by MCP and HTTP. */
+export async function buildMissingSolutionPayload(
+  memoryStore: MemoryQdrantStore,
+  uri: string
+): Promise<NextOutput> {
+  const { uuid, uri: requestedUri } = normalizeMemoryUri(uri);
+  const retryCount = await proofOfWorkStore.incrementRetry(uuid);
+  const noSolChallenge = await buildChallenge(null, undefined);
+  return {
+    must_obey: retryCount < 3,
+    current_step: buildCurrentStep(null, requestedUri),
+    challenge: noSolChallenge,
+    message: 'Solution is required for steps 2+. Use kairos_begin for step 1.',
+    next_action: `retry kairos_next with ${requestedUri} -- include solution matching challenge`,
+    error_code: 'MISSING_FIELD',
+    retry_count: retryCount
+  };
+}
+
+export type TryElicitResult = { payload: NextOutput } | { solution: ProofOfWorkSubmission };
+
+/**
+ * Shared execute: submit solution and return next step/challenge. Used by MCP tool and HTTP route.
+ * When tryElicit is provided (MCP), user_input elicitation may return a payload or adjusted solution.
+ */
+export async function executeNext(
+  memoryStore: MemoryQdrantStore,
+  qdrantService: QdrantService | undefined,
+  input: NextInput,
+  tenantId: string,
+  options?: { tryElicit?: (memory: Memory, solution: ProofOfWorkSubmission, requestedUri: string) => Promise<TryElicitResult> }
+): Promise<NextOutput> {
+  const { uri, solution } = input;
+  const { uuid, uri: requestedUri } = normalizeMemoryUri(uri);
+  const memory = await loadMemoryWithCache(memoryStore, uuid);
+
+  let solutionToUse = solution;
+  if (memory && options?.tryElicit) {
+    const elicitResult = await options.tryElicit(memory, solution as ProofOfWorkSubmission, requestedUri);
+    if ('payload' in elicitResult) return elicitResult.payload;
+    solutionToUse = elicitResult.solution;
+  }
+
+  let submissionOutcome: HandleProofResult | undefined;
+  if (memory) {
+    if (!memory.proof_of_work && solutionToUse) {
+      const prevResult = await tryApplySolutionToPreviousStep(
+        memory,
+        solutionToUse as ProofOfWorkSubmission,
+        (id) => loadMemoryWithCache(memoryStore, id),
+        qdrantService
+      );
+      if (prevResult.applied) {
+        if (prevResult.outcome.blockedPayload) {
+          if (qdrantService) await updateStepQuality(qdrantService, prevResult.prevMemory, 'failure', tenantId);
+          return prevResult.outcome.blockedPayload as NextOutput;
+        }
+        const previousBlock = await ensurePreviousProofCompleted(
+          memory,
+          (id) => loadMemoryWithCache(memoryStore, id),
+          qdrantService
+        );
+        if (!previousBlock && qdrantService && !prevResult.outcome.alreadyRecorded) {
+          await updateStepQuality(qdrantService, prevResult.prevMemory, 'success', tenantId);
+        }
+        if (!previousBlock) {
+          const nextFromRequested = await resolveChainNextStep(memory, qdrantService);
+          const nextStepUri = nextFromRequested?.uuid ? `kairos://mem/${nextFromRequested.uuid}` : null;
+          const output = (await buildKairosNextPayload(memory, requestedUri, nextStepUri, undefined)) as NextOutput;
+          if (prevResult.outcome.proofHash) output.proof_hash = prevResult.outcome.proofHash;
+          return output;
+        }
+      }
+    }
+
+    if (memory.proof_of_work && solutionToUse) {
+      const prevResultWhenMatch = await tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious(
+        memory,
+        solutionToUse as ProofOfWorkSubmission,
+        (id) => loadMemoryWithCache(memoryStore, id),
+        qdrantService
+      );
+      if (prevResultWhenMatch.applied) {
+        if (prevResultWhenMatch.outcome.blockedPayload) {
+          if (qdrantService) await updateStepQuality(qdrantService, prevResultWhenMatch.prevMemory, 'failure', tenantId);
+          return prevResultWhenMatch.outcome.blockedPayload as NextOutput;
+        }
+        if (qdrantService && !prevResultWhenMatch.outcome.alreadyRecorded) {
+          await updateStepQuality(qdrantService, prevResultWhenMatch.prevMemory, 'success', tenantId);
+        }
+        const nextFromRequested = await resolveChainNextStep(memory, qdrantService);
+        const nextStepUri = nextFromRequested?.uuid ? `kairos://mem/${nextFromRequested.uuid}` : null;
+        const nextMemory = nextFromRequested ? await loadMemoryWithCache(memoryStore, nextFromRequested.uuid) : null;
+        const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
+        const output = (await buildKairosNextPayload(memory, requestedUri, nextStepUri, challengeProof)) as NextOutput;
+        if (prevResultWhenMatch.outcome.proofHash) output.proof_hash = prevResultWhenMatch.outcome.proofHash;
+        return output;
+      }
+    }
+
+    const isStep1 = !memory.chain || memory.chain.step_index <= 1;
+    let expectedPreviousHash: string;
+    if (isStep1) {
+      expectedPreviousHash = GENESIS_HASH;
+    } else {
+      const prev = await resolveChainPreviousStep(memory, qdrantService);
+      const prevHash = prev?.uuid ? await proofOfWorkStore.getProofHash(prev.uuid) : null;
+      expectedPreviousHash = prevHash ?? GENESIS_HASH;
+    }
+    submissionOutcome = await handleProofSubmission(solutionToUse as ProofOfWorkSubmission, memory, { expectedPreviousHash });
+    if (submissionOutcome.blockedPayload) {
+      if (qdrantService) await updateStepQuality(qdrantService, memory, 'failure', tenantId);
+      return submissionOutcome.blockedPayload as NextOutput;
+    }
+
+    const previousBlock = await ensurePreviousProofCompleted(
+      memory,
+      (id) => loadMemoryWithCache(memoryStore, id),
+      qdrantService
+    );
+    if (previousBlock) {
+      if (qdrantService) await updateStepQuality(qdrantService, memory, 'failure', tenantId);
+      const payload = await buildMissingProofPayload(
+        memory,
+        previousBlock,
+        requestedUri,
+        uuid,
+        (id) => loadMemoryWithCache(memoryStore, id),
+        qdrantService
+      );
+      return {
+        must_obey: payload.retry_count < 3,
+        current_step: payload.current_step,
+        challenge: payload.challenge,
+        message: previousBlock.message,
+        next_action: payload.next_action,
+        error_code: previousBlock.error_code || 'MISSING_PROOF',
+        retry_count: payload.retry_count
+      };
+    }
+    if (qdrantService && !submissionOutcome.alreadyRecorded) {
+      await updateStepQuality(qdrantService, memory, 'success', tenantId);
+    }
+  }
+
+  const nextStepInfo = memory ? await resolveChainNextStep(memory, qdrantService) : undefined;
+  const nextMemory = nextStepInfo ? await loadMemoryWithCache(memoryStore, nextStepInfo.uuid) : null;
+  const displayMemory = nextMemory ?? memory ?? null;
+  const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
+  const displayUri = nextStepInfo ? `kairos://mem/${nextStepInfo.uuid}` : requestedUri;
+  const nextFromDisplay = displayMemory ? await resolveChainNextStep(displayMemory, qdrantService) : undefined;
+  const nextStepUri = nextFromDisplay?.uuid ? `kairos://mem/${nextFromDisplay.uuid}` : null;
+  const output = (await buildKairosNextPayload(displayMemory, displayUri, nextStepUri, challengeProof)) as NextOutput;
+  if (submissionOutcome?.proofHash) output.proof_hash = submissionOutcome.proofHash;
+  return output;
+}
+
 export function registerKairosNextTool(server: any, memoryStore: MemoryQdrantStore, options: RegisterNextOptions = {}) {
   const toolName = options.toolName || 'kairos_next';
   structuredLogger.debug(`kairos_next registration inputSchema: ${JSON.stringify(kairosNextInputSchema)}`);
@@ -137,211 +298,34 @@ export function registerKairosNextTool(server: any, memoryStore: MemoryQdrantSto
       inputSchema: kairosNextInputSchema,
       outputSchema: kairosNextOutputSchema
     },
-    async (params: any) => {
+    async (params: unknown) => {
       const tenantId = getTenantId();
       const spaceId = getSpaceContextFromStorage()?.defaultWriteSpaceId ?? 'default';
       structuredLogger.debug(`kairos_next space_id=${spaceId}`);
-      const inputSize = JSON.stringify(params).length;
-      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, inputSize);
-      
-      const timer = mcpToolDuration.startTimer({ 
-        tool: toolName,
-        tenant_id: tenantId 
-      });
-      const respond = (payload: any) => {
-        const structured = {
-          content: [{
-            type: 'text', text: JSON.stringify(payload)
-          }],
+      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(params).length);
+      const timer = mcpToolDuration.startTimer({ tool: toolName, tenant_id: tenantId });
+      const respond = (payload: NextOutput) => {
+        mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
+        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(payload).length);
+        timer({ tool: toolName, status: 'success', tenant_id: tenantId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
           structuredContent: payload
         };
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        const outputSize = JSON.stringify(structured).length;
-        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, outputSize);
-        timer({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        return structured;
       };
       try {
-        const { uri, solution } = params as { uri: string; solution: ProofOfWorkSubmission };
-        const { uuid, uri: requestedUri } = normalizeMemoryUri(uri);
-
-        // Validate solution is provided
-        if (!solution) {
-          const retryCount = await proofOfWorkStore.incrementRetry(uuid);
-          const noSolChallenge = await buildChallenge(null, undefined);
-          return respond({
-            must_obey: retryCount < 3,
-            current_step: buildCurrentStep(null, requestedUri),
-            challenge: noSolChallenge,
-            message: 'Solution is required for steps 2+. Use kairos_begin for step 1.',
-            next_action: `retry kairos_next with ${requestedUri} -- include solution matching challenge`,
-            error_code: 'MISSING_FIELD',
-            retry_count: retryCount
-          });
+        const input = kairosNextInputSchema.parse(params);
+        if (!input.solution) {
+          return respond(await buildMissingSolutionPayload(memoryStore, input.uri));
         }
-
-        const memory = await loadMemoryWithCache(memoryStore, uuid);
-
-        let solutionToUse = solution;
-        if (memory) {
-          const elicitResult = await tryUserInputElicitation(server, memory, solution, requestedUri, buildCurrentStep);
-          if ('payload' in elicitResult) return respond(elicitResult.payload);
-          solutionToUse = elicitResult.solution;
-        }
-
-        let submissionOutcome: HandleProofResult | undefined;
-        if (memory) {
-          if (!memory.proof_of_work && solutionToUse) {
-            const prevResult = await tryApplySolutionToPreviousStep(
-              memory,
-              solutionToUse,
-              (id) => loadMemoryWithCache(memoryStore, id),
-              options.qdrantService
-            );
-            if (prevResult.applied) {
-              if (prevResult.outcome.blockedPayload) {
-                if (options.qdrantService) {
-                  await updateStepQuality(options.qdrantService, prevResult.prevMemory, 'failure', tenantId);
-                }
-                return respond(prevResult.outcome.blockedPayload);
-              }
-              const previousBlock = await ensurePreviousProofCompleted(
-                memory,
-                (id) => loadMemoryWithCache(memoryStore, id),
-                options.qdrantService
-              );
-              if (!previousBlock && options.qdrantService && !prevResult.outcome.alreadyRecorded) {
-                await updateStepQuality(options.qdrantService, prevResult.prevMemory, 'success', tenantId);
-              }
-              if (!previousBlock) {
-                const nextFromRequested = await resolveChainNextStep(memory, options.qdrantService);
-                const nextStepUri = nextFromRequested?.uuid
-                  ? `kairos://mem/${nextFromRequested.uuid}`
-                  : null;
-                const output = await buildKairosNextPayload(memory, requestedUri, nextStepUri, undefined);
-                if (prevResult.outcome.proofHash) output.proof_hash = prevResult.outcome.proofHash;
-                return respond(output);
-              }
-            }
-          }
-
-          if (memory.proof_of_work && solutionToUse) {
-            const prevResultWhenMatch = await tryApplySolutionToPreviousStepWhenSolutionMatchesPrevious(
-              memory,
-              solutionToUse,
-              (id) => loadMemoryWithCache(memoryStore, id),
-              options.qdrantService
-            );
-            if (prevResultWhenMatch.applied) {
-              if (prevResultWhenMatch.outcome.blockedPayload) {
-                if (options.qdrantService) {
-                  await updateStepQuality(options.qdrantService, prevResultWhenMatch.prevMemory, 'failure', tenantId);
-                }
-                return respond(prevResultWhenMatch.outcome.blockedPayload);
-              }
-              if (options.qdrantService && !prevResultWhenMatch.outcome.alreadyRecorded) {
-                await updateStepQuality(options.qdrantService, prevResultWhenMatch.prevMemory, 'success', tenantId);
-              }
-              const nextFromRequested = await resolveChainNextStep(memory, options.qdrantService);
-              const nextStepUri = nextFromRequested?.uuid
-                ? `kairos://mem/${nextFromRequested.uuid}`
-                : null;
-              const nextMemory = nextFromRequested ? await loadMemoryWithCache(memoryStore, nextFromRequested.uuid) : null;
-              const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
-              const output = await buildKairosNextPayload(memory, requestedUri, nextStepUri, challengeProof);
-              if (prevResultWhenMatch.outcome.proofHash) output.proof_hash = prevResultWhenMatch.outcome.proofHash;
-              return respond(output);
-            }
-          }
-
-          const isStep1 = !memory.chain || memory.chain.step_index <= 1;
-          let expectedPreviousHash: string;
-          if (isStep1) {
-            expectedPreviousHash = GENESIS_HASH;
-          } else {
-            const prev = await resolveChainPreviousStep(memory, options.qdrantService);
-            const prevHash = prev?.uuid ? await proofOfWorkStore.getProofHash(prev.uuid) : null;
-            expectedPreviousHash = prevHash ?? GENESIS_HASH;
-          }
-          submissionOutcome = await handleProofSubmission(solutionToUse, memory, { expectedPreviousHash });
-          if (submissionOutcome.blockedPayload) {
-            if (options.qdrantService) {
-              await updateStepQuality(options.qdrantService, memory, 'failure', tenantId);
-            }
-            return respond(submissionOutcome.blockedPayload);
-          }
-
-          const previousBlock = await ensurePreviousProofCompleted(
-            memory,
-            (id) => loadMemoryWithCache(memoryStore, id),
-            options.qdrantService
-          );
-          if (previousBlock) {
-            if (options.qdrantService) {
-              await updateStepQuality(options.qdrantService, memory, 'failure', tenantId);
-            }
-            const payload = await buildMissingProofPayload(
-              memory,
-              previousBlock,
-              requestedUri,
-              uuid,
-              (id) => loadMemoryWithCache(memoryStore, id),
-              options.qdrantService
-            );
-            return respond({
-              must_obey: payload.retry_count < 3,
-              current_step: payload.current_step,
-              challenge: payload.challenge,
-              message: previousBlock.message,
-              next_action: payload.next_action,
-              error_code: previousBlock.error_code || 'MISSING_PROOF',
-              retry_count: payload.retry_count
-            });
-          }
-          if (options.qdrantService && !submissionOutcome.alreadyRecorded) {
-            await updateStepQuality(options.qdrantService, memory, 'success', tenantId);
-          }
-        }
-        // Resolve next step
-        const nextStepInfo = memory ? await resolveChainNextStep(memory, options.qdrantService) : undefined;
-        const nextMemory = nextStepInfo ? await loadMemoryWithCache(memoryStore, nextStepInfo.uuid) : null;
-        const displayMemory = nextMemory ?? memory;
-        const challengeProof = nextMemory?.proof_of_work ?? memory?.proof_of_work;
-        const displayUri = nextStepInfo ? `kairos://mem/${nextStepInfo.uuid}` : requestedUri;
-        // Resolve the step AFTER the display step to get next_action URI
-        const nextFromDisplay = displayMemory ? await resolveChainNextStep(displayMemory, options.qdrantService) : undefined;
-        const nextStepUri = nextFromDisplay?.uuid
-          ? `kairos://mem/${nextFromDisplay.uuid}`
-          : null;
-        const output = await buildKairosNextPayload(displayMemory, displayUri, nextStepUri, challengeProof);
-        if (submissionOutcome?.proofHash) {
-          output.proof_hash = submissionOutcome.proofHash;
-        }
+        const tryElicit = (memory: Memory, solution: ProofOfWorkSubmission, requestedUri: string) =>
+          tryUserInputElicitation(server, memory, solution, requestedUri, buildCurrentStep);
+        const output = await executeNext(memoryStore, options.qdrantService, input, tenantId, { tryElicit });
         return respond(output);
       } catch (error) {
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        mcpToolErrors.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        timer({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
+        mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        timer({ tool: toolName, status: 'error', tenant_id: tenantId });
         throw error;
       }
     }

--- a/src/tools/kairos_next_schema.ts
+++ b/src/tools/kairos_next_schema.ts
@@ -10,7 +10,7 @@ const memoryUriSchema = z
   .string()
   .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
 
-const solutionSchema = z.object({
+export const solutionSchema = z.object({
   type: z.enum(['shell', 'mcp', 'user_input', 'comment']).describe('Must match challenge.type'),
   nonce: z.string().optional().describe('Echo nonce from challenge'),
   proof_hash: z.string().optional().describe('Echo proof_hash from previous challenge or response'),
@@ -86,4 +86,5 @@ export const kairosNextOutputSchema = z.object({
   retry_count: z.number().optional().describe('Number of retries on this step (present on error responses)')
 });
 
+export type SolutionSubmission = z.infer<typeof solutionSchema>;
 export { memoryUriSchema };

--- a/src/tools/kairos_search.ts
+++ b/src/tools/kairos_search.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import type { MemoryQdrantStore } from '../services/memory/store.js';
 import type { QdrantService } from '../services/qdrant/service.js';
 import { structuredLogger } from '../utils/structured-logger.js';
@@ -15,6 +14,7 @@ import {
   KAIROS_ENABLE_GROUP_COLLAPSE
 } from '../config.js';
 import { createResults, generateUnifiedOutput } from './kairos_search_output.js';
+import { searchInputSchema, searchOutputSchema, type SearchInput, type SearchOutput } from './kairos_search_schema.js';
 
 const CREATION_PROTOCOL_UUID = '00000000-0000-0000-0000-000000002001';
 const CREATION_PROTOCOL_URI = `kairos://mem/${CREATION_PROTOCOL_UUID}`;
@@ -85,6 +85,69 @@ async function searchAndBuildCandidates(
   return candidateMap;
 }
 
+/** Core search: build candidates and return unified output. Used by executeSearch. */
+async function doSearch(
+  memoryStore: MemoryQdrantStore,
+  qdrantService: QdrantService | undefined,
+  searchQuery: string,
+  effectiveLimit: number
+): Promise<SearchOutput> {
+  const normalizedQuery = searchQuery.toLowerCase();
+  const candidateMap = await searchAndBuildCandidates(
+    memoryStore,
+    searchQuery,
+    normalizedQuery,
+    KAIROS_ENABLE_GROUP_COLLAPSE,
+    effectiveLimit
+  );
+  let headCandidates = Array.from(candidateMap.values()).sort((a, b) => b.score - a.score);
+  if (headCandidates.length > effectiveLimit) {
+    headCandidates = headCandidates.slice(0, effectiveLimit);
+  }
+  const results = headCandidates.length > 0 ? createResults(headCandidates, SCORE_THRESHOLD) : [];
+  return generateUnifiedOutput(results, qdrantService, {
+    refiningUri: REFINING_PROTOCOL_URI,
+    refiningNextAction: REFINING_NEXT_ACTION,
+    createUri: CREATION_PROTOCOL_URI,
+    createNextAction: CREATE_NEXT_ACTION
+  });
+}
+
+/**
+ * Shared execute: search for protocol chains. Used by MCP tool and HTTP route.
+ * When runInSpace is provided and input has space/space_id, the search runs in that space context.
+ */
+export async function executeSearch(
+  memoryStore: MemoryQdrantStore,
+  qdrantService: QdrantService | undefined,
+  input: SearchInput,
+  options?: { runInSpace?: (fn: () => Promise<SearchOutput>) => Promise<SearchOutput> }
+): Promise<SearchOutput> {
+  const { query, space, space_id, max_choices } = input;
+  const effectiveLimit = Math.max(
+    KAIROS_SEARCH_LIMIT_MIN,
+    Math.min(KAIROS_SEARCH_LIMIT_CAP, max_choices ?? KAIROS_SEARCH_MAX_CHOICES)
+  );
+  const searchQuery = queryForSearch(query);
+  const normalizedQuery = searchQuery.toLowerCase();
+  const cacheKey = `begin:v3:${normalizedQuery}:${KAIROS_ENABLE_GROUP_COLLAPSE}:${effectiveLimit}`;
+
+  const cachedResult = await redisCacheService.get(cacheKey);
+  if (cachedResult) {
+    return searchOutputSchema.parse(JSON.parse(cachedResult)) as SearchOutput;
+  }
+
+  const run = () => doSearch(memoryStore, qdrantService, searchQuery, effectiveLimit);
+  const spaceParam = space ?? space_id;
+  const result =
+    options?.runInSpace && spaceParam != null
+      ? await options.runInSpace(run)
+      : await run();
+
+  await redisCacheService.set(cacheKey, JSON.stringify(result), 300);
+  return result;
+}
+
 /**
  * Register kairos_search tool
  * 
@@ -93,155 +156,63 @@ async function searchAndBuildCandidates(
  */
 export function registerSearchTool(server: any, memoryStore: MemoryQdrantStore, options: RegisterSearchOptions = {}) {
   const toolName = options.toolName || 'kairos_search';
-  const memoryUriSchema = z
-    .string()
-    .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
-  const choiceUriSchema = memoryUriSchema;
+  const qdrantService = options.qdrantService;
 
-  const inputSchema = z.object({
-    query: z.string().min(1).describe('Search query for chain heads'),
-    space: z.string().optional().describe('Scope results to this space (must be in your allowed spaces)'),
-    space_id: z.string().optional().describe('Alias for space'),
-    max_choices: z
-      .number()
-      .int()
-      .min(KAIROS_SEARCH_LIMIT_MIN)
-      .max(KAIROS_SEARCH_LIMIT_CAP)
-      .optional()
-      .describe('Max match choices to return. Omit for server default; use higher for broad/vague queries.')
-  });
-
-  const outputSchema = z.object({
-    must_obey: z.boolean().describe('Always true. Follow next_action.'),
-    message: z.string().describe('Human-readable summary'),
-    next_action: z.string().describe("Global directive: pick one choice and follow that choice's next_action."),
-    choices: z.array(z.object({
-      uri: choiceUriSchema,
-      label: z.string(),
-      chain_label: z.string().nullable(),
-      score: z.number().nullable().describe('0.0-1.0 for matches, null for refine/create'),
-      role: z.enum(['match', 'refine', 'create']).describe('match = search result, refine = search again, create = system action'),
-      tags: z.array(z.string()),
-      next_action: z.string().describe('Instruction for this choice: call kairos_begin with this choice\'s uri.'),
-      protocol_version: z.string().nullable().describe('Stored protocol version (e.g. semver) for match choices; null for refine/create. Compare with skill-bundled protocol to decide if re-mint is needed.')
-    })).describe('Options: match(es) first, then refine (if present), then create (if present).')
-  });
-
-  structuredLogger.debug(`kairos_search registration inputSchema: ${JSON.stringify(inputSchema)}`);
-  structuredLogger.debug(`kairos_search registration outputSchema: ${JSON.stringify(outputSchema)}`);
+  structuredLogger.debug(`kairos_search registration inputSchema: ${JSON.stringify(searchInputSchema)}`);
+  structuredLogger.debug(`kairos_search registration outputSchema: ${JSON.stringify(searchOutputSchema)}`);
   server.registerTool(
     toolName,
     {
       title: 'Search for protocol chains',
       description: getToolDoc('kairos_search') || 'Search for protocol chains matching the query. Always returns must_obey: true with a choices array. Follow next_action.',
-      inputSchema,
-      outputSchema
+      inputSchema: searchInputSchema,
+      outputSchema: searchOutputSchema
     },
-    async (params: any) => {
+    async (params: unknown) => {
       const tenantId = getTenantId();
-      const { query, space, space_id, max_choices } = params as {
-        query: string;
-        space?: string;
-        space_id?: string;
-        max_choices?: number;
-      };
-      const spaceParam = space ?? space_id;
-      const effectiveLimit = Math.max(
-        KAIROS_SEARCH_LIMIT_MIN,
-        Math.min(KAIROS_SEARCH_LIMIT_CAP, max_choices ?? KAIROS_SEARCH_MAX_CHOICES)
-      );
-      const inputSize = JSON.stringify({ query }).length;
-      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, inputSize);
+      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(params).length);
+      const timer = mcpToolDuration.startTimer({ tool: toolName, tenant_id: tenantId });
 
-      const timer = mcpToolDuration.startTimer({
-        tool: toolName,
-        tenant_id: tenantId
-      });
-      const respond = (payload: any) => {
-        const structured = {
-          content: [{
-            type: 'text', text: JSON.stringify(payload)
-          }],
+      const respond = (payload: SearchOutput) => {
+        mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
+        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(payload).length);
+        timer({ tool: toolName, status: 'success', tenant_id: tenantId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
           structuredContent: payload
         };
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        const outputSize = JSON.stringify(structured).length;
-        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, outputSize);
-        timer({ 
-          tool: toolName, 
-          status: 'success',
-          tenant_id: tenantId 
-        });
-        return structured;
       };
+
       try {
-        return runWithOptionalSpaceAsync(spaceParam, async () => {
-          const searchQuery = queryForSearch(query || '');
-          const normalizedQuery = searchQuery.toLowerCase();
-          const cacheKey = `begin:v3:${normalizedQuery}:${KAIROS_ENABLE_GROUP_COLLAPSE}:${effectiveLimit}`;
-
-          const cachedResult = await redisCacheService.get(cacheKey);
-          if (cachedResult) {
-            const parsed = JSON.parse(cachedResult);
-            return respond(parsed);
-          }
-
-          const candidateMap = await searchAndBuildCandidates(
-            memoryStore,
-            searchQuery,
-            normalizedQuery,
-            KAIROS_ENABLE_GROUP_COLLAPSE,
-            effectiveLimit
-          );
-
-          let headCandidates = Array.from(candidateMap.values()).sort((a, b) => (b.score - a.score));
-          if (headCandidates.length > effectiveLimit) {
-            headCandidates = headCandidates.slice(0, effectiveLimit);
-          }
-
-          const results = headCandidates.length > 0 ? createResults(headCandidates, SCORE_THRESHOLD) : [];
-          const output = await generateUnifiedOutput(results, options.qdrantService, {
-            refiningUri: REFINING_PROTOCOL_URI,
-            refiningNextAction: REFINING_NEXT_ACTION,
-            createUri: CREATION_PROTOCOL_URI,
-            createNextAction: CREATE_NEXT_ACTION
-          });
-
-          await redisCacheService.set(cacheKey, JSON.stringify(output), 300);
-          return respond(output);
-        });
+        const input = searchInputSchema.parse(params);
+        const spaceParam = input.space ?? input.space_id;
+        const runInSpace =
+          spaceParam != null
+            ? (fn: () => Promise<SearchOutput>) => runWithOptionalSpaceAsync(spaceParam, fn)
+            : undefined;
+        const output = await executeSearch(
+          memoryStore,
+          qdrantService,
+          input,
+          runInSpace != null ? { runInSpace } : undefined
+        );
+        return respond(output);
       } catch (error) {
         if (error instanceof Error && error.message === 'Requested space is not in your allowed spaces') {
           mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
           mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
           timer({ tool: toolName, status: 'error', tenant_id: tenantId });
           return {
-            content: [{ type: 'text', text: JSON.stringify({ error: 'forbidden', message: error.message }) }],
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'forbidden', message: error.message }) }],
             isError: true
           };
         }
         const ctxErr = getSpaceContextFromStorage();
         structuredLogger.warn(`kairos_search error (returning empty results) space_id=${ctxErr?.defaultWriteSpaceId ?? 'default'}: ${error instanceof Error ? error.message : String(error)}`);
-        mcpToolCalls.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        mcpToolErrors.inc({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        timer({ 
-          tool: toolName, 
-          status: 'error',
-          tenant_id: tenantId 
-        });
-        const fallback = await generateUnifiedOutput([], options.qdrantService, {
+        mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        timer({ tool: toolName, status: 'error', tenant_id: tenantId });
+        const fallback = await generateUnifiedOutput([], qdrantService, {
           refiningUri: REFINING_PROTOCOL_URI,
           refiningNextAction: REFINING_NEXT_ACTION,
           createUri: CREATION_PROTOCOL_URI,

--- a/src/tools/kairos_search_schema.ts
+++ b/src/tools/kairos_search_schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { KAIROS_SEARCH_LIMIT_CAP, KAIROS_SEARCH_LIMIT_MIN } from '../config.js';
+
+const memoryUriSchema = z
+  .string()
+  .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
+
+const choiceUriSchema = memoryUriSchema;
+
+export const searchInputSchema = z.object({
+  query: z.string().min(1).describe('Search query for chain heads'),
+  space: z.string().optional().describe('Scope results to this space (must be in your allowed spaces)'),
+  space_id: z.string().optional().describe('Alias for space'),
+  max_choices: z
+    .number()
+    .int()
+    .min(KAIROS_SEARCH_LIMIT_MIN)
+    .max(KAIROS_SEARCH_LIMIT_CAP)
+    .optional()
+    .describe('Max match choices to return. Omit for server default; use higher for broad/vague queries.')
+});
+
+export const searchOutputSchema = z.object({
+  must_obey: z.boolean().describe('Always true. Follow next_action.'),
+  message: z.string().describe('Human-readable summary'),
+  next_action: z.string().describe("Global directive: pick one choice and follow that choice's next_action."),
+  choices: z.array(z.object({
+    uri: choiceUriSchema,
+    label: z.string(),
+    chain_label: z.string().nullable(),
+    score: z.number().nullable().describe('0.0-1.0 for matches, null for refine/create'),
+    role: z.enum(['match', 'refine', 'create']).describe('match = search result, refine = search again, create = system action'),
+    tags: z.array(z.string()),
+    next_action: z.string().describe("Instruction for this choice: call kairos_begin with this choice's uri."),
+    protocol_version: z.string().nullable().describe('Stored protocol version (e.g. semver) for match choices; null for refine/create. Compare with skill-bundled protocol to decide if re-mint is needed.')
+  })).describe('Options: match(es) first, then refine (if present), then create (if present).')
+}).strict();
+
+export type SearchInput = z.infer<typeof searchInputSchema>;
+export type SearchOutput = z.infer<typeof searchOutputSchema>;

--- a/src/tools/kairos_spaces.ts
+++ b/src/tools/kairos_spaces.ts
@@ -3,7 +3,6 @@
  * chain counts per space, and optionally chain titles and step counts.
  */
 
-import { z } from 'zod';
 import type { MemoryQdrantStore } from '../services/memory/store.js';
 import { getToolDoc } from '../resources/embedded-mcp-resources.js';
 import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
@@ -12,6 +11,7 @@ import { buildSpaceFilter } from '../utils/space-filter.js';
 import { spaceIdToDisplayName } from '../utils/space-display.js';
 import { KAIROS_APP_SPACE_ID } from '../config.js';
 import { structuredLogger } from '../utils/structured-logger.js';
+import { spacesInputSchema, spacesOutputSchema } from './kairos_spaces_schema.js';
 
 const SPACES_TOOL_NAME = 'kairos_spaces';
 const SCROLL_LIMIT = 2000;
@@ -125,24 +125,8 @@ export interface RegisterKairosSpacesOptions {
 
 export function registerKairosSpacesTool(server: any, memoryStore: MemoryQdrantStore, options: RegisterKairosSpacesOptions = {}): void {
   const toolName = options.toolName ?? SPACES_TOOL_NAME;
-
-  const inputSchema = z.object({
-    include_chain_titles: z.boolean().optional().default(false).describe('If true, include for each space a list of chains with title and step_count')
-  });
-
-  const chainInfoSchema = z.object({
-    chain_id: z.string(),
-    title: z.string(),
-    step_count: z.number()
-  });
-  const spaceInfoSchema = z.object({
-    name: z.string(),
-    chain_count: z.number(),
-    chains: z.array(chainInfoSchema).optional()
-  });
-  const outputSchema = z.object({
-    spaces: z.array(spaceInfoSchema)
-  });
+  const inputSchema = spacesInputSchema;
+  const outputSchema = spacesOutputSchema;
 
   server.registerTool(
     toolName,

--- a/src/tools/kairos_spaces_schema.ts
+++ b/src/tools/kairos_spaces_schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const spacesInputSchema = z.object({
+  include_chain_titles: z.boolean().optional().default(false).describe('If true, include for each space a list of chains with title and step_count')
+});
+
+const chainInfoSchema = z.object({
+  chain_id: z.string(),
+  title: z.string(),
+  step_count: z.number()
+});
+
+const spaceInfoSchema = z.object({
+  name: z.string(),
+  chain_count: z.number(),
+  chains: z.array(chainInfoSchema).optional()
+});
+
+export const spacesOutputSchema = z.object({
+  spaces: z.array(spaceInfoSchema)
+}).strict();
+
+export type SpacesInput = z.infer<typeof spacesInputSchema>;
+export type SpacesOutput = z.infer<typeof spacesOutputSchema>;

--- a/src/tools/kairos_update.ts
+++ b/src/tools/kairos_update.ts
@@ -1,162 +1,11 @@
-import { z } from 'zod';
+import type { QdrantService } from '../services/qdrant/service.js';
 import { qdrantService as qdrantServiceSingleton } from '../services/qdrant/index.js';
 import { getToolDoc } from '../resources/embedded-mcp-resources.js';
 import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
 import { getTenantId } from '../utils/tenant-context.js';
+import { updateInputSchema, updateOutputSchema, type UpdateInput, type UpdateOutput } from './kairos_update_schema.js';
 
-// Removed legacy registerUpdateTool (no backward compatibility)
-
-// Simple KAIROS update tool focused on cache correctness
-export function registerKairosUpdateTool(server: any, toolName = 'kairos_update') {
-    const qdrantService = qdrantServiceSingleton;
-    const memoryUriSchema = z
-        .string()
-        .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
-    server.registerTool(
-        toolName,
-        {
-            title: 'Update KAIROS Memory(s)',
-            description: getToolDoc('kairos_update'),
-            inputSchema: z.object({
-                uris: z.array(memoryUriSchema).nonempty().describe('Non-empty array of kairos://mem/{uuid} URIs to update'),
-                markdown_doc: z.array(z.string().min(1)).optional().describe('Array of Markdown BODY or full KAIROS render; BODY will be extracted and stored for each URI'),
-                updates: z.record(z.string(), z.any()).optional().describe('Advanced field updates; prefer markdown_doc for content changes')
-            }),
-            outputSchema: z.object({
-                results: z.array(z.object({
-                    uri: memoryUriSchema,
-                    status: z.enum(['updated', 'error']),
-                    message: z.string()
-                })),
-                total_updated: z.number(),
-                total_failed: z.number()
-            })
-        },
-        async (params: any) => {
-            const tenantId = getTenantId();
-            const inputSize = JSON.stringify(params).length;
-            mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, inputSize);
-            
-            const timer = mcpToolDuration.startTimer({ 
-              tool: toolName,
-              tenant_id: tenantId 
-            });
-            
-            let result: any;
-            
-            try {
-                const uris = params?.uris;
-                const markdownDoc: string[] | undefined = params.markdown_doc;
-                const updates: Record<string, any> | undefined = params.updates;
-
-                if (!Array.isArray(uris) || uris.length === 0) {
-                    throw new Error('uris must be a non-empty array of strings');
-                }
-
-            const results: any[] = [];
-            let totalUpdated = 0;
-            let totalFailed = 0;
-
-            if (markdownDoc && markdownDoc.length !== uris.length) {
-                throw new Error('markdown_doc array length must match uris array length');
-            }
-
-            for (let i = 0; i < uris.length; i++) {
-                const uri = uris[i];
-                try {
-                    // Extract UUID from URI
-                    const uuid = typeof uri === 'string' ? uri.split('/').pop() : undefined;
-                    if (!uuid) {
-                        throw new Error('Invalid URI format');
-                    }
-
-                    // Prefer markdown_doc path: extract BODY if markers present
-                    const mk = Array.isArray(markdownDoc) ? markdownDoc[i] : undefined;
-                    if (typeof mk === 'string' && mk.trim().length > 0) {
-                        const body = extractBody(mk);
-                        await qdrantService.updateMemory(uuid, { text: body });
-                    } else if (updates && Object.keys(updates).length > 0) {
-                        // Back-compat path: if updates.text seems to contain a full KAIROS HTML render
-                        // (<!-- KAIROS:BODY-START --> markers), extract the BODY and apply it as a plain 'text' update.
-                        if (typeof updates['text'] === 'string' && updates['text'].indexOf('<!-- KAIROS:BODY-START') !== -1 && updates['text'].indexOf('<!-- KAIROS:BODY-END') !== -1) {
-                            const body = extractBody(updates['text']);
-                            // Only update the 'text' field to ensure header/footer are untouched
-                            await qdrantService.updateMemory(uuid, { text: body });
-                        } else {
-                            // If no KB markers found, forward raw updates as-is (back-compat behavior)
-                            await qdrantService.updateMemory(uuid, updates);
-                        }
-                    } else {
-                        throw new Error('Provide markdown_doc or updates');
-                    }
-
-                    results.push({
-                        uri,
-                        status: 'updated' as const,
-                        message: `Memory ${uri} updated successfully`
-                    });
-                    totalUpdated++;
-                } catch (error) {
-                    const errorMessage = error instanceof Error ? error.message : String(error);
-                    results.push({
-                        uri,
-                        status: 'error' as const,
-                        message: `Failed to update memory: ${errorMessage}`
-                    });
-                    totalFailed++;
-                }
-            }
-
-            result = {
-                results,
-                total_updated: totalUpdated,
-                total_failed: totalFailed
-            };
-
-            const finalResult = {
-                content: [{ type: 'text', text: JSON.stringify(result) }],
-                structuredContent: result
-            };
-            
-            mcpToolCalls.inc({ 
-              tool: toolName, 
-              status: 'success',
-              tenant_id: tenantId 
-            });
-            
-            const outputSize = JSON.stringify(finalResult).length;
-            mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, outputSize);
-            
-            timer({ 
-              tool: toolName, 
-              status: 'success',
-              tenant_id: tenantId 
-            });
-            
-            return finalResult;
-            } catch (error) {
-                mcpToolCalls.inc({ 
-                  tool: toolName, 
-                  status: 'error',
-                  tenant_id: tenantId 
-                });
-                mcpToolErrors.inc({ 
-                  tool: toolName, 
-                  status: 'error',
-                  tenant_id: tenantId 
-                });
-                timer({ 
-                  tool: toolName, 
-                  status: 'error',
-                  tenant_id: tenantId 
-                });
-                throw error;
-            }
-        }
-    );
-}
-
-// Extract BODY from a full KAIROS render if present; otherwise return input as-is
+/** Extract BODY from a full KAIROS render if present; otherwise return input as-is */
 function extractBody(text: string): string {
     const start = /<!--\s*KAIROS:BODY-START\s*-->/i;
     const end = /<!--\s*KAIROS:BODY-END\s*-->/i;
@@ -170,4 +19,96 @@ function extractBody(text: string): string {
         return text.slice(startIdx, e).trim();
     }
     return text;
+}
+
+/** Shared execute: update memories by URIs. Used by MCP tool and HTTP route. */
+export async function executeUpdate(
+  qdrantService: QdrantService,
+  input: UpdateInput
+): Promise<UpdateOutput> {
+  const { uris, markdown_doc: markdownDoc, updates } = input;
+  if (markdownDoc && markdownDoc.length !== uris.length) {
+    throw new Error('markdown_doc array length must match uris array length');
+  }
+  const results: UpdateOutput['results'] = [];
+  let totalUpdated = 0;
+  let totalFailed = 0;
+
+  for (let i = 0; i < uris.length; i++) {
+    const uri = uris[i]!;
+    try {
+      const uuid = typeof uri === 'string' ? uri.split('/').pop() : undefined;
+      if (!uuid) {
+        throw new Error('Invalid URI format');
+      }
+      const mk = Array.isArray(markdownDoc) ? markdownDoc[i] : undefined;
+      if (typeof mk === 'string' && mk.trim().length > 0) {
+        const body = extractBody(mk);
+        await qdrantService.updateMemory(uuid, { text: body });
+      } else if (updates && Object.keys(updates).length > 0) {
+        if (typeof updates['text'] === 'string' && updates['text'].indexOf('<!-- KAIROS:BODY-START') !== -1 && updates['text'].indexOf('<!-- KAIROS:BODY-END') !== -1) {
+          const body = extractBody(updates['text']);
+          await qdrantService.updateMemory(uuid, { text: body });
+        } else {
+          await qdrantService.updateMemory(uuid, updates);
+        }
+      } else {
+        throw new Error('Provide markdown_doc or updates');
+      }
+      results.push({
+        uri,
+        status: 'updated',
+        message: `Memory ${uri} updated successfully`
+      });
+      totalUpdated++;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      results.push({
+        uri,
+        status: 'error',
+        message: `Failed to update memory: ${errorMessage}`
+      });
+      totalFailed++;
+    }
+  }
+
+  return {
+    results,
+    total_updated: totalUpdated,
+    total_failed: totalFailed
+  };
+}
+
+export function registerKairosUpdateTool(server: any, toolName = 'kairos_update') {
+  const qdrantService = qdrantServiceSingleton;
+  server.registerTool(
+    toolName,
+    {
+      title: 'Update KAIROS Memory(s)',
+      description: getToolDoc('kairos_update'),
+      inputSchema: updateInputSchema,
+      outputSchema: updateOutputSchema
+    },
+    async (params: unknown) => {
+      const tenantId = getTenantId();
+      mcpToolInputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(params).length);
+      const timer = mcpToolDuration.startTimer({ tool: toolName, tenant_id: tenantId });
+      try {
+        const input = updateInputSchema.parse(params);
+        const result = await executeUpdate(qdrantService, input);
+        mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
+        mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(result).length);
+        timer({ tool: toolName, status: 'success', tenant_id: tenantId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+          structuredContent: result
+        };
+      } catch (error) {
+        mcpToolCalls.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        mcpToolErrors.inc({ tool: toolName, status: 'error', tenant_id: tenantId });
+        timer({ tool: toolName, status: 'error', tenant_id: tenantId });
+        throw error;
+      }
+    }
+  );
 }

--- a/src/tools/kairos_update_schema.ts
+++ b/src/tools/kairos_update_schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+const memoryUriSchema = z
+  .string()
+  .regex(/^kairos:\/\/mem\/[0-9a-f-]{36}$/i, 'must match kairos://mem/{uuid}');
+
+export const updateInputSchema = z.object({
+  uris: z.array(memoryUriSchema).nonempty().describe('Non-empty array of kairos://mem/{uuid} URIs to update'),
+  markdown_doc: z.array(z.string().min(1)).optional().describe('Array of Markdown BODY or full KAIROS render; BODY will be extracted and stored for each URI'),
+  updates: z.record(z.string(), z.any()).optional().describe('Advanced field updates; prefer markdown_doc for content changes')
+});
+
+export const updateOutputSchema = z.object({
+  results: z.array(z.object({
+    uri: memoryUriSchema,
+    status: z.enum(['updated', 'error']),
+    message: z.string()
+  })),
+  total_updated: z.number(),
+  total_failed: z.number()
+});
+
+export type UpdateInput = z.infer<typeof updateInputSchema>;
+export type UpdateOutput = z.infer<typeof updateOutputSchema>;

--- a/src/ui/components/run/RunGuidedContent.tsx
+++ b/src/ui/components/run/RunGuidedContent.tsx
@@ -60,11 +60,17 @@ export function RunGuidedContent({
           {t("run.currentStep")}
         </h2>
         <div className="rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-4">
-          <div className="text-sm text-[var(--color-text-muted)] mb-2">
-            {t("run.stepUri")}: <span className="font-mono break-all">{run.current_step.uri}</span>
-          </div>
-          {run.current_step.content ? (
-            <RenderedMarkdown content={run.current_step.content} />
+          {run.current_step ? (
+            <>
+              <div className="text-sm text-[var(--color-text-muted)] mb-2">
+                {t("run.stepUri")}: <span className="font-mono break-all">{run.current_step.uri}</span>
+              </div>
+              {run.current_step.content ? (
+                <RenderedMarkdown content={run.current_step.content} />
+              ) : (
+                <p className="text-sm text-[var(--color-text-muted)] m-0">{t("run.noStepContent")}</p>
+              )}
+            </>
           ) : (
             <p className="text-sm text-[var(--color-text-muted)] m-0">{t("run.noStepContent")}</p>
           )}

--- a/src/ui/hooks/useKairosAttest.ts
+++ b/src/ui/hooks/useKairosAttest.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
-import type { KairosAttestResponse } from "@/lib/kairosRunTypes";
+import type { AttestOutput } from "../../tools/kairos_attest_schema.js";
 
 export type KairosAttestInput = {
   uri: string;
@@ -8,7 +8,7 @@ export type KairosAttestInput = {
   message: string;
 };
 
-async function kairosAttest(input: KairosAttestInput): Promise<KairosAttestResponse> {
+async function kairosAttest(input: KairosAttestInput): Promise<AttestOutput> {
   const res = await apiFetch("/api/kairos_attest", {
     method: "POST",
     body: JSON.stringify(input),

--- a/src/ui/hooks/useKairosBegin.ts
+++ b/src/ui/hooks/useKairosBegin.ts
@@ -1,8 +1,8 @@
 import { useMutation } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
-import type { KairosBeginResponse } from "@/lib/kairosRunTypes";
+import type { BeginOutput } from "../../tools/kairos_begin.js";
 
-async function kairosBegin(uri: string): Promise<KairosBeginResponse> {
+async function kairosBegin(uri: string): Promise<BeginOutput> {
   const res = await apiFetch("/api/kairos_begin", {
     method: "POST",
     body: JSON.stringify({ uri }),

--- a/src/ui/hooks/useKairosNext.ts
+++ b/src/ui/hooks/useKairosNext.ts
@@ -1,13 +1,14 @@
 import { useMutation } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
-import type { KairosNextResponse, ProofOfWorkSubmission } from "@/lib/kairosRunTypes";
+import type { NextOutput } from "../../tools/kairos_next.js";
+import type { SolutionSubmission } from "../../tools/kairos_next_schema.js";
 
 export type KairosNextInput = {
   uri: string;
-  solution: ProofOfWorkSubmission;
+  solution: SolutionSubmission;
 };
 
-async function kairosNext(input: KairosNextInput): Promise<KairosNextResponse> {
+async function kairosNext(input: KairosNextInput): Promise<NextOutput> {
   const res = await apiFetch("/api/kairos_next", {
     method: "POST",
     body: JSON.stringify(input),

--- a/src/ui/hooks/useProtocol.ts
+++ b/src/ui/hooks/useProtocol.ts
@@ -1,15 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
+import type { DumpOutput } from "../../tools/kairos_dump_schema.js";
 
-export interface ProtocolDump {
-  markdown_doc: string;
-  uri: string;
-  label: string;
-  chain_label: string | null;
-  step_count?: number;
-}
-
-async function fetchProtocol(uri: string): Promise<ProtocolDump> {
+async function fetchProtocol(uri: string): Promise<DumpOutput> {
   const res = await apiFetch("/api/kairos_dump", {
     method: "POST",
     body: JSON.stringify({ uri, protocol: true }),

--- a/src/ui/hooks/useRunSession.ts
+++ b/src/ui/hooks/useRunSession.ts
@@ -17,7 +17,8 @@ export type RunSession = {
   started_at: string;
   updated_at: string;
   status: "running" | "ready_to_attest" | "completed" | "error";
-  current_step: KairosStep;
+  /** May be null when response has no current_step (schema allows optional/nullable). */
+  current_step: KairosStep | null;
   challenge: Challenge;
   next_action?: string;
   last_message?: string;

--- a/src/ui/hooks/useSearch.ts
+++ b/src/ui/hooks/useSearch.ts
@@ -1,24 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
+import type { SearchOutput } from "../../tools/kairos_search_schema.js";
 
-export interface SearchChoice {
-  uri: string;
-  label: string;
-  chain_label: string | null;
-  score: number | null;
-  role: "match" | "refine" | "create";
-  tags: string[];
-  next_action: string;
-  protocol_version?: string | null;
-}
-
-export interface SearchResult {
-  choices: SearchChoice[];
-  message?: string;
-  next_action?: string;
-}
-
-async function searchProtocols(query: string): Promise<SearchResult> {
+async function searchProtocols(query: string): Promise<SearchOutput> {
   const res = await apiFetch("/api/kairos_search", {
     method: "POST",
     body: JSON.stringify({ query: query.trim() }),

--- a/src/ui/lib/kairosRunTypes.ts
+++ b/src/ui/lib/kairosRunTypes.ts
@@ -1,83 +1,15 @@
-export type ProofOfWorkType = "shell" | "mcp" | "user_input" | "comment";
+/**
+ * Re-exports from canonical tool schemas. Do not define local types here.
+ */
+import type { BeginOutput } from "../../tools/kairos_begin.js";
+import type { NextOutput } from "../../tools/kairos_next.js";
+import type { AttestOutput } from "../../tools/kairos_attest_schema.js";
+import type { SolutionSubmission } from "../../tools/kairos_next_schema.js";
 
-export type Challenge = {
-  type: ProofOfWorkType;
-  description?: string;
-  nonce?: string;
-  proof_hash?: string;
-  shell?: {
-    cmd?: string;
-    timeout_seconds?: number;
-  };
-  mcp?: {
-    tool_name?: string;
-    expected_result?: unknown;
-  };
-  user_input?: {
-    prompt?: string;
-  };
-  comment?: {
-    min_length?: number;
-  };
-};
+export type { BeginOutput, NextOutput, AttestOutput, SolutionSubmission };
 
-export type ProofOfWorkSubmission = {
-  type: ProofOfWorkType;
-  nonce?: string;
-  proof_hash?: string;
-  /** @deprecated v1 compat only; avoid using in new clients. */
-  previousProofHash?: string;
-  shell?: {
-    exit_code: number;
-    stdout?: string;
-    stderr?: string;
-    duration_seconds?: number;
-  };
-  mcp?: {
-    tool_name: string;
-    arguments?: unknown;
-    result: unknown;
-    success: boolean;
-  };
-  user_input?: {
-    confirmation: string;
-    timestamp?: string;
-  };
-  comment?: {
-    text: string;
-  };
-};
-
-export type KairosStep = {
-  uri: string;
-  content: string;
-  mimeType: string;
-};
-
-export type KairosBeginResponse = {
-  must_obey: boolean;
-  current_step: KairosStep;
-  challenge: Challenge;
-  message?: string;
-  next_action?: string;
-  error_code?: string;
-  retry_count?: number;
-  proof_hash?: string;
-  metadata?: unknown;
-};
-
-export type KairosNextResponse = KairosBeginResponse;
-
-export type KairosAttestResponse = {
-  results: Array<{
-    uri: string;
-    outcome: "success" | "failure";
-    quality_bonus: number;
-    message: string;
-    rated_at: string;
-  }>;
-  total_rated: number;
-  total_failed: number;
-  metadata?: unknown;
-};
-
+export type Challenge = BeginOutput["challenge"];
+export type KairosStep = NonNullable<BeginOutput["current_step"]>;
+/** Alias for SolutionSubmission (canonical type from kairos_next_schema). */
+export type ProofOfWorkSubmission = SolutionSubmission;
+export type ProofOfWorkType = Challenge["type"];

--- a/src/ui/pages/RunGuidedPage.tsx
+++ b/src/ui/pages/RunGuidedPage.tsx
@@ -66,7 +66,7 @@ export function RunGuidedPage() {
         started_at: startedAt,
         updated_at: startedAt,
         status,
-        current_step: res.current_step,
+        current_step: res.current_step ?? null,
         challenge: res.challenge,
         next_action: res.next_action,
         last_message: res.message,
@@ -91,7 +91,7 @@ export function RunGuidedPage() {
   };
 
   const handleSubmitStep = async (draft: Omit<ProofOfWorkSubmission, "nonce" | "proof_hash" | "previousProofHash">) => {
-    if (!run) return;
+    if (!run?.current_step) return;
     const nonce = run.challenge.nonce;
     const proofHash = run.previous_proof_hash ?? run.challenge.proof_hash;
     const solution: ProofOfWorkSubmission = {
@@ -101,7 +101,7 @@ export function RunGuidedPage() {
     };
 
     try {
-      const res = await next.mutateAsync({ uri: run.current_step.uri, solution });
+      const res = await next.mutateAsync({ uri: run.current_step!.uri, solution });
       const updatedAt = nowIso();
       const readyToAttest = res.next_action?.includes("kairos_attest") || (res.message?.toLowerCase().includes("call kairos_attest") ?? false);
       const attestUri = extractFirstMemUri(res.next_action) ?? run.attest_uri;
@@ -109,7 +109,7 @@ export function RunGuidedPage() {
         ...run,
         updated_at: updatedAt,
         status: readyToAttest ? "ready_to_attest" : "running",
-        current_step: res.current_step,
+        current_step: res.current_step ?? null,
         challenge: res.challenge,
         next_action: res.next_action,
         last_message: res.message,
@@ -118,7 +118,7 @@ export function RunGuidedPage() {
         history: [
           ...run.history,
           {
-            step: run.current_step,
+            step: run.current_step!,
             challenge: run.challenge,
             solution,
             submitted_at: updatedAt,
@@ -139,7 +139,8 @@ export function RunGuidedPage() {
 
   const handleAttest = async () => {
     if (!run) return;
-    const attestUri = run.attest_uri ?? run.current_step.uri;
+    const attestUri = run.attest_uri ?? run.current_step?.uri;
+    if (!attestUri) return;
     try {
       const res = await attest.mutateAsync({
         uri: attestUri,

--- a/tests/integration/api-error-paths.test.ts
+++ b/tests/integration/api-error-paths.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Error-path tests: missing required fields, invalid types, non-existent URIs.
+ * Asserts consistent error shape and status codes between MCP and HTTP.
+ */
+
+import { createMcpConnection } from '../utils/mcp-client-utils.js';
+import { getAuthHeaders, getTestAuthBaseUrl } from '../utils/auth-headers.js';
+import { parseMcpJson } from '../utils/expect-with-raw.js';
+
+const BASE_URL = getTestAuthBaseUrl().replace(/\/$/, '');
+const API_BASE = `${BASE_URL}/api`;
+
+function httpFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(path, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...(init.headers as Record<string, string>) }
+  });
+}
+
+describe('API error paths: consistent handling across MCP and HTTP', () => {
+  let mcpConnection: { client: { callTool: (arg: { name: string; arguments?: Record<string, unknown> }) => Promise<unknown> }; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    mcpConnection = await createMcpConnection();
+  }, 60000);
+
+  afterAll(async () => {
+    if (mcpConnection) await mcpConnection.close();
+  });
+
+  describe('kairos_search', () => {
+    test('HTTP rejects empty query with 400 and INVALID_INPUT', async () => {
+      expect.hasAssertions();
+      const res = await httpFetch(`${API_BASE}/kairos_search`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '' })
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as Record<string, unknown>;
+      expect(data.error).toBe('INVALID_INPUT');
+      expect(data.message).toBeDefined();
+    });
+
+    test('MCP empty query returns error or fallback', async () => {
+      expect.hasAssertions();
+      const result = await mcpConnection.client.callTool({
+        name: 'kairos_search',
+        arguments: { query: '' }
+      });
+      const r = result as { isError?: boolean; content?: Array<{ type: string; text?: string }> };
+      if (r.isError) {
+        expect(r.content).toBeDefined();
+        return;
+      }
+      try {
+        const parsed = parseMcpJson(result, 'kairos_search empty query');
+        expect(parsed).toBeDefined();
+      } catch {
+        expect(r.content?.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('kairos_dump', () => {
+    test('HTTP rejects missing uri with 400', async () => {
+      expect.hasAssertions();
+      const res = await httpFetch(`${API_BASE}/kairos_dump`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as Record<string, unknown>;
+      expect(data.error).toBe('INVALID_INPUT');
+    });
+
+    test('HTTP returns 404 for non-existent URI', async () => {
+      expect.hasAssertions();
+      const res = await httpFetch(`${API_BASE}/kairos_dump`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uri: 'kairos://mem/00000000-0000-0000-0000-000000000000' })
+      });
+      expect(res.status).toBe(404);
+      const data = (await res.json()) as Record<string, unknown>;
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe('kairos_attest', () => {
+    test('HTTP rejects invalid outcome enum with 400', async () => {
+      expect.hasAssertions();
+      const res = await httpFetch(`${API_BASE}/kairos_attest`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          uri: 'kairos://mem/00000000-0000-0000-0000-000000000000',
+          outcome: 'invalid',
+          message: 'test'
+        })
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as Record<string, unknown>;
+      expect(data.error).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('kairos_delete', () => {
+    test('HTTP rejects empty uris array with 400', async () => {
+      expect.hasAssertions();
+      const res = await httpFetch(`${API_BASE}/kairos_delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uris: [] })
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as Record<string, unknown>;
+      expect(data.error).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('kairos_next', () => {
+    test('HTTP rejects missing uri with 400', async () => {
+      expect.hasAssertions();
+      const res = await httpFetch(`${API_BASE}/kairos_next`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+      expect(res.status).toBe(400);
+      const data = (await res.json()) as Record<string, unknown>;
+      expect(data.error).toBe('INVALID_INPUT');
+    });
+  });
+});

--- a/tests/integration/api-mcp-parity.test.ts
+++ b/tests/integration/api-mcp-parity.test.ts
@@ -1,0 +1,188 @@
+/**
+ * API-MCP parity tests: same operation via MCP and HTTP must return identical response shapes.
+ * No stripping of metadata; if HTTP adds fields (e.g. metadata) that MCP does not have, tests fail.
+ * Schema conformance: MCP and HTTP responses must parse against the canonical Zod output schemas.
+ */
+
+import { createMcpConnection } from '../utils/mcp-client-utils.js';
+import { getAuthHeaders, getTestAuthBaseUrl } from '../utils/auth-headers.js';
+import { parseMcpJson } from '../utils/expect-with-raw.js';
+import { spacesOutputSchema } from '../../src/tools/kairos_spaces_schema.js';
+import { searchOutputSchema } from '../../src/tools/kairos_search_schema.js';
+import { dumpOutputSchema } from '../../src/tools/kairos_dump_schema.js';
+import { deleteOutputSchema } from '../../src/tools/kairos_delete_schema.js';
+
+const BASE_URL = getTestAuthBaseUrl().replace(/\/$/, '');
+const API_BASE = `${BASE_URL}/api`;
+
+function httpFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(path, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...(init.headers as Record<string, string>) }
+  });
+}
+
+function sortedKeys(obj: Record<string, unknown>): string[] {
+  return Object.keys(obj).sort();
+}
+
+describe('API-MCP parity: identical response shapes', () => {
+  let mcpConnection: { client: { callTool: (arg: { name: string; arguments: Record<string, unknown> }) => Promise<unknown> }; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    mcpConnection = await createMcpConnection();
+  }, 60000);
+
+  afterAll(async () => {
+    if (mcpConnection) await mcpConnection.close();
+  });
+
+  describe('kairos_spaces', () => {
+    test('MCP and HTTP responses have identical key sets', async () => {
+      expect.hasAssertions();
+
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_spaces',
+        arguments: { include_chain_titles: false }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_spaces MCP');
+
+      const httpRes = await httpFetch(`${API_BASE}/kairos_spaces`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ include_chain_titles: false })
+      });
+      expect(httpRes.ok).toBe(true);
+      const httpParsed = (await httpRes.json()) as Record<string, unknown>;
+
+      expect(sortedKeys(mcpParsed)).toEqual(sortedKeys(httpParsed));
+    });
+  });
+
+  describe('kairos_search', () => {
+    test('MCP and HTTP responses have identical key sets', async () => {
+      expect.hasAssertions();
+
+      const query = `ParityTest ${Date.now()}`;
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_search',
+        arguments: { query }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_search MCP');
+
+      const httpRes = await httpFetch(`${API_BASE}/kairos_search`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+      });
+      expect(httpRes.ok).toBe(true);
+      const httpParsed = (await httpRes.json()) as Record<string, unknown>;
+
+      expect(sortedKeys(mcpParsed)).toEqual(sortedKeys(httpParsed));
+    });
+  });
+
+  describe('kairos_dump', () => {
+    test('MCP and HTTP responses have identical key sets for same URI', async () => {
+      expect.hasAssertions();
+
+      const uri = 'kairos://mem/00000000-0000-0000-0000-000000002001';
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_dump',
+        arguments: { uri, protocol: false }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_dump MCP');
+
+      const httpRes = await httpFetch(`${API_BASE}/kairos_dump`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uri, protocol: false })
+      });
+      expect(httpRes.ok).toBe(true);
+      const httpParsed = (await httpRes.json()) as Record<string, unknown>;
+
+      expect(sortedKeys(mcpParsed)).toEqual(sortedKeys(httpParsed));
+    });
+  });
+
+  describe('kairos_delete', () => {
+    test('MCP and HTTP responses have identical key sets', async () => {
+      expect.hasAssertions();
+
+      const uris = ['kairos://mem/00000000-0000-0000-0000-000000000000'];
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_delete',
+        arguments: { uris }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_delete MCP');
+
+      const httpRes = await httpFetch(`${API_BASE}/kairos_delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uris })
+      });
+      expect(httpRes.ok).toBe(true);
+      const httpParsed = (await httpRes.json()) as Record<string, unknown>;
+
+      expect(sortedKeys(mcpParsed)).toEqual(sortedKeys(httpParsed));
+    });
+  });
+
+  describe('Schema conformance: outputSchema.parse(response)', () => {
+    test('kairos_spaces: MCP response parses against spacesOutputSchema', async () => {
+      expect.hasAssertions();
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_spaces',
+        arguments: { include_chain_titles: false }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_spaces MCP');
+      const parsed = spacesOutputSchema.safeParse(mcpParsed);
+      expect(parsed.success).toBe(true);
+    });
+
+    test('kairos_spaces: HTTP response parses against spacesOutputSchema', async () => {
+      expect.hasAssertions();
+      const httpRes = await httpFetch(`${API_BASE}/kairos_spaces`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+      const httpParsed = (await httpRes.json()) as Record<string, unknown>;
+      const parsed = spacesOutputSchema.safeParse(httpParsed);
+      expect(parsed.success).toBe(true);
+    });
+
+    test('kairos_search: MCP response parses against searchOutputSchema', async () => {
+      expect.hasAssertions();
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_search',
+        arguments: { query: 'SchemaConformance' }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_search MCP');
+      const parsed = searchOutputSchema.safeParse(mcpParsed);
+      expect(parsed.success).toBe(true);
+    });
+
+    test('kairos_dump: MCP response parses against dumpOutputSchema', async () => {
+      expect.hasAssertions();
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_dump',
+        arguments: { uri: 'kairos://mem/00000000-0000-0000-0000-000000002001', protocol: false }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_dump MCP');
+      const parsed = dumpOutputSchema.safeParse(mcpParsed);
+      expect(parsed.success).toBe(true);
+    });
+
+    test('kairos_delete: MCP response parses against deleteOutputSchema', async () => {
+      expect.hasAssertions();
+      const mcpResult = await mcpConnection.client.callTool({
+        name: 'kairos_delete',
+        arguments: { uris: ['kairos://mem/00000000-0000-0000-0000-000000000000'] }
+      });
+      const mcpParsed = parseMcpJson(mcpResult, 'kairos_delete MCP');
+      const parsed = deleteOutputSchema.safeParse(mcpParsed);
+      expect(parsed.success).toBe(true);
+    });
+  });
+});

--- a/tests/integration/cli-commands-advanced.test.ts
+++ b/tests/integration/cli-commands-advanced.test.ts
@@ -6,34 +6,24 @@
 import { execAsync, BASE_URL, CLI_PATH, TEST_FILE, setupServerCheck } from './cli-commands-shared.js';
 
 describe('CLI Commands Advanced --url Tests', () => {
-  let serverAvailable = false;
-  let cachedMintedUri: string | null = null;
+  let cachedMintedUri: string;
 
   beforeAll(async () => {
-    serverAvailable = await setupServerCheck();
-    // Mint once and cache the URI for all tests to reuse
-    if (serverAvailable) {
-      const mintResult = await execAsync(
-        `node ${CLI_PATH} mint --url ${BASE_URL} --force "${TEST_FILE}"`
-      );
-      const mintData = JSON.parse(mintResult.stdout);
-      if (mintData.items && mintData.items.length > 0) {
-        cachedMintedUri = mintData.items[0].uri;
-      }
+    await setupServerCheck();
+    const mintResult = await execAsync(
+      `node ${CLI_PATH} mint --url ${BASE_URL} --force "${TEST_FILE}"`
+    );
+    const mintData = JSON.parse(mintResult.stdout);
+    if (!mintData.items || mintData.items.length === 0) {
+      throw new Error('Mint did not return items; cannot run advanced CLI tests');
     }
+    cachedMintedUri = mintData.items[0].uri;
   }, 60000);
-
-  async function getMintedUri(): Promise<string | null> {
-    // Return cached URI to avoid expensive mint operations
-    return cachedMintedUri;
-  }
 
   describe('next command', () => {
     test('next uses --url parameter', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       // CLI next requires solution for steps 2+, and --output json for JSON format
       // Note: Minted URI is typically step 1, so kairos_next will be blocked
@@ -58,10 +48,8 @@ describe('CLI Commands Advanced --url Tests', () => {
     }, 30000);
 
     test('next uses -u short form', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       // CLI next requires solution for steps 2+, and --output json for JSON format
       // Note: Minted URI is typically step 1, so kairos_next will be blocked
@@ -86,10 +74,8 @@ describe('CLI Commands Advanced --url Tests', () => {
     }, 30000);
 
     test('next with --url and --solution', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const solution = JSON.stringify({
         type: 'comment',
@@ -114,10 +100,8 @@ describe('CLI Commands Advanced --url Tests', () => {
 
   describe('update command', () => {
     test('update uses --url parameter', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} update --url ${BASE_URL} --file "${TEST_FILE}" "${uri}"`
@@ -129,10 +113,8 @@ describe('CLI Commands Advanced --url Tests', () => {
     }, 30000);
 
     test('update uses -u short form', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} update -u ${BASE_URL} --file "${TEST_FILE}" "${uri}"`
@@ -146,10 +128,8 @@ describe('CLI Commands Advanced --url Tests', () => {
 
   describe('attest command', () => {
     test('attest uses --url parameter', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} attest --url ${BASE_URL} "${uri}" success "Test attestation"`
@@ -161,10 +141,8 @@ describe('CLI Commands Advanced --url Tests', () => {
     }, 30000);
 
     test('attest uses -u short form', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} attest -u ${BASE_URL} "${uri}" success "Test attestation"`
@@ -176,10 +154,8 @@ describe('CLI Commands Advanced --url Tests', () => {
     }, 30000);
 
     test('attest with --url and --quality-bonus', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} attest --url ${BASE_URL} "${uri}" success "Test" --quality-bonus 5`
@@ -191,10 +167,8 @@ describe('CLI Commands Advanced --url Tests', () => {
     }, 30000);
 
     test('attest with --url and --model', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} attest --url ${BASE_URL} "${uri}" success "Test" --model "test-model"`
@@ -208,10 +182,8 @@ describe('CLI Commands Advanced --url Tests', () => {
 
   describe('delete command', () => {
     test('delete uses --url parameter', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} delete --url ${BASE_URL} "${uri}"`
@@ -223,10 +195,8 @@ describe('CLI Commands Advanced --url Tests', () => {
     }, 30000);
 
     test('delete uses -u short form', async () => {
-      if (!serverAvailable) return;
-
-      const uri = await getMintedUri();
-      if (!uri) return;
+      expect.hasAssertions();
+      const uri = cachedMintedUri;
 
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} delete -u ${BASE_URL} "${uri}"`

--- a/tests/integration/cli-commands-basic.test.ts
+++ b/tests/integration/cli-commands-basic.test.ts
@@ -6,36 +6,29 @@
 import { execAsync, BASE_URL, CLI_PATH, TEST_FILE, setupServerCheck } from './cli-commands-shared.js';
 
 describe('CLI Commands Basic --url Tests', () => {
-  let serverAvailable = false;
   let cachedSearchUri: string | null = null;
 
   beforeAll(async () => {
-    serverAvailable = await setupServerCheck();
-    // Mint test protocol then get a URI from search (no longer rely on built-in mem docs)
-    if (serverAvailable) {
-      try {
-        await execAsync(
-          `node ${CLI_PATH} mint --url ${BASE_URL} --force "${TEST_FILE}"`
-        );
-        const searchResult = await execAsync(
-          `node ${CLI_PATH} search --url ${BASE_URL} "Minimal CLI Test Document"`
-        );
-        const searchData = JSON.parse(searchResult.stdout);
-        // V2: extract URI from choices array (first match)
-        const matchChoice = Array.isArray(searchData.choices)
-          ? searchData.choices.find((c: any) => c.role === 'match')
-          : null;
-        cachedSearchUri = matchChoice?.uri || null;
-      } catch {
-        cachedSearchUri = null;
-      }
+    await setupServerCheck();
+    await execAsync(
+      `node ${CLI_PATH} mint --url ${BASE_URL} --force "${TEST_FILE}"`
+    );
+    const searchResult = await execAsync(
+      `node ${CLI_PATH} search --url ${BASE_URL} "Minimal CLI Test Document"`
+    );
+    const searchData = JSON.parse(searchResult.stdout);
+    const matchChoice = Array.isArray(searchData.choices)
+      ? searchData.choices.find((c: { role: string }) => c.role === 'match')
+      : null;
+    cachedSearchUri = matchChoice?.uri ?? null;
+    if (!cachedSearchUri) {
+      throw new Error('Failed to get URI from search after mint');
     }
   }, 60000);
 
   describe('search command', () => {
     test('search uses --url parameter', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} search --url ${BASE_URL} "test query"`
       );
@@ -49,8 +42,7 @@ describe('CLI Commands Basic --url Tests', () => {
     }, 30000);
 
     test('search uses -u short form', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} search -u ${BASE_URL} "test query"`
       );
@@ -66,8 +58,7 @@ describe('CLI Commands Basic --url Tests', () => {
 
   describe('begin command', () => {
     test('begin uses --url parameter with URI', async () => {
-      if (!serverAvailable || !cachedSearchUri) return;
-
+      expect.hasAssertions();
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} begin --url ${BASE_URL} "${cachedSearchUri}"`
       );
@@ -81,8 +72,7 @@ describe('CLI Commands Basic --url Tests', () => {
     }, 30000);
 
     test('begin uses -u short form with URI', async () => {
-      if (!serverAvailable || !cachedSearchUri) return;
-
+      expect.hasAssertions();
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} begin -u ${BASE_URL} "${cachedSearchUri}"`
       );
@@ -98,8 +88,7 @@ describe('CLI Commands Basic --url Tests', () => {
 
   describe('mint command', () => {
     test('mint uses --url parameter', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // Use --force to handle case where chain already exists from previous test runs
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} mint --url ${BASE_URL} --force "${TEST_FILE}"`
@@ -111,8 +100,7 @@ describe('CLI Commands Basic --url Tests', () => {
     }, 30000);
 
     test('mint uses -u short form', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // Use --force to handle case where chain already exists from previous test runs
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} mint -u ${BASE_URL} --force "${TEST_FILE}"`
@@ -124,8 +112,7 @@ describe('CLI Commands Basic --url Tests', () => {
     }, 30000);
 
     test('mint with --url and --force (updates existing)', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // Test that --force works on existing chain
       // Chain should already exist from previous tests, so this tests update path
       const { stdout, stderr } = await execAsync(
@@ -140,8 +127,7 @@ describe('CLI Commands Basic --url Tests', () => {
     }, 30000);
 
     test('mint with --url and --model', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // Use --force to handle case where chain already exists from previous test runs
       const { stdout, stderr } = await execAsync(
         `node ${CLI_PATH} mint --url ${BASE_URL} --force --model "test-model" "${TEST_FILE}"`

--- a/tests/integration/cli-commands-env.test.ts
+++ b/tests/integration/cli-commands-env.test.ts
@@ -6,16 +6,13 @@
 import { execAsync, BASE_URL, CLI_PATH, TEST_FILE, setupServerCheck } from './cli-commands-shared.js';
 
 describe('CLI Commands Environment & Error Tests', () => {
-  let serverAvailable = false;
-
   beforeAll(async () => {
-    serverAvailable = await setupServerCheck();
+    await setupServerCheck();
   }, 60000);
 
   describe('KAIROS_API_URL environment variable', () => {
     test('search uses KAIROS_API_URL environment variable', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       const { stdout, stderr } = await execAsync(
         `KAIROS_API_URL=${BASE_URL} node ${CLI_PATH} search "test query"`
       );
@@ -29,8 +26,7 @@ describe('CLI Commands Environment & Error Tests', () => {
     }, 30000);
 
     test('begin uses KAIROS_API_URL environment variable with URI', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // Mint test protocol then search to get a valid URI (no longer rely on built-in mem docs)
       await execAsync(
         `KAIROS_API_URL=${BASE_URL} node ${CLI_PATH} mint --force "${TEST_FILE}"`
@@ -59,8 +55,7 @@ describe('CLI Commands Environment & Error Tests', () => {
     }, 30000);
 
     test('mint uses KAIROS_API_URL environment variable', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // Use --force to handle case where chain already exists from previous test runs
       const { stdout, stderr } = await execAsync(
         `KAIROS_API_URL=${BASE_URL} node ${CLI_PATH} mint --force "${TEST_FILE}"`
@@ -72,8 +67,7 @@ describe('CLI Commands Environment & Error Tests', () => {
     }, 30000);
 
     test('--url parameter overrides KAIROS_API_URL environment variable', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // Set env var to wrong URL, but --url should override
       const { stdout, stderr } = await execAsync(
         `KAIROS_API_URL=http://wrong-url:9999 node ${CLI_PATH} search --url ${BASE_URL} "test query"`
@@ -90,16 +84,14 @@ describe('CLI Commands Environment & Error Tests', () => {
 
   describe('Error handling with --url', () => {
     test('search fails with invalid --url', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       await expect(
         execAsync(`node ${CLI_PATH} search --url http://invalid-url:9999 "test query"`)
       ).rejects.toThrow();
     }, 30000);
 
     test('begin fails with invalid --url', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       // URI can be any; we are asserting the client rejects when server URL is invalid
       await expect(
         execAsync(`node ${CLI_PATH} begin --url http://invalid-url:9999 "kairos://mem/00000000-0000-0000-0000-000000000000"`)
@@ -107,16 +99,14 @@ describe('CLI Commands Environment & Error Tests', () => {
     }, 30000);
 
     test('mint fails with invalid --url', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       await expect(
         execAsync(`node ${CLI_PATH} mint --url http://invalid-url:9999 "${TEST_FILE}"`)
       ).rejects.toThrow();
     }, 30000);
 
     test('next fails with invalid --url', async () => {
-      if (!serverAvailable) return;
-
+      expect.hasAssertions();
       const testUri = 'kairos://mem/00000000-0000-0000-0000-000000000000';
       await expect(
         execAsync(`node ${CLI_PATH} next --url http://invalid-url:9999 "${testUri}"`)

--- a/tests/integration/cli-commands-shared.ts
+++ b/tests/integration/cli-commands-shared.ts
@@ -32,19 +32,12 @@ export const CLI_PATH = join(process.cwd(), 'dist/cli/index.js');
 // Use minimal test file for CLI parameter tests (faster than full AI_CODING_RULES.md)
 export const TEST_FILE = join(process.cwd(), 'tests/test-data/cli-minimal-test.md');
 
-export async function setupServerCheck() {
-  let serverAvailable = false;
-  try {
-    await waitForHealthCheck({
-      url: `${BASE_URL}/health`,
-      timeoutMs: 60000,
-      intervalMs: 500
-    });
-    serverAvailable = true;
-  } catch (_error) {
-    serverAvailable = false;
-    console.warn('Server not available, skipping CLI tests');
-  }
-  return serverAvailable;
+/** Throws if server is not available. Call in beforeAll; do not catch. */
+export async function setupServerCheck(): Promise<void> {
+  await waitForHealthCheck({
+    url: `${BASE_URL}/health`,
+    timeoutMs: 60000,
+    intervalMs: 500
+  });
 }
 

--- a/tests/integration/http-api-dump.test.ts
+++ b/tests/integration/http-api-dump.test.ts
@@ -64,10 +64,23 @@ describe('POST /api/kairos_dump', () => {
       return;
     }
 
-    const markdown = `# Dump HTTP ${Date.now()}\n\n## Step 1\nContent for HTTP dump test.`;
+    const markdown = `# Dump HTTP ${Date.now()}
+
+## Natural Language Triggers
+When to run.
+
+## Step 1
+Content for HTTP dump test.
+
+\`\`\`json
+{"challenge": {"type": "comment", "description": "Minimal"}}
+\`\`\`
+
+## Completion Rule
+Done.`;
     const mintRes = await fetch(`${API_BASE}/kairos_mint/raw?force=true`, {
       method: 'POST',
-      headers: { 'Content-Type': 'text/markdown', ...getAuthHeaders() },
+      headers: { 'Content-Type': 'text/markdown', 'X-LLM-Model-ID': 'test-model', ...getAuthHeaders() },
       body: markdown
     });
     expect(mintRes.status).toBe(200);
@@ -88,7 +101,5 @@ describe('POST /api/kairos_dump', () => {
     expect(data.markdown_doc.length).toBeGreaterThan(0);
     expect(data).toHaveProperty('uri', uri);
     expect(data).toHaveProperty('label');
-    expect(data).toHaveProperty('metadata');
-    expect(data.metadata).toHaveProperty('duration_ms');
   }, 30000);
 });

--- a/tests/integration/http-api-endpoints.test.ts
+++ b/tests/integration/http-api-endpoints.test.ts
@@ -12,30 +12,31 @@ function apiFetch(url: string, init: RequestInit = {}): Promise<Response> {
 }
 
 describe('HTTP REST API Endpoints', () => {
-  let serverAvailable = false;
-
   beforeAll(async () => {
-    try {
-      await waitForHealthCheck({
-        url: `${BASE_URL}/health`,
-        timeoutMs: 60000,
-        intervalMs: 500
-      });
-      serverAvailable = true;
-    } catch (_error) {
-      serverAvailable = false;
-      console.warn('Server not available, skipping HTTP API tests');
-    }
+    await waitForHealthCheck({
+      url: `${BASE_URL}/health`,
+      timeoutMs: 60000,
+      intervalMs: 500
+    });
   }, 60000);
 
   describe('POST /api/kairos_mint/raw', () => {
     test('accepts raw markdown and stores memories', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
+      const markdown = `# Test Document ${Date.now()}
 
-      const markdown = `# Test Document ${Date.now()}\n\nThis is a test document for HTTP API mint endpoint.`;
+## Natural Language Triggers
+When to run this test protocol.
+
+## Step 1
+Content for HTTP API mint endpoint.
+
+\`\`\`json
+{"challenge": {"type": "comment", "description": "Minimal step"}}
+\`\`\`
+
+## Completion Rule
+Protocol is complete when this step is done.`;
       const response = await apiFetch(`${API_BASE}/kairos_mint/raw?force=true`, {
         method: 'POST',
         headers: { 'Content-Type': 'text/markdown', 'X-LLM-Model-ID': 'test-model' },
@@ -50,15 +51,10 @@ describe('HTTP REST API Endpoints', () => {
       expect(data.items.length).toBeGreaterThan(0);
       expect(data.items[0]).toHaveProperty('uri');
       expect(data.items[0].uri).toMatch(/^kairos:\/\/mem\//);
-      expect(data.metadata).toHaveProperty('count');
-      expect(data.metadata).toHaveProperty('duration_ms');
     }, 30000);
 
     test('rejects empty markdown', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_mint/raw`, {
         method: 'POST',
@@ -73,15 +69,25 @@ describe('HTTP REST API Endpoints', () => {
     });
 
     test('handles force update parameter', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
-      const markdown = `# Force Update Test ${Date.now()}\n\nTesting force update.`;
+      const markdown = `# Force Update Test ${Date.now()}
+
+## Natural Language Triggers
+When to run.
+
+## Step 1
+Testing force update.
+
+\`\`\`json
+{"challenge": {"type": "comment", "description": "Minimal"}}
+\`\`\`
+
+## Completion Rule
+Done.`;
       const response = await apiFetch(`${API_BASE}/kairos_mint/raw?force=true`, {
         method: 'POST',
-        headers: { 'Content-Type': 'text/markdown' },
+        headers: { 'Content-Type': 'text/markdown', 'X-LLM-Model-ID': 'test-model' },
         body: markdown
       });
 
@@ -93,10 +99,7 @@ describe('HTTP REST API Endpoints', () => {
 
   describe('POST /api/snapshot', () => {
     test('triggers Qdrant snapshot', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/snapshot`, { method: 'POST' });
 
@@ -111,10 +114,7 @@ describe('HTTP REST API Endpoints', () => {
 
   describe('POST /api/kairos_search', () => {
     test('searches for chain heads', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const query = `Test Query ${Date.now()}`;
       const response = await apiFetch(`${API_BASE}/kairos_search`, {
@@ -124,22 +124,23 @@ describe('HTTP REST API Endpoints', () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json();
-      // V2 unified response shape
-      expect(data).toHaveProperty('must_obey');
+      const data = (await response.json()) as Record<string, unknown>;
+      // V2 unified response shape: exact top-level keys (canonical shape; no metadata in spec)
+      const canonicalSearchKeys = ['choices', 'message', 'must_obey', 'next_action'];
+      expect(Object.keys(data).sort()).toEqual([...canonicalSearchKeys].sort());
+      expect(data.must_obey).toBe(true);
       expect(Array.isArray(data.choices)).toBe(true);
       expect(typeof data.message).toBe('string');
       expect(typeof data.next_action).toBe('string');
-      expect(Array.isArray(data.choices)).toBe(true);
-      expect(data).toHaveProperty('metadata');
-      expect(data.metadata).toHaveProperty('duration_ms');
+      // Type checks
+      expect(typeof data.must_obey).toBe('boolean');
+      if (data.metadata && typeof data.metadata === 'object' && data.metadata !== null && 'duration_ms' in data.metadata) {
+        expect(typeof (data.metadata as { duration_ms?: number }).duration_ms).toBe('number');
+      }
     }, 30000);
 
     test('rejects empty query', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_search`, {
         method: 'POST',
@@ -155,10 +156,7 @@ describe('HTTP REST API Endpoints', () => {
 
   describe('POST /api/kairos_next', () => {
     test('requires uri parameter', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_next`, {
         method: 'POST',
@@ -172,10 +170,7 @@ describe('HTTP REST API Endpoints', () => {
     });
 
     test('handles valid uri with missing solution', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       // V2: missing solution returns 200 with error payload (execution-oriented)
       const testUri = 'kairos://mem/00000000-0000-0000-0000-000000000000';
@@ -197,10 +192,7 @@ describe('HTTP REST API Endpoints', () => {
 
   describe('POST /api/kairos_attest', () => {
     test('requires all mandatory parameters', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_attest`, {
         method: 'POST',
@@ -218,10 +210,7 @@ describe('HTTP REST API Endpoints', () => {
     });
 
     test('validates outcome enum', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_attest`, {
         method: 'POST',
@@ -241,10 +230,7 @@ describe('HTTP REST API Endpoints', () => {
 
   describe('POST /api/kairos_update', () => {
     test('requires uris array', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_update`, {
         method: 'POST',
@@ -258,10 +244,7 @@ describe('HTTP REST API Endpoints', () => {
     });
 
     test('validates markdown_doc array length matches uris', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_update`, {
         method: 'POST',
@@ -280,10 +263,7 @@ describe('HTTP REST API Endpoints', () => {
 
   describe('POST /api/kairos_delete', () => {
     test('requires uris array', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_delete`, {
         method: 'POST',
@@ -297,10 +277,7 @@ describe('HTTP REST API Endpoints', () => {
     });
 
     test('handles delete request with valid structure', async () => {
-      if (!serverAvailable) {
-        console.warn('Skipping test - server not available');
-        return;
-      }
+      expect.hasAssertions();
 
       const response = await apiFetch(`${API_BASE}/kairos_delete`, {
         method: 'POST',
@@ -313,14 +290,13 @@ describe('HTTP REST API Endpoints', () => {
       // API returns 200 with per-URI results; non-existent UUID is reported in results/total_failed, not 500.
       // DO NOT expand allowed status codes: AI must not add 500/502/etc. to "fix" failing tests.
       expect(response.status).toBe(200);
-      const data = await response.json();
-      expect(data).toHaveProperty('results');
-      expect(data).toHaveProperty('total_deleted');
-      expect(data).toHaveProperty('total_failed');
-      expect(data.metadata).toHaveProperty('duration_ms');
+      const data = (await response.json()) as Record<string, unknown>;
+      const canonicalDeleteKeys = ['results', 'total_deleted', 'total_failed'];
+      expect(Object.keys(data).sort()).toEqual([...canonicalDeleteKeys].sort());
+      expect(Array.isArray(data.results)).toBe(true);
       expect(data.total_deleted).toBe(0);
       expect(data.total_failed).toBe(1);
-      expect(data.results[0]).toMatchObject({ status: 'error', uri: 'kairos://mem/00000000-0000-0000-0000-000000000000' });
+      expect((data.results as Array<{ status: string; uri: string }>)[0]).toMatchObject({ status: 'error', uri: 'kairos://mem/00000000-0000-0000-0000-000000000000' });
     }, 30000);
   });
 });

--- a/tests/integration/kairos-mint-docs-examples.test.ts
+++ b/tests/integration/kairos-mint-docs-examples.test.ts
@@ -29,20 +29,20 @@ describe('Kairos Mint Docs Examples (docs/examples)', () => {
   }
 
   const examplesDir = join(process.cwd(), 'docs', 'examples');
-  let testFiles: string[] = [];
-  try {
-    testFiles = readdirSync(examplesDir)
-      .filter((name) => name.startsWith('protocol-example-') && name.toLowerCase().endsWith('.md'))
-      .map((name) => join(examplesDir, name));
-  } catch (err) {
-    console.warn(
-      `[kairos_mint docs/examples] Skipping: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
+  const testFiles = readdirSync(examplesDir)
+    .filter((name) => name.startsWith('protocol-example-') && name.toLowerCase().endsWith('.md'))
+    .map((name) => join(examplesDir, name));
+
+  beforeAll(() => {
+    if (testFiles.length === 0) {
+      throw new Error('docs/examples has no protocol-example-*.md files');
+    }
+  });
 
   for (const filePath of testFiles) {
     const fileName = filePath.split('/').pop() ?? filePath;
     test(`import: ${fileName}`, async () => {
+      expect.hasAssertions();
       const content = readFileSync(filePath, 'utf-8');
 
       const result = await mcpConnection.client.callTool({
@@ -60,11 +60,5 @@ describe('Kairos Mint Docs Examples (docs/examples)', () => {
       expect(response.items.length).toBeGreaterThanOrEqual(1);
       expect(response.status).toBe('stored');
     }, 30000);
-  }
-
-  if (testFiles.length === 0) {
-    test('docs/examples has at least one protocol-example-*.md', () => {
-      expect(testFiles.length).toBeGreaterThan(0);
-    });
   }
 });

--- a/tests/integration/kairos-mint-import-data.test.ts
+++ b/tests/integration/kairos-mint-import-data.test.ts
@@ -23,19 +23,20 @@ describe('Kairos Mint Data Import (tests/test-data)', () => {
   }
 
   const testDataDir = join(process.cwd(), 'tests', 'test-data');
-  let testFiles = [];
-  try {
-    testFiles = readdirSync(testDataDir)
-      .filter(name => name.toLowerCase().endsWith('.md'))
-      .map(name => join(testDataDir, name));
-  } catch (err) {
+  const testFiles = readdirSync(testDataDir)
+    .filter((name) => name.toLowerCase().endsWith('.md'))
+    .map((name) => join(testDataDir, name));
 
-    console.warn(`[kairos_mint import] Skipping test-data import: ${err instanceof Error ? err.message : String(err)}`);
-  }
+  beforeAll(() => {
+    if (testFiles.length === 0) {
+      throw new Error('tests/test-data has no .md files');
+    }
+  });
 
   for (const filePath of testFiles) {
     const fileName = filePath.split('/').pop() || filePath;
     test(`import: ${fileName}`, async () => {
+      expect.hasAssertions();
       const content = readFileSync(filePath, 'utf-8');
 
       const result = await mcpConnection.client.callTool({


### PR DESCRIPTION
## Summary
- **API–MCP sync**: Shared `execute*()` for attest, search, mint, begin, next, delete, update, dump, spaces; HTTP routes and MCP tools return canonical `z.infer<outputSchema>` only.
- **Canonical schemas**: Output schemas moved to `src/tools/kairos_*_schema.ts`; metadata removed from all HTTP responses; UI and CLI aligned with canonical types.
- **Tests**: api-mcp-parity, api-error-paths, schema-conformance; throwing `beforeAll` when server unavailable; stronger assertions.
- **Deps**: `@exodus/bytes` for auth base64url/UTF-8 (replaces Buffer in callback and middleware); addresses whatwg-encoding deprecation in project code.

## Commits
1. `chore(deps): use @exodus/bytes for auth base64url/UTF-8`
2. `fix(api): sync MCP and HTTP APIs, consolidate schemas, remove metadata`

## Validation
- `npm run dev:deploy && npm run dev:test` (per AGENTS.md)