### PR TITLE
fix(dump): avoid duplicate H2 headings in protocol markdown_doc

### DIFF
--- a/src/tools/kairos_dump.ts
+++ b/src/tools/kairos_dump.ts
@@ -5,6 +5,7 @@ import { getToolDoc } from '../resources/embedded-mcp-resources.js';
 import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
 import { getTenantId, getSpaceContextFromStorage } from '../utils/tenant-context.js';
 import { extractMemoryBody } from '../utils/memory-body.js';
+import { stripRedundantStepH2 } from '../utils/dump-markdown.js';
 import { buildChallengeShapeForDisplay } from './kairos_next-pow-helpers.js';
 import { resolveChainFirstStep } from '../services/chain-utils.js';
 import { redisCacheService } from '../services/redis-cache.js';
@@ -37,17 +38,6 @@ function challengeBlock(pow: ProofOfWorkDefinition | undefined): string {
   return '\n\n```json\n' + JSON.stringify({ challenge: pow }) + '\n```';
 }
 
-/**
- * If body starts with a single line that is exactly the step's H2 (## label), strip it
- * so the protocol builder does not emit the same heading twice.
- */
-function stripLeadingH2IfMatches(body: string, label: string): string {
-  if (!body || !label) return body;
-  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const re = new RegExp(`^##\\s*${escaped}\\s*\\n+`);
-  return body.replace(re, '').trimStart();
-}
-
 function buildMarkdownDocSingle(memory: Memory): string {
   const body = extractMemoryBody(memory.text);
   return body + challengeBlock(memory.proof_of_work);
@@ -59,7 +49,7 @@ function buildMarkdownDocProtocol(memories: Memory[]): string {
   const parts: string[] = ['# ' + chainLabel];
   for (const m of memories) {
     const body = extractMemoryBody(m.text);
-    const bodyStripped = stripLeadingH2IfMatches(body, m.label);
+    const bodyStripped = stripRedundantStepH2(body, m.label);
     parts.push('## ' + m.label + '\n\n' + bodyStripped + challengeBlock(m.proof_of_work));
   }
   return parts.join('\n\n');

--- a/src/utils/dump-markdown.ts
+++ b/src/utils/dump-markdown.ts
@@ -1,0 +1,47 @@
+/**
+ * Remove a redundant H2 that matches the step label from memory body before
+ * protocol dump prepends `## {label}`.
+ *
+ * Minting derives `label` from the first `##` line in the segment (any line),
+ * but the stored body can include prose before that heading. The previous
+ * implementation only stripped when `## label` was the first line, which
+ * produced duplicate H2s in `kairos_dump` protocol output.
+ */
+export function stripRedundantStepH2(body: string, label: string): string {
+  if (!body || !label) return body;
+  const labelNorm = label.trim();
+  if (!labelNorm) return body;
+
+  const lines = body.split(/\r?\n/);
+  let inFence = false;
+  let matchIndex = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmedLine = lines[i]!.trim();
+    if (trimmedLine.startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const m = lines[i]!.match(/^\s*##\s+(.+)\s*$/);
+    if (m && m[1]!.trim() === labelNorm) {
+      matchIndex = i;
+      break;
+    }
+  }
+
+  if (matchIndex === -1) return body;
+
+  const next = [...lines.slice(0, matchIndex), ...lines.slice(matchIndex + 1)];
+  // Removing "## Title" often leaves two blank lines where one is enough
+  if (
+    matchIndex > 0 &&
+    matchIndex < next.length &&
+    next[matchIndex - 1] === '' &&
+    next[matchIndex] === ''
+  ) {
+    next.splice(matchIndex, 1);
+  }
+  return next.join('\n').trimStart();
+}

--- a/tests/unit/dump-markdown.test.ts
+++ b/tests/unit/dump-markdown.test.ts
@@ -1,0 +1,26 @@
+import { stripRedundantStepH2 } from '../../src/utils/dump-markdown.js';
+
+describe('stripRedundantStepH2', () => {
+  test('strips leading H2 matching label', () => {
+    expect(stripRedundantStepH2('## Step A\n\nBody.', 'Step A')).toBe('Body.');
+  });
+
+  test('strips first matching H2 when prose precedes it (mint label from first ## in segment)', () => {
+    const body = 'Read this first.\n\n## Do Thing\n\nThen act.';
+    expect(stripRedundantStepH2(body, 'Do Thing')).toBe('Read this first.\n\nThen act.');
+  });
+
+  test('does not strip H2 inside fenced code block', () => {
+    const body = '```markdown\n## Not Real\n```\n\n## Real\n\ntext';
+    expect(stripRedundantStepH2(body, 'Real')).toBe('```markdown\n## Not Real\n```\n\ntext');
+  });
+
+  test('does not strip when label differs', () => {
+    const body = '## Other\n\nBody';
+    expect(stripRedundantStepH2(body, 'Mine')).toBe(body);
+  });
+
+  test('handles CRLF in input', () => {
+    expect(stripRedundantStepH2('## T\r\n\r\nx', 'T')).toBe('x');
+  });
+});


### PR DESCRIPTION
## Summary

Users reported that `kairos_dump` with `protocol: true` produced markdown with duplicated `##` step headings.

## Root cause

- Step `label` is derived from the **first** `##` line anywhere in the minted segment (`stepLabelFromSegment` uses multiline matching).
- The stored body can still contain prose **before** that heading.
- Dump always prepended `## {label}` and only stripped a matching H2 when it was the **first** line of the body, so the same title appeared twice.

## Change

- Add `stripRedundantStepH2` in `src/utils/dump-markdown.ts`: fence-aware scan for the first real `##` line matching the step label, remove it once, and collapse the usual double blank left behind.
- Wire it into `buildMarkdownDocProtocol` in `kairos_dump.ts`.
- Unit tests: `tests/unit/dump-markdown.test.ts`.

## Testing

- `npx jest --runInBand tests/unit/dump-markdown.test.ts`