### PR TITLE
fix(search): remove normalizedQuery, keep TITLE_BOOST + creation-protocol blockquote

### DIFF
--- a/docs/architecture/search-query.md
+++ b/docs/architecture/search-query.md
@@ -36,10 +36,10 @@ flowchart LR
 ## End-to-end flow
 
 1. **Input:** MCP tool `kairos_search` or HTTP `POST /api/kairos_search` with `query` (and optional `space`).
-2. **Query normalization:** The raw query is normalized for search and cache key: built-in protocol URIs and UUIDs (refine and creation) are stripped so the query text is not literally “searching for” those protocols. Empty after strip is valid (returns no vector matches).
+2. **Query preparation:** The raw query is cleaned for search and cache key: built-in protocol URIs and UUIDs (refine and creation) are stripped so the query text is not literally “searching for” those protocols. Empty after strip is valid (returns no vector matches).
 3. **Space context:** If `space` is provided and allowed, the request runs in that space context; otherwise the default (e.g. personal) is used. Search sees **allowed spaces plus the KAIROS app space** (`getSearchSpaceIds()`).
-4. **Cache:** A Redis cache key is built from normalized query and group-collapse flag. On hit, the cached unified response is returned; no Qdrant call.
-5. **Store call:** `memoryStore.searchMemories(searchQuery, limit, enableGroupCollapse)` runs. It uses normalized query for cache write and passes the same search query to the vector layer.
+4. **Cache:** A Redis cache key is built from the search query and group-collapse flag. On hit, the cached unified response is returned; no Qdrant call.
+5. **Store call:** `memoryStore.searchMemories(searchQuery, limit, enableGroupCollapse)` runs. It uses the (trimmed) search query for cache write and passes the same query to the vector layer.
 6. **Vector search:** Embedding + BM25 hybrid in Qdrant (see below). Results are chain heads only (`chain.step_index === 1`), with exclusions applied in the Qdrant filter.
 7. **Candidate handling:** Results are deduplicated by chain (prefer chain head, then by score). Top N by score are kept; each is checked against `SCORE_THRESHOLD`. Refine and create choices are appended when needed (no match, or multiple matches, or single weak match).
 8. **Response:** Unified `choices` with `uri`, `label`, `chain_label`, `score`, `role`, `tags`, `next_action`, and optional `protocol_version`.
@@ -78,11 +78,11 @@ Search uses the **Query API** (Qdrant 1.14+): prefetch with fusion, then an oute
 
 After RRF, the final score is:
 
-`score = $score + TITLE_BOOST * match(chain.label, text: normalizedQuery) + attest_boost`
+`score = $score + TITLE_BOOST * match(chain.label, text: query) + attest_boost`
 
 - `$score` is the RRF score from prefetch.
 - `TITLE_BOOST` is 0.5.
-- `match(chain.label, text: normalizedQuery)` is a Qdrant condition: it contributes when the chain's label contains all tokens of the normalized query (title match). So protocols whose chain title matches the query get an additive boost.
+- `match(chain.label, text: query)` is a Qdrant condition: it contributes when the chain's label contains all tokens of the (trimmed) search query (title match). So protocols whose chain title matches the query get an additive boost.
 - `attest_boost` is a numeric payload field on the point (precomputed when quality metrics are updated); protocols with more successful attestations get a higher value, so they rank slightly higher when relevance is similar.
 
 Per the principle above, all scoring is expressed in Qdrant (formula, filter, prefetch); the app does not modify scores after the query.
@@ -123,7 +123,7 @@ The store returns `{ memories, scores }`. The tool layer then:
 
 ## Cache
 
-- **Key:** `begin:v3:{normalizedQuery}:{enableGroupCollapse}` (e.g. Redis).
+- **Key:** `begin:v3:{searchQuery}:{enableGroupCollapse}:{limit}` (e.g. Redis).
 - **Value:** Full unified JSON response (stringified).
 - **TTL:** 300 seconds (configurable where the cache is set).
 - Cache is written after a successful search and read at the start of the request when the key exists.

--- a/scripts/query-search-standalone.mjs
+++ b/scripts/query-search-standalone.mjs
@@ -112,7 +112,7 @@ async function main() {
     process.exit(1);
   }
 
-  const normalizedQuery = query.trim().toLowerCase();
+  const queryTrimmed = query.trim();
   console.log('Query:', query);
   console.log('Collection:', QDRANT_COLLECTION, `(limit ${limit})`);
   if (denseOnly) console.log('Mode: dense only (no BM25)');
