### PR TITLE
fix(kairos-bundle): skill-dir run path, prereqs, and absolute --dir

### DIFF
--- a/skills/kairos-bundle/SKILL.md
+++ b/skills/kairos-bundle/SKILL.md
@@ -9,20 +9,29 @@ Export all KAIROS protocols to a directory of `.md` files, or import all `.md` f
 
 ## Prerequisites
 
+- **Python 3** — Interpreter to run the script.
+- **KAIROS CLI** — For obtaining a token (`kairos token`); must be on `PATH`.
+- **KAIROS MCP** — Server running and reachable (e.g. `KAIROS_API_URL` or default `http://localhost:3000`).
 - **KAIROS_TOKEN** — Bearer token (e.g. `KAIROS_TOKEN=$(kairos token)`).
 - **KAIROS_API_URL** — Optional; default `http://localhost:3000`.
 
 ## Run the script
 
-From the **repo root**:
+From the **skill directory** (the directory that contains this `SKILL.md` — e.g. `skills/kairos-bundle` in the repo or `~/.agents/skills/kairos-bundle` when installed):
 
 ```bash
 # Export: save all protocols from spaces into --dir
-KAIROS_TOKEN=$(kairos token) python3 skills/kairos-bundle/scripts/kairos-bundle.py export [--dir DIR]
+KAIROS_TOKEN=$(kairos token) python3 scripts/kairos-bundle.py export [--dir DIR]
 
 # Import: mint all .md files from --dir into KAIROS (personal space)
-KAIROS_TOKEN=$(kairos token) python3 skills/kairos-bundle/scripts/kairos-bundle.py import [--dir DIR]
+KAIROS_TOKEN=$(kairos token) python3 scripts/kairos-bundle.py import [--dir DIR]
 ```
+
+So the script path is always `scripts/kairos-bundle.py` relative to the skill directory; the agent should run these commands with the current working directory set to the skill directory.
+
+**Do not confuse:** the **skill directory** (cwd when running) is where the skill and script live. The **`--dir`** option is the **bundle directory** — where `.md` files are written (export) or read from (import); it is independent of the skill directory.
+
+**Critical — always use an absolute path for `--dir` when the user means a project path.** The script is run with cwd = skill directory (so `scripts/kairos-bundle.py` is found). Any relative path passed to `--dir` is then resolved relative to that cwd (e.g. `~/.agents/skills/kairos-bundle` when the skill is installed there). So if the user says e.g. "export to kairos/bundles/trunk", they mean relative to the **workspace/project root**, not the skill directory. The agent must resolve that path against the workspace root and pass the **absolute path** to `--dir` (e.g. `--dir /path/to/project/kairos/bundles/trunk` or `--dir "$(pwd)/kairos/bundles/trunk"` when the shell is already in the project root). Otherwise files will be written under the skill directory or `~/.agents`, which is wrong.
 
 ## Options
 
@@ -37,7 +46,18 @@ KAIROS_TOKEN=$(kairos token) python3 skills/kairos-bundle/scripts/kairos-bundle.
 
 ## Examples
 
+When the bundle directory is inside the user's project, use an absolute path (resolve from workspace root):
+
 ```bash
-KAIROS_TOKEN=$(kairos token) python3 skills/kairos-bundle/scripts/kairos-bundle.py export --dir ./protocols --space "Personal"
-KAIROS_TOKEN=$(kairos token) python3 skills/kairos-bundle/scripts/kairos-bundle.py import --dir ./protocols --force
+# From project root; BUNDLE_DIR is absolute so it doesn't depend on skill cwd
+cd /path/to/project
+KAIROS_TOKEN=$(kairos token) python3 /path/to/skill/scripts/kairos-bundle.py export --dir "$(pwd)/kairos/bundles/trunk" --space "Personal"
+KAIROS_TOKEN=$(kairos token) python3 /path/to/skill/scripts/kairos-bundle.py import --dir "$(pwd)/kairos/bundles/trunk" --force
+```
+
+Or call from the skill directory and pass an absolute bundle path:
+
+```bash
+cd ~/.agents/skills/kairos-bundle   # or skills/kairos-bundle in repo
+KAIROS_TOKEN=$(kairos token) python3 scripts/kairos-bundle.py export --dir /path/to/project/kairos/bundles/trunk
 ```

