### PR TITLE
docs: business cases, automation positioning, and non-public folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,9 @@ helm/kairos-fullstack/charts/*.tgz
 .local/
 local/
 
+# Non-public repo content (not published)
+non-public/
+
 # Package managers
 .yarn/
 .pnp.*

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D25.0.0-brightgreen)](https://nodejs.org/)
 
-KAIROS MCP™ gives AI agents persistent memory and deterministic protocol
-execution. Agents store, retrieve, and run reusable protocol chains across
-sessions — without losing context between runs.
+KAIROS MCP™ **automates AI agents and chats** with persistent memory and
+deterministic protocol execution. Agents store, retrieve, and run reusable
+workflows across sessions—so you get repeatable procedures, not one-off chat.
 
 ## Why KAIROS
 
-Without persistent memory, agents repeat work, lose context, and cannot
+Without persistent workflows, agents repeat work, lose context, and cannot
 follow multi-step procedures reliably. KAIROS fixes this with three
 primitives:
 
@@ -20,6 +20,23 @@ primitives:
 drives `next_action` at every step
 - **Agent-facing design** — tool descriptions and error messages built for  
 programmatic consumption and recovery
+
+Protocol execution runs in a fixed order: search for a match, begin the run,
+solve each step’s challenge, then attest completion.
+
+```mermaid
+flowchart LR
+  A([search]) --> B([begin]) --> C([next]) --> D([attest])
+  C -.-> C
+  style A fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style B fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style C fill:#ffb74d,stroke:#f57c00,color:#333
+  style D fill:#81c784,stroke:#388e3c,color:#333
+```
+
+**Use cases:** Run the same release or deploy checklist every time; onboard
+repos or triage support with a searchable playbook; let agents follow
+minted procedures across sessions instead of ad-hoc chat.
 
 ## Quick start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # KAIROS MCP documentation
 
-This folder contains documentation for KAIROS MCP: setup guides, CLI
-reference, and protocol workflow details.
+KAIROS MCP automates AI agents and chats with persistent, deterministic
+workflows. This folder contains setup guides, CLI reference, and protocol
+workflow details.
 
 ## Start here
 
@@ -28,6 +29,12 @@ execute end-to-end.
   per-tool workflow reference, response shapes, and scenarios.
 - [Authentication overview](architecture/auth-overview.md) — server auth (Bearer/session), shared CLI and MCP config, Keycloak, login flow.
 - [Logging](architecture/logging.md) — log levels, standard fields, env vars, error codes.
+
+## Business applications
+
+- [Business application cases](business/README.md) — manager-focused examples:
+  standardizing commits and MRs, compliance review from a new document (e.g. NIST),
+  Terraform module standardization.
 
 ## Concepts
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -70,10 +70,11 @@ step-skipping: challenge-type-specific error messages and `next_action`
 when proof is missing (for example, telling the agent to ask the user for
 `user_input` instead of inferring the answer).
 
-## Auth URL topology (QA / Docker)
+## Auth and URL topology
 
-[Auth URLs: QA and Docker topology](auth-urls-qa.md) explains which
-Keycloak URL each party uses and how `KEYCLOAK_URL` vs
+[Authentication overview](auth-overview.md) covers server auth (Bearer/session),
+shared CLI and MCP config, Keycloak clients, and login flow. It also explains
+which Keycloak URL each party uses and how `KEYCLOAK_URL` vs
 `KEYCLOAK_INTERNAL_URL` are set in `.env` and `compose.yaml`.
 
 ## Authentication and logging

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -362,7 +362,7 @@ flowchart TD
 - [Full execution workflow](workflow-full-execution.md) — protocol run
   end-to-end
 - [Quality metadata](quality-metadata.md) — scoring and bonus structure
-- [Auth URLs: QA and Docker topology](auth-urls-qa.md) — Keycloak URL
+- [Authentication overview](auth-overview.md) — Keycloak URL
   routing
 - [`compose.yaml`](../../compose.yaml) — default (Docker named volumes)
 - `VOLUME_LOCAL_PATH` — host path for bind mounts (set in `.env`)

--- a/docs/business/README.md
+++ b/docs/business/README.md
@@ -1,0 +1,65 @@
+# Business application cases
+
+<img src="../../logo/kaiiros-mcp.svg" width="96" alt="KAIROS MCP logo" />
+
+This section describes **real-world applications** of KAIROS for managers and
+decision-makers. Each case is a short example of how teams use automated
+workflows to standardize processes, speed up compliance, or keep codebases
+consistent—without going into technical protocol details.
+
+## What these cases show
+
+- **Repeatable procedures:** The same workflow runs the same way every time,
+  so outcomes are predictable.
+- **Speed:** From a new requirement (e.g. a compliance document) to a first
+  result in minutes.
+- **Consistency:** Team practices (commits, merge requests, Terraform style)
+  are enforced by a shared procedure instead of ad-hoc chat.
+
+```mermaid
+flowchart LR
+  subgraph in["Inputs"]
+    A([New standard])
+    B([Team policy])
+    C([Legacy modules])
+  end
+  subgraph kairos["KAIROS workflow"]
+    D[Run procedure]
+  end
+  subgraph out["Outcomes"]
+    E[Compliance report]
+    F[Consistent MRs]
+    G[Standardized code]
+  end
+  A --> D --> E
+  B --> D --> F
+  C --> D --> G
+  style A fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style B fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style C fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style D fill:#ffb74d,stroke:#f57c00,color:#333
+  style E fill:#81c784,stroke:#388e3c,color:#333
+  style F fill:#81c784,stroke:#388e3c,color:#333
+  style G fill:#81c784,stroke:#388e3c,color:#333
+```
+
+## Cases
+
+| Case | Problem | Outcome |
+|------|--------|--------|
+| [Standardize commits and merge requests](case-standardize-commits-and-merge-requests.md) | Align the team on commit messages and MR rules | One shared procedure; everyone follows the same steps when creating merge requests |
+| [Compliance review from a new document (15 minutes)](case-compliance-review-from-pdf.md) | Check a codebase against a new compliance standard (e.g. NIST) | New procedure created from the PDF; first compliance report against the repo in about 15 minutes |
+| [Terraform module standardization](case-terraform-module-standardization.md) | Keep Terraform modules consistent and up to date | Standardize-project style workflow applied to Terraform; updated, consistent modules |
+
+## Who this is for
+
+| Audience | Interest |
+|----------|----------|
+| Engineering and platform leads | Automate team workflows and reduce drift |
+| Compliance and risk | Fast, repeatable checks against standards |
+| Product and delivery | Agents that follow a playbook instead of one-off chat |
+
+## More information
+
+For technical details on how protocols run, see [Architecture and protocol
+workflows](../architecture/README.md).

--- a/docs/business/case-compliance-review-from-pdf.md
+++ b/docs/business/case-compliance-review-from-pdf.md
@@ -1,0 +1,73 @@
+# Case 2: Verify new compliance in 15 minutes (from a PDF to a first report)
+
+<img src="../../logo/kaiiros-mcp.svg" width="64" alt="KAIROS MCP logo" />
+
+## Problem
+
+A new compliance or security standard is published (e.g. a NIST guideline).
+The team needs to check the codebase against it quickly, without manually
+reading the whole document and turning it into a checklist every time.
+
+## At a glance
+
+| | |
+|--|--|
+| **Goal** | First compliance report against a new standard in ~15 minutes |
+| **Input** | Link to the standard (e.g. [NIST SP 800-218A](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-218A.pdf)) |
+| **Output** | Runnable procedure + report (gaps and areas to improve) |
+| **Benefit** | No manual checklist building; procedure is reusable for other repos |
+
+## Scenario
+
+1. **Input:** A link to the standard—for example
+   [NIST SP 800-218A](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-218A.pdf)
+   (Secure Software Development Practices for Generative AI and Dual-Use
+   Foundation Models).
+
+2. **Request:** "Prepare a new procedure for this document." The system
+   turns the PDF (or its content) into a runnable compliance-review
+   procedure—e.g. "NIST SP 800-218A — AI Model Development Security Review."
+
+3. **Learning:** Once the procedure exists, the AI has effectively "learned"
+   how to check compliance against that standard. The procedure encodes the
+   review steps; no need to re-read the PDF for every run.
+
+4. **First run:** The user runs the new procedure against the local repo.
+   The agent follows the procedure and produces a **first compliance report**:
+   areas that match the standard and areas to improve.
+
+```mermaid
+flowchart LR
+  A([PDF or link]) --> B[Create procedure]
+  B --> C[Compliance checklist]
+  C --> D[Run vs. repo]
+  D --> E[Report: gaps + recommendations]
+  style A fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style B fill:#ffb74d,stroke:#f57c00,color:#333
+  style C fill:#ede7f6,stroke:#5e35b1,color:#333
+  style D fill:#f0f4f8,stroke:#4a6fa5,color:#333
+  style E fill:#81c784,stroke:#388e3c,color:#333
+```
+
+## Generic flow
+
+1. Provide the new standard (e.g. PDF link or content).
+2. Ask for a new procedure that reflects that standard.
+3. Use the resulting procedure as the compliance checklist.
+4. Run it against a target (e.g. repo, project); get a report with gaps and
+   recommendations.
+
+## Outcome
+
+- **Speed:** From "we have a new PDF" to "we have a first report" in the
+  order of **15 minutes**, not days.
+- **Reuse:** The same procedure can be run again on other repos or after
+  changes, so compliance checks stay repeatable.
+- **Clarity:** The report highlights where the codebase aligns or falls
+  short, so teams know what to fix.
+
+## Takeaway
+
+New compliance requirements can be turned into an automated review procedure
+quickly. The team gets a first compliance snapshot against the new standard
+without manually building a checklist from the document.

--- a/docs/business/case-standardize-commits-and-merge-requests.md
+++ b/docs/business/case-standardize-commits-and-merge-requests.md
@@ -1,0 +1,66 @@
+# Case 1: Standardize commits and merge requests across the team
+
+<img src="../../logo/kaiiros-mcp.svg" width="64" alt="KAIROS MCP logo" />
+
+## Problem
+
+The team's commit messages and merge request (MR) habits are inconsistent.
+Some use conventional commits, others free-form text; branch naming and MR
+titles vary. Review and tooling (e.g. changelogs) become harder, and
+onboarding is noisy.
+
+## At a glance
+
+| | |
+|--|--|
+| **Goal** | One shared procedure for creating merge requests |
+| **Input** | Team policy (branch naming, commit format, MR conventions) |
+| **Output** | Consistent MRs and commits every time |
+| **Benefit** | No reliance on each person remembering the policy |
+
+## Approach
+
+Introduce a **single, shared procedure** that everyone (and every AI agent)
+uses when creating a merge request. The procedure encodes the team's rules:
+branch naming, commit message format, optional scope, and any MR title/description
+conventions. Once the procedure is in place, anyone—human or agent—runs the
+same workflow and gets the same structure.
+
+```mermaid
+flowchart LR
+  A([Developer or agent]) --> B{Create MR?}
+  B -->|Yes| C[Run shared procedure]
+  C --> D[Branch + commit + MR content]
+  D --> E[Consistent MR]
+  style A fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style B fill:#e8c547,stroke:#c4a535,color:#333
+  style C fill:#ffb74d,stroke:#f57c00,color:#333
+  style D fill:#ede7f6,stroke:#5e35b1,color:#333
+  style E fill:#81c784,stroke:#388e3c,color:#333
+```
+
+## Generic flow
+
+1. The team (or platform lead) defines the desired standard and turns it
+   into a runnable procedure (e.g. "Create merge request").
+2. When a developer or agent needs to open an MR, they run that procedure
+   instead of improvising.
+3. The procedure guides them through: branch type and name, commit style,
+   and MR content, so output is consistent.
+4. Over time, all MRs created via this workflow follow the same rules;
+   tooling and reviews can rely on that.
+
+## Outcome
+
+- **One source of truth:** Commit and MR standards live in one procedure,
+  not in scattered docs or memory.
+- **Same behavior every time:** No need to remember the rules; the workflow
+  applies them.
+- **Easier automation:** Agents and scripts can "create merge request" by
+  running the procedure, so automation stays aligned with the team standard.
+
+## Takeaway
+
+Standardizing commits and merge requests becomes a matter of adopting a
+shared workflow. The team gets consistent MRs and commits without depending
+on each person remembering the policy.

--- a/docs/business/case-terraform-module-standardization.md
+++ b/docs/business/case-terraform-module-standardization.md
@@ -1,0 +1,68 @@
+# Case 3: Standardizing and updating Terraform modules
+
+<img src="../../logo/kaiiros-mcp.svg" width="64" alt="KAIROS MCP logo" />
+
+## Problem
+
+Terraform modules across teams or repos have drifted: different naming,
+structure, or patterns. Updating them manually is slow and error-prone; you
+want a consistent, repeatable way to bring modules in line with a standard.
+
+## At a glance
+
+| | |
+|--|--|
+| **Goal** | All Terraform modules aligned to a single standard |
+| **Input** | Standard (layout, naming, versions) + target module repo/dir |
+| **Output** | Updated, consistent module (or report of changes) |
+| **Benefit** | Same procedure scales to many repos; no hand-crafted edits |
+
+## Approach
+
+Use a **standardize-project** style procedure that applies a defined set of
+rules to a Terraform codebase. The procedure guides the agent (or operator)
+through the steps needed to align the module with the standard: structure,
+naming, versions, and any project-specific conventions. The result is an
+updated, consistent module without ad-hoc edits.
+
+```mermaid
+flowchart LR
+  A([Org standard]) --> B[Standardization procedure]
+  C([Module repo]) --> B
+  B --> D[Check structure]
+  D --> E[Update versions + naming]
+  E --> F[Consistent module]
+  style A fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style C fill:#4a6fa5,stroke:#2d4a7a,color:#fff
+  style B fill:#ffb74d,stroke:#f57c00,color:#333
+  style D fill:#f0f4f8,stroke:#4a6fa5,color:#333
+  style E fill:#ede7f6,stroke:#5e35b1,color:#333
+  style F fill:#81c784,stroke:#388e3c,color:#333
+```
+
+## Generic flow
+
+1. The organization defines what "standard" means for Terraform modules
+   (layout, naming, required files, version pins, etc.) and captures it in
+   a standardization procedure.
+2. When a module needs to be updated or aligned, the team runs that
+   procedure against the module's repo or directory.
+3. The procedure walks through the steps (e.g. check structure, update
+   versions, apply naming rules) and produces changes or a report.
+4. The same procedure can be run on other modules so that over time all
+   of them follow the same standard.
+
+## Outcome
+
+- **Consistency:** All modules that have been through the workflow conform
+  to the same rules.
+- **Repeatability:** Every run follows the same steps; no reliance on
+  someone "just knowing" what to do.
+- **Scalability:** New or legacy modules can be standardized by running the
+  procedure again, so the standard scales across many repos.
+
+## Takeaway
+
+Terraform module standardization becomes a defined workflow. Teams get
+updated, consistent modules by running the same procedure instead of
+hand-crafting each change.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debian777/kairos-mcp",
   "version": "3.3.0-rc.0",
-  "description": "kairos MCP Server - AI Knowledge Memory System for AI Agent Consciousness Infrastructure",
+  "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",
   "author": "Jakub Plichcinski <kuba@xpl.pl>",
@@ -17,17 +17,15 @@
   "keywords": [
     "mcp",
     "model-context-protocol",
-    "knowledge-bank",
-    "ai-knowledge",
+    "agent-automation",
+    "workflow-orchestration",
+    "ai-agents",
     "ai-memory",
     "knowledge-management",
-    "ai-consciousness",
-    "ai-infrastructure",
     "vector-database",
     "qdrant",
-    "ai-agents",
-    "knowledge-retrieval",
-    "semantic-search"
+    "semantic-search",
+    "ai-infrastructure"
   ],
   "bin": {
     "kairos": "dist/cli/index.js"


### PR DESCRIPTION
## Summary
- **docs/business/** — Three manager-focused cases (MR standardization, compliance from PDF in 15 min, Terraform standardization) with logo, Mermaid diagrams (GitLab docs style), and at-a-glance tables.
- **README & docs/README** — Lead with agent automation messaging; add protocol flow Mermaid and use cases.
- **package.json** — Description and keywords for agent automation and workflow orchestration.
- **Architecture docs** — Fix broken auth links (auth-urls-qa → auth-overview).
- **.gitignore** — Add `non-public/` for unreleased content.