### PR TITLE
release: 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.3.1-rc.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.3.1-rc.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.3.1-rc.0",
+  "version": "3.3.1",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/kairos/SKILL.md
+++ b/skills/kairos/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   /kairos. Do not require the user to mention tools or protocols. For
   first-time install and server setup, use the kairos-install skill instead.
 metadata:
-  version: "3.3.0"
+  version: "3.3.1"
   author: kairos-mcp
 allowed-tools: kairos_search kairos_begin kairos_next kairos_mint kairos_attest kairos_dump kairos_update kairos_delete kairos_spaces
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.1-rc.0"
+version: "3.3.1"
 
 title: Create New KAIROS Protocol Chain
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.1-rc.0"
+version: "3.3.1"
 
 title: Get help refining your search
 ---


### PR DESCRIPTION
## Summary
- Promote `3.3.1-rc.0` to stable `3.3.1`.
- Sync packaged version metadata in release artifacts and the `kairos` skill.

## Test plan
- [x] `npm ci`
- [x] `npm run dev:deploy`
- [x] `npm run dev:test`