--- a/skills/kairos-bundle/requirements.txt
+++ b/skills/kairos-bundle/requirements.txt
@@ -1,1 +1,3 @@
-# kairos-bundle: stdlib-only; add deps here if needed
+# Runtime prerequisites (see SKILL.md): Python 3, KAIROS CLI (for kairos token),
+# KAIROS MCP server (API reachable at KAIROS_API_URL).
+# pip deps below (stdlib-only; add packages here if needed)

--- a/skills/kairos-bundle/scripts/kairos-bundle.py
+++ b/skills/kairos-bundle/scripts/kairos-bundle.py
@@ -11,9 +11,9 @@ Usage:
   export  - save all protocols from spaces into --dir
   import  - mint all .md files from --dir into KAIROS (personal space)
 
-Run from repo root:
-  KAIROS_TOKEN=$(kairos token) python3 skills/kairos-bundle/scripts/kairos-bundle.py export [--dir DIR]
-  KAIROS_TOKEN=$(kairos token) python3 skills/kairos-bundle/scripts/kairos-bundle.py import [--dir DIR] [--force]
+Run from the skill directory (directory containing SKILL.md):
+  KAIROS_TOKEN=$(kairos token) python3 scripts/kairos-bundle.py export [--dir DIR]
+  KAIROS_TOKEN=$(kairos token) python3 scripts/kairos-bundle.py import [--dir DIR] [--force]
 """
 from __future__ import annotations
 
@@ -28,11 +28,10 @@ import urllib.request
 import venv
 from pathlib import Path
 
-# Skill dir (skills/kairos-bundle); repo root for cwd when re-exec
-SCRIPT_DIR = Path(__file__).resolve().parent.parent
-REPO_ROOT = SCRIPT_DIR.parent.parent
-VENV_DIR = SCRIPT_DIR / ".venv"
-REQUIREMENTS = SCRIPT_DIR / "requirements.txt"
+# Skill root (directory containing SKILL.md); works in-repo or when skill is installed elsewhere
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+VENV_DIR = SKILL_ROOT / ".venv"
+REQUIREMENTS = SKILL_ROOT / "requirements.txt"
 
 
 def _venv_python() -> Path:
@@ -58,7 +57,7 @@ def _ensure_venv_and_install() -> bool:
     if REQUIREMENTS.exists():
         rc = subprocess.run(
             [str(py), "-m", "pip", "install", "--quiet", "-r", str(REQUIREMENTS)],
-            cwd=REPO_ROOT,
+            cwd=SKILL_ROOT,
             capture_output=True,
             timeout=120,
         )
@@ -312,6 +311,6 @@ if __name__ == "__main__":
             sys.exit(1)
         py = _venv_python()
         script_abs = Path(__file__).resolve()
-        rc = subprocess.run([str(py), str(script_abs)] + sys.argv[1:], cwd=REPO_ROOT)
+        rc = subprocess.run([str(py), str(script_abs)] + sys.argv[1:], cwd=SKILL_ROOT)
         sys.exit(rc.returncode)
     sys.exit(main())


### PR DESCRIPTION
## Summary

- **Run path:** Script is run from the **skill directory** using `scripts/kairos-bundle.py` so it works when the skill is installed (e.g. `~/.agents/skills/kairos-bundle`) as well as in-repo.
- **Script:** Uses `SKILL_ROOT` instead of `REPO_ROOT` for venv and cwd so behaviour is correct regardless of install location.
- **Prerequisites:** `requirements.txt` and SKILL.md now document runtime prereqs: Python 3, KAIROS CLI, KAIROS MCP.
- **`--dir`:** Doc and examples require using an **absolute path** for `--dir` when the user means a project path, so bundles are not written under `~/.agents` by mistake.

Fixes the case where `--dir kairos/bundles/trunk` was written to `~/.agents/kairos/bundles/trunk` instead of the project.