@@ -151,7 +151,7 @@ async function main() {
       formula: {
         sum: [
           '$score',
-          { mult: [TITLE_BOOST, { key: 'chain.label', match: { text: normalizedQuery } }] },
+          { mult: [TITLE_BOOST, { key: 'chain.label', match: { text: queryTrimmed } }] },
           'attest_boost'
         ]
       },

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -44,6 +44,11 @@ cleanly with kairos_dump and kairos_mint.
 
 ## How to write a Natural Language Triggers section
 
+> **THIS IS THE KEY INSTRUCTION THAT PREVENTS THE SEARCH BUG.**
+>
+> Without this step, protocol authors may put operational content in step 1,
+> making the chain invisible to `kairos_search`.
+
 Every protocol **must** include a `## Natural Language Triggers` section as the
 **first H2** after the H1 title and introductory paragraph. This section tells
 agents when to activate the protocol from human speech.

--- a/src/services/memory/store-methods.ts
+++ b/src/services/memory/store-methods.ts
@@ -121,24 +121,24 @@ export class MemoryQdrantStoreMethods {
   }
 
   async searchMemories(query: string, limit: number, collapse: boolean = true): Promise<{ memories: Memory[], scores: number[] }> {
-    const normalizedQuery = (query || '').trim().toLowerCase();
+    const queryKey = (query || '').trim();
 
-    if (!normalizedQuery) {
+    if (!queryKey) {
       return { memories: [], scores: [] };
     }
 
-    const vectorResult = await this.vectorSearch(normalizedQuery, query, limit);
-    await redisCacheService.setSearchResult(normalizedQuery, limit, vectorResult, { collapse });
+    const vectorResult = await this.vectorSearch(queryKey, limit);
+    await redisCacheService.setSearchResult(queryKey, limit, vectorResult, { collapse });
     return vectorResult;
   }
 
   /**
    * Hybrid search: dense + BM25 via Query API with formula-based title boosting.
    * Inner prefetch: 1× dense + 3× BM25 fused via RRF.
-   * Outer query: formula = $score + TITLE_BOOST * match(chain.label, text: normalizedQuery) + attest_boost.
+   * Outer query: formula = $score + TITLE_BOOST * match(chain.label, text: query) + attest_boost.
    * match.text requires ALL query tokens in chain.label, boosting only exact title matches.
    */
-  private async vectorSearch(normalizedQuery: string, query: string, limit: number): Promise<{ memories: Memory[], scores: number[] }> {
+  private async vectorSearch(query: string, limit: number): Promise<{ memories: Memory[], scores: number[] }> {
     const queryEmbeddingResult = await embeddingService.generateEmbedding(query);
     const queryVector = queryEmbeddingResult.embedding;
     const vectorName = `vs${queryVector.length}`;
@@ -187,7 +187,7 @@ export class MemoryQdrantStoreMethods {
               {
                 mult: [
                   TITLE_BOOST,
-                  { key: 'chain.label', match: { text: normalizedQuery } }
+                  { key: 'chain.label', match: { text: query } }
                 ]
               },
               'attest_boost'

--- a/src/tools/kairos_search.ts
+++ b/src/tools/kairos_search.ts
@@ -67,7 +67,6 @@ function addCandidate(
 async function searchAndBuildCandidates(
   memoryStore: MemoryQdrantStore,
   query: string,
-  normalizedQuery: string,
   enableGroupCollapse: boolean,
   maxChoices: number
 ): Promise<Map<string, { memory: Memory; score: number }>> {
@@ -92,11 +91,9 @@ async function doSearch(
   searchQuery: string,
   effectiveLimit: number
 ): Promise<SearchOutput> {
-  const normalizedQuery = searchQuery.toLowerCase();
   const candidateMap = await searchAndBuildCandidates(
     memoryStore,
     searchQuery,
-    normalizedQuery,
     KAIROS_ENABLE_GROUP_COLLAPSE,
     effectiveLimit
   );
@@ -129,8 +126,7 @@ export async function executeSearch(
     Math.min(KAIROS_SEARCH_LIMIT_CAP, max_choices ?? KAIROS_SEARCH_MAX_CHOICES)
   );
   const searchQuery = queryForSearch(query);
-  const normalizedQuery = searchQuery.toLowerCase();
-  const cacheKey = `begin:v3:${normalizedQuery}:${KAIROS_ENABLE_GROUP_COLLAPSE}:${effectiveLimit}`;
+  const cacheKey = `begin:v3:${searchQuery}:${KAIROS_ENABLE_GROUP_COLLAPSE}:${effectiveLimit}`;
 
   const cachedResult = await redisCacheService.get(cacheKey);
   if (cachedResult) {


### PR DESCRIPTION
## Summary
- **Part 1:** Keep TITLE_BOOST; remove `normalizedQuery` everywhere. Use (trimmed) `searchQuery` / `query` for cache keys and for `match(chain.label, text: query)` in app, standalone script, and docs.
- **Part 2:** Add the "search bug" blockquote to the built-in creation protocol (Natural Language Triggers section).

## Changes
- `src/tools/kairos_search.ts`: cache key and `searchAndBuildCandidates` use `searchQuery` only; no `normalizedQuery`.
- `src/services/memory/store-methods.ts`: `searchMemories` uses `queryKey = trim(query)`; `vectorSearch(query, limit)` single param; formula uses `match(chain.label, text: query)`.
- `scripts/query-search-standalone.mjs`: trimmed query for formula (no lowercasing).
- `docs/architecture/search-query.md`: formula and cache key docs use `query`/`searchQuery`; reworded flow.
- `src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md`: blockquote added after "How to write a Natural Language Triggers section".

## Verification
- `npm run dev:deploy && npm run dev:test` — all tests passed.
- Standalone script verified: mixed-case and lowercase queries return same results (Qdrant match case-insensitive).