### PR TITLE
chore(ci): Integration Playwright cache + GitHub job summaries

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -105,6 +105,10 @@ The integration workflow uses **optional secrets:** `OPENAI_API_KEY` (embedding 
 
 **Actions → Integration → Run workflow** (workflow_dispatch).
 
+**Caching:** The job restores/saves **Docker infra** images (`compose.yaml` hash) and **`~/.cache/ms-playwright`** keyed by `package-lock.json` so Playwright’s Chromium install is usually a no-op after the first run per lockfile revision.
+
+**Job summary:** Most steps append a **Vitest-style** block to `$GITHUB_STEP_SUMMARY` (`##` title, `### Summary`, ✅/❌ bullets) via `scripts/run-with-github-summary.mjs`. **Vitest** adds its own “Vitest Test Report” when `CI=true` (`vitest.config.ts`). **Jest** integration tests append “Jest integration tests” via `tests/reporters/jest-github-summary-reporter.cjs` when `GITHUB_STEP_SUMMARY` is set (`scripts/run-env.sh`).
+
 ## Release: only acceptable final output
 
 After a version-bump PR is merged to main, the **only** path that publishes is: **Release tag on version bump** (creates tag if needed) → **Release** workflow (publish-npm → publish-docker → create GitHub Release).

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,15 +35,15 @@ jobs:
           cache: "npm"
 
       - name: Check versions (mem = package.json, skills = last stable)
-        run: npm run version:check-skills
+        run: node scripts/run-with-github-summary.mjs "Version check (mem & skills)" -- npm run version:check-skills
 
       - name: Lint skills (skills-ref)
-        run: python3 scripts/lint_skills.py
+        run: node scripts/run-with-github-summary.mjs "Lint skills (skills-ref)" -- python3 scripts/lint_skills.py
 
       - name: "Generate .env (fullstack: infra + app + auth)"
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: python3 scripts/generate_dev_secrets.py
+        run: node scripts/run-with-github-summary.mjs "Generate .env (dev secrets)" -- python3 scripts/generate_dev_secrets.py
 
       - name: Verify .env exists
         run: ls -la .env
@@ -110,29 +110,46 @@ jobs:
           done
 
       - name: Configure Keycloak realms and test user
-        run: python3 scripts/configure-keycloak-realms.py
+        run: node scripts/run-with-github-summary.mjs "Configure Keycloak realms" -- python3 scripts/configure-keycloak-realms.py
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/run-with-github-summary.mjs "Install dependencies" -- npm ci
+
+      # Avoid re-downloading ~280MB Chromium/headless-shell/ffmpeg when lockfile unchanged
+      - name: Restore Playwright browsers cache
+        uses: actions/cache/restore@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium
+        id: playwright-install
+        run: node scripts/run-with-github-summary.mjs "Install Playwright browsers" -- npx playwright install chromium
+
+      - name: Save Playwright browsers cache
+        uses: actions/cache/save@v5
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && steps.playwright-install.outcome == 'success'
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('package-lock.json') }}
 
       - name: TypeScript check
-        run: npx tsc --noEmit
+        run: node scripts/run-with-github-summary.mjs "TypeScript check" -- npx tsc --noEmit
         # Fail fast on TS errors (e.g. duplicate function); full build runs later.
 
       - name: Knip (compliance)
-        run: npm run knip
+        run: node scripts/run-with-github-summary.mjs "Knip (compliance)" -- npm run knip
 
       - name: Run UI tests
+        # Vitest appends its own "Vitest Test Report" to GITHUB_STEP_SUMMARY when CI=true (vitest.config.ts)
         run: npm run test:ui
 
       - name: Build package (tgz)
-        run: npm run build:tgz
+        run: node scripts/run-with-github-summary.mjs "Build package (tgz)" -- npm run build:tgz
 
       - name: Install package from tgz
-        run: npm install ./dist/debian777-kairos-mcp-$(node -p "require('./package.json').version").tgz
+        run: node scripts/run-with-github-summary.mjs "Install package from tgz" -- npm install ./dist/debian777-kairos-mcp-$(node -p "require('./package.json').version").tgz
 
       - name: Start app (from installed package)
         env:

