### PR TITLE
release: 3.3.1-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.3.0",
+  "version": "3.3.1-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.3.0",
+      "version": "3.3.1-rc.0",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.3.0",
+  "version": "3.3.1-rc.0",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.0"
+version: "3.3.1-rc.0"
 
 title: Create New KAIROS Protocol Chain
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.0"
+version: "3.3.1-rc.0"
 
 title: Get help refining your search
 ---


### PR DESCRIPTION
RC for next release. Changes since v3.3.0:
- NIST SP 800-218A hardening: Phase 2.5 + Phase 3 (#173)
- fix(kairos-bundle): skill-dir run path, prereqs, absolute --dir (#179)
- chore(deps): dependency updates (jose, undici, npm-dependencies group, Dependabot consolidation)