### PR TITLE
docs(embed-docs): WIP mem drafts pointer

### DIFF
--- a/src/embed-docs/WIP-mem-drafts.md
+++ b/src/embed-docs/WIP-mem-drafts.md
@@ -1,0 +1,13 @@
+# Mem drafts (not in git)
+
+Draft MCP mem resources for **upcoming features** must **not** live under `mem/` until they should boot-inject (every `*.md` in `mem/` is loaded at runtime).
+
+**Location:** `.local/wip/embed-docs-mem/` (ignored by root `.gitignore`).
+
+**Promote:** move the `.md` into `src/embed-docs/mem/` when ready; run `npm run version:sync-skills` after a version bump in the same change set.
+
+## Current draft
+
+| File | Notes |
+|------|--------|
+| `00000000-0000-0000-0000-000000002003.md` | Design Protocol Family — upcoming feature. |


### PR DESCRIPTION
## What
- Moved draft `00000000-0000-0000-0000-000000002003.md` to **`.local/wip/embed-docs-mem/`** (gitignored via `.local/`).
- Added **`src/embed-docs/WIP-mem-drafts.md`** (tracked) so the draft is not forgotten and we do not put non-injectable docs under `mem/` (every `*.md` there is boot-injected).

## Note
`002003` was not tracked on `main`; if you already had it locally, it now lives under `.local/wip/embed-docs-mem/`.