--- a/scripts/run-env.sh
+++ b/scripts/run-env.sh
@@ -426,11 +426,16 @@ test() {
             # In CI, run without --silent so the step log shows which test failed
             silent_flag=""
             [ "${CI:-}" = "true" ] || silent_flag="--silent"
+            # Job summary (GitHub Actions): same style as Vitest's github-actions reporter
+            summary_reporter=()
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                summary_reporter=(--reporters default --reporters "$PROJECT_DIR/tests/reporters/jest-github-summary-reporter.cjs")
+            fi
             # deploy - now need to run manually: npm run dev:deploy
             if [ ${#args[@]} -eq 0 ]; then
-                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag --runInBand --detectOpenHandles --testTimeout=30000 --testPathPatterns "tests/integration/" 2>&1  | tee -a "$REPORT_LOG_FILE"
+                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag --runInBand --detectOpenHandles --testTimeout=30000 "${summary_reporter[@]}" --testPathPatterns "tests/integration/" 2>&1  | tee -a "$REPORT_LOG_FILE"
             else
-                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag --runInBand --detectOpenHandles --testTimeout=30000 "${args[@]}" 2>&1  | tee -a "$REPORT_LOG_FILE"
+                MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag --runInBand --detectOpenHandles --testTimeout=30000 "${summary_reporter[@]}" "${args[@]}" 2>&1  | tee -a "$REPORT_LOG_FILE"
             fi
             ;;
         prod)

--- a/scripts/run-with-github-summary.mjs
+++ b/scripts/run-with-github-summary.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Run a command and append a GitHub Actions job summary section (Vitest-style headings).
+ * Only writes when GITHUB_STEP_SUMMARY is set (GitHub Actions).
+ *
+ * Usage:
+ *   node scripts/run-with-github-summary.mjs "Section title" -- <command> [args...]
+ *
+ * Example:
+ *   node scripts/run-with-github-summary.mjs "TypeScript check" -- npx tsc --noEmit
+ */
+import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const argv = process.argv.slice(2);
+const sep = argv.indexOf('--');
+if (sep < 1 || sep === argv.length - 1) {
+  console.error(
+    'Usage: node scripts/run-with-github-summary.mjs "Section title" -- <command> [args...]\n' +
+      'Example: node scripts/run-with-github-summary.mjs "Knip" -- npm run knip'
+  );
+  process.exit(2);
+}
+
+const title = argv.slice(0, sep).join(' ');
+const command = argv[sep + 1];
+const cmdArgs = argv.slice(sep + 2);
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+const result = spawnSync(command, cmdArgs, {
+  stdio: 'inherit',
+  env: process.env,
+  shell: false
+});
+
+const code = result.status ?? 1;
+const ok = code === 0;
+const icon = ok ? '✅' : '❌';
+const cmdLine = [command, ...cmdArgs].join(' ');
+
+if (summaryPath) {
+  const body =
+    `## ${title}\n\n` +
+    `### Summary\n\n` +
+    `- ${icon} **${cmdLine}** — ${ok ? 'passed' : 'failed'}\n\n`;
+  appendFileSync(summaryPath, body, 'utf8');
+}
+
+process.exit(code);

--- a/tests/reporters/jest-github-summary-reporter.cjs
+++ b/tests/reporters/jest-github-summary-reporter.cjs
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Jest reporter: append a Vitest-style block to GITHUB_STEP_SUMMARY (GitHub Actions only).
+ */
+const fs = require('fs');
+
+class JestGitHubSummaryReporter {
+  onRunComplete(_contexts, results) {
+    const path = process.env.GITHUB_STEP_SUMMARY;
+    if (!path || !results) {
+      return;
+    }
+
+    const passedSuites = results.numPassedTestSuites ?? 0;
+    const failedSuites = results.numFailedTestSuites ?? 0;
+    const pendingSuites = results.numPendingTestSuites ?? 0;
+    const totalSuites = results.numTotalTestSuites ?? passedSuites + failedSuites + pendingSuites;
+
+    const passedTests = results.numPassedTests ?? 0;
+    const failedTests = results.numFailedTests ?? 0;
+    const pendingTests = results.numPendingTests ?? 0;
+    const totalTests = results.numTotalTests ?? passedTests + failedTests + pendingTests;
+
+    const ok = results.success !== false && failedSuites === 0 && failedTests === 0;
+    const suiteIcon = ok ? '✅' : '❌';
+    const testIcon = ok ? '✅' : '❌';
+
+    const suiteParts = [`${passedSuites} passed`];
+    if (failedSuites) suiteParts.push(`${failedSuites} failed`);
+    if (pendingSuites) suiteParts.push(`${pendingSuites} pending`);
+
+    const testParts = [`${passedTests} passed`];
+    if (failedTests) testParts.push(`${failedTests} failed`);
+    if (pendingTests) testParts.push(`${pendingTests} skipped`);
+
+    const block =
+      `## Jest integration tests\n\n` +
+      `### Summary\n\n` +
+      `- ${suiteIcon} **Test files** — ${suiteParts.join(', ')} · ${totalSuites} total\n` +
+      `- ${testIcon} **Tests** — ${testParts.join(', ')} · ${totalTests} total\n\n`;
+
+    try {
+      fs.appendFileSync(path, block, 'utf8');
+    } catch {
+      // ignore summary write errors
+    }
+  }
+}
+
+module.exports = JestGitHubSummaryReporter;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
+const vitestReporters = process.env.CI ? ["default", "github-actions"] : ["default"];
+
 export default defineConfig({
   root: ".",
   plugins: [react()],
@@ -15,5 +17,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./tests/ui/setup.ts"],
     include: ["tests/ui/**/*.test.{ts,tsx}"],
+    reporters: vitestReporters,
   },
 });


### PR DESCRIPTION
## Summary
- Cache `~/.cache/ms-playwright` in the Integration workflow (keyed by `package-lock.json`) to avoid re-downloading Chromium/headless-shell/ffmpeg on every run.
- Append **Vitest-style** job summary sections (`##` / `### Summary` / ✅❌) for most Integration steps via `scripts/run-with-github-summary.mjs`.
- Enable Vitest **`github-actions`** reporter when `CI=true` so UI tests match the built-in “Vitest Test Report” card.
- Add a small **Jest** reporter for integration tests and enable it from `scripts/run-env.sh` when `GITHUB_STEP_SUMMARY` is set.
- Document caching + job summaries in `.github/workflows/README.md`.

## Test plan
- [ ] Integration workflow green on this PR
- [x] Local: `eslint` (pre-commit) passes
- [x] Local: `CI=true npm run test:ui` and Vitest summary smoke check