### PR TITLE
fix(dump): resolve chain_id from browse + feat(cli): token storage hint on login

### DIFF
--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -19,8 +19,19 @@ function escapeHtml(s: string): string {
 }
 
 import { openBrowser } from '../auth-error.js';
-import { getDefaultApiUrlFromFile, readConfig, writeConfig } from '../config-file.js';
+import { getDefaultApiUrlFromFile, readConfig, writeConfig, normalizeApiUrl } from '../config-file.js';
+import { getToken, isKeyringAvailable } from '../keyring.js';
 import { writeError, writeStdout, writeStderr } from '../output.js';
+
+/** Describe where the current token is stored (no path). Used for "Already authenticated. Token …" message. */
+async function getTokenStorageHint(baseUrl: string, token: string): Promise<string> {
+    const normalized = normalizeApiUrl(baseUrl);
+    if (isKeyringAvailable()) {
+        const fromKeyring = await getToken(normalized);
+        if (fromKeyring === token) return 'Token stored in keychain.';
+    }
+    return 'Token in config file.';
+}
 
 /** Resolve current API base URL (env, then config default, then getApiUrl()). Exported for logout. */
 export function getBaseUrl(): string {
@@ -211,7 +222,8 @@ export function loginCommand(program: Command): void {
                 }
                 const config = await readConfig(baseUrl);
                 if (config.bearerToken && (await isTokenValid(baseUrl, config.bearerToken))) {
-                    writeStdout('Already authenticated.');
+                    const storage = await getTokenStorageHint(baseUrl, config.bearerToken);
+                    writeStdout(`Already authenticated. ${storage}`);
                     process.exit(0);
                     return;
                 }

--- a/src/tools/kairos_dump.ts
+++ b/src/tools/kairos_dump.ts
@@ -79,7 +79,13 @@ export async function executeDump(
   const { uri, protocol = false } = params;
   const { uuid, uri: normalizedUri } = normalizeUri(uri);
 
-  const memory = await loadMemory(memoryStore, uuid);
+  let memory = await loadMemory(memoryStore, uuid);
+  // Browse UI uses chain_id as protocol URI; dump expects memory UUID. Resolve chain_id -> first-step memory.
+  if (!memory && qdrantService && typeof qdrantService.getChainMemories === 'function') {
+    const chainPoints = await qdrantService.getChainMemories(uuid);
+    const firstUuid = chainPoints[0]?.uuid;
+    if (firstUuid) memory = await loadMemory(memoryStore, firstUuid);
+  }
   if (!memory) {
     const err = new Error('Memory not found');
     (err as any).statusCode = 404;

--- a/tests/integration/http-api-dump.test.ts
+++ b/tests/integration/http-api-dump.test.ts
@@ -102,4 +102,58 @@ Done.`;
     expect(data).toHaveProperty('uri', uri);
     expect(data).toHaveProperty('label');
   }, 30000);
+
+  test('returns full protocol when URI is chain_id (browse case)', async () => {
+    if (!serverAvailable) {
+      console.warn('Skipping test - server not available');
+      return;
+    }
+
+    const title = `Dump By Chain ${Date.now()}`;
+    const markdown = `# ${title}
+
+## Natural Language Triggers
+Browse chain dump.
+
+## Step One
+First step body.
+
+\`\`\`json
+{"challenge": {"type": "comment", "description": "Step one"}}
+\`\`\`
+
+## Completion Rule
+Done.`;
+    const mintRes = await fetch(`${API_BASE}/kairos_mint/raw?force=true`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/markdown', 'X-LLM-Model-ID': 'test-model', ...getAuthHeaders() },
+      body: markdown
+    });
+    expect(mintRes.status).toBe(200);
+
+    const spacesRes = await fetch(`${API_BASE}/kairos_spaces`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+      body: JSON.stringify({ include_chain_titles: true })
+    });
+    expect(spacesRes.status).toBe(200);
+    const spacesData = await spacesRes.json();
+    const chains = spacesData.spaces?.flatMap((s: { chains?: Array<{ chain_id: string; title: string }> }) => s.chains ?? []) ?? [];
+    const chain = chains.find((c: { title: string }) => c.title === title);
+    expect(chain).toBeDefined();
+
+    const dumpByChainUri = `kairos://mem/${chain!.chain_id}`;
+    const response = await fetch(`${API_BASE}/kairos_dump`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+      body: JSON.stringify({ uri: dumpByChainUri, protocol: true })
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveProperty('markdown_doc');
+    expect(typeof data.markdown_doc).toBe('string');
+    expect(data.markdown_doc).toContain('First step body');
+    expect(data).toHaveProperty('step_count');
+    expect(Number(data.step_count)).toBeGreaterThanOrEqual(1);
+  }, 30000);
 });


### PR DESCRIPTION
## Summary

**1. fix(dump): open protocol from Browse by label**
- Browse UI uses `chain_id` as protocol URI; `kairos_dump` expected memory UUID → 404 when opening from Browse.
- When `loadMemory(uuid)` returns null, resolve `uuid` as chain_id via `getChainMemories`, use first step's memory for dump.
- Add integration test: dump by chain_id (browse case).

**2. feat(cli): token storage hint when already authenticated**
- `kairos login` when already authenticated now prints where the token lives: `Token stored in keychain.` or `Token in config file.`
- No path/location, just storage type — helps users know where to look (e.g. keychain vs file).

## Testing
- `npm run dev:deploy && npm run dev:test -- tests/integration/http-api-dump.test.ts` (4 tests pass)
- CLI: run `kairos login` when already logged in → see storage hint