### PR TITLE
feat(cli): mint directory bundles; CodeQL hygiene; UI logo CSP

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,3 +10,11 @@ paths-ignore:
   - "tests/**"
   # All log/audit output is sanitized by sanitizeLogMessage/sanitizeBindingsForAudit; unit-tested. CodeQL does not model these sanitizers.
   - "src/utils/structured-logger.ts"
+
+# kairos_mint: POST body is the markdown document from the authenticated CLI (local protocol files).
+# js/file-access-to-http is a false positive here; URL is the configured API base, not attacker-controlled SSRF.
+query-filters:
+  - exclude:
+      id: js/file-access-to-http
+    paths-ignore:
+      - src/cli/api-client.ts

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -107,18 +107,34 @@ kairos next kairos://mem/<step-uuid> \
 
 ### mint — store a new document
 
-Store a new markdown document in KAIROS.
+Store a new markdown document in KAIROS. You can pass a single `.md` file, or a
+directory. For a directory, the CLI mints every `.md` file in that directory
+(non-recursive by default) and prints a JSON batch object. Use `--recursive` to
+include `.md` files in subdirectories. If any mint in a batch fails, the CLI
+still finishes the rest unless you pass `--fail-fast`; the process exits with
+status `1` when at least one file failed.
 
 ```bash
 kairos mint document.md
 kairos mint document.md --model "gpt-4"
 kairos mint document.md --model "gpt-4" --force
+kairos mint ./my-bundle --force
+kairos mint ./my-bundle --force --recursive
 ```
 
 **Options:**
 
 - `--model <model>` — LLM model ID for attribution (for example, `gpt-4`)
 - `--force` — overwrite if a chain with the same label already exists
+- `-r, --recursive` — when the path is a directory, include `.md` files in
+  subdirectories
+- `--fail-fast` — stop after the first mint error in a directory batch (default
+  is to continue and report all results)
+
+**Directory batch output:** stdout is a JSON object with `batch: true`, `root`
+(resolved directory path), and `results`: an array of per-file outcomes. Each
+success entry includes `ok: true`, `status`, and `items` (same shape as a
+single-file mint). Each failure includes `ok: false` and `error`.
 
 ### update — update memories
 
@@ -232,6 +248,7 @@ kairos search "coding standards"
 kairos begin kairos://mem/xxx
 kairos next kairos://mem/xxx --follow
 kairos mint my-protocol.md --model "claude-3" --force
+kairos mint ./exported-protocols --model "claude-3" --force --recursive
 kairos update kairos://mem/xxx --file updated-content.md
 kairos delete kairos://mem/xxx
 kairos attest kairos://mem/xxx success "All steps completed"

--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -136,7 +136,6 @@ export class ApiClient {
             headers['x-force-update'] = 'true';
         }
 
-        // codeql[js/file-access-to-http]: kairos_mint contract — POST body is the markdown document supplied by the authenticated caller (CLI reads local protocol files). Not an exfiltration channel; URL is this client's configured API base.
         const response = await fetch(url, {
             method: 'POST',
             headers,

--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -136,6 +136,7 @@ export class ApiClient {
             headers['x-force-update'] = 'true';
         }
 
+        // codeql[js/file-access-to-http]: kairos_mint contract — POST body is the markdown document supplied by the authenticated caller (CLI reads local protocol files). Not an exfiltration channel; URL is this client's configured API base.
         const response = await fetch(url, {
             method: 'POST',
             headers,

--- a/src/cli/commands/mint.ts
+++ b/src/cli/commands/mint.ts
@@ -3,38 +3,151 @@
  */
 
 import { Command } from 'commander';
-import { readFileSync } from 'fs';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
 import { ApiClient } from '../api-client.js';
 import { handleApiError } from '../auth-error.js';
 import { writeError, writeJson } from '../output.js';
+import type { MintOutput } from '../../tools/kairos_mint_schema.js';
+
+function isMdFileName(name: string): boolean {
+    return name.endsWith('.md');
+}
+
+/** Absolute paths to `.md` regular files under root, sorted lexicographically. */
+function collectMdFiles(absRoot: string, recursive: boolean): string[] {
+    if (!recursive) {
+        const dirents = readdirSync(absRoot, { withFileTypes: true });
+        const paths: string[] = [];
+        for (const d of dirents) {
+            if (!d.isFile() || !isMdFileName(d.name)) continue;
+            paths.push(join(absRoot, d.name));
+        }
+        return paths.sort((a, b) => a.localeCompare(b));
+    }
+
+    const relEntries = readdirSync(absRoot, { recursive: true }) as string[];
+    const paths: string[] = [];
+    for (const rel of relEntries) {
+        if (!rel || !isMdFileName(rel)) continue;
+        const full = join(absRoot, rel);
+        let st;
+        try {
+            st = statSync(full);
+        } catch {
+            continue;
+        }
+        if (!st.isFile()) continue;
+        paths.push(full);
+    }
+    return paths.sort((a, b) => a.localeCompare(b));
+}
+
+type BatchEntry =
+    | { path: string; ok: true; status: 'stored'; items: MintOutput['items'] }
+    | { path: string; ok: false; error: string };
+
+function jsonPathForResult(absRoot: string, filePath: string): string {
+    return relative(absRoot, filePath).split('\\').join('/');
+}
 
 export function mintCommand(program: Command): void {
     program
         .command('mint')
-        .description('Store a new markdown document in KAIROS')
-        .argument('<file>', 'Path to markdown file')
+        .description('Store a new markdown document in KAIROS (file, or directory of .md files)')
+        .argument('<path>', 'Path to a markdown file or a directory of .md files')
         .option('--model <model>', 'LLM model ID for attribution (e.g., "gpt-4", "claude-3")')
         .option('--force', 'Force update if a memory chain with the same label already exists')
-        .action(async (file: string, options: { model?: string; force?: boolean }) => {
-            try {
-                const markdown = readFileSync(file, 'utf-8');
-                const client = new ApiClient(undefined, !program.opts()['noBrowser']);
-                const mintOptions: { llmModelId?: string; force?: boolean } = {};
-                if (options.model) {
-                    mintOptions.llmModelId = options.model;
-                }
-                if (options.force) {
-                    mintOptions.force = options.force;
-                }
-                const response = await client.mint(markdown, mintOptions);
-                writeJson(response);
-            } catch (error) {
-                if (error instanceof Error && error.message.includes('ENOENT')) {
-                    writeError(`File not found: ${file}`);
-                    process.exit(1);
-                }
-                handleApiError(error, !program.opts()['noBrowser']);
-            }
-        });
-}
+        .option('-r, --recursive', 'When path is a directory, include .md files in subdirectories')
+        .option('--fail-fast', 'Stop on first mint error (default: mint all files, exit 1 if any failed)')
+        .action(
+            async (
+                inputPath: string,
+                options: { model?: string; force?: boolean; recursive?: boolean; failFast?: boolean }
+            ) => {
+                const openBrowser = !program.opts()['noBrowser'];
+                try {
+                    let st;
+                    try {
+                        st = statSync(inputPath);
+                    } catch (e) {
+                        if (e instanceof Error && 'code' in e && (e as NodeJS.ErrnoException).code === 'ENOENT') {
+                            writeError(`Path not found: ${inputPath}`);
+                            process.exit(1);
+                        }
+                        throw e;
+                    }
 
+                    const mintOptions: { llmModelId?: string; force?: boolean } = {};
+                    if (options.model) {
+                        mintOptions.llmModelId = options.model;
+                    }
+                    if (options.force) {
+                        mintOptions.force = options.force;
+                    }
+
+                    const client = new ApiClient(undefined, openBrowser);
+
+                    if (st.isFile()) {
+                        const markdown = readFileSync(inputPath, 'utf-8');
+                        const response = await client.mint(markdown, mintOptions);
+                        writeJson(response);
+                        return;
+                    }
+
+                    if (!st.isDirectory()) {
+                        writeError(`Not a file or directory: ${inputPath}`);
+                        process.exit(1);
+                    }
+
+                    const absRoot = resolve(inputPath);
+                    const mdFiles = collectMdFiles(absRoot, Boolean(options.recursive));
+                    if (mdFiles.length === 0) {
+                        writeError(`No .md files in ${inputPath}`);
+                        process.exit(1);
+                    }
+
+                    const results: BatchEntry[] = [];
+                    let anyFailed = false;
+                    const failFast = Boolean(options.failFast);
+
+                    for (const filePath of mdFiles) {
+                        const relPath = jsonPathForResult(absRoot, filePath);
+                        try {
+                            const markdown = readFileSync(filePath, 'utf-8');
+                            const response = await client.mint(markdown, mintOptions);
+                            results.push({
+                                path: relPath,
+                                ok: true,
+                                status: response.status,
+                                items: response.items
+                            });
+                        } catch (error) {
+                            const message = error instanceof Error ? error.message : String(error);
+                            results.push({ path: relPath, ok: false, error: message });
+                            anyFailed = true;
+                            if (failFast) {
+                                break;
+                            }
+                        }
+                    }
+
+                    writeJson({
+                        batch: true,
+                        root: absRoot,
+                        results
+                    });
+
+                    if (anyFailed) {
+                        process.exit(1);
+                    }
+                } catch (error) {
+                    if (error instanceof Error && error.message.includes('ENOENT')) {
+                        writeError(`File not found: ${inputPath}`);
+                        process.exit(1);
+                    }
+                    handleApiError(error, openBrowser);
+                }
+            }
+        );
+}

--- a/src/cli/commands/mint.ts
+++ b/src/cli/commands/mint.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from 'commander';
-import { readdirSync, readFileSync, statSync } from 'fs';
+import { closeSync, fstatSync, openSync, readFileSync, readdirSync } from 'fs';
 import { join, relative, resolve } from 'path';
 import { ApiClient } from '../api-client.js';
 import { handleApiError } from '../auth-error.js';
@@ -14,13 +14,29 @@ function isMdFileName(name: string): boolean {
     return name.endsWith('.md');
 }
 
-/** Absolute paths to `.md` regular files under root, sorted lexicographically. */
+/**
+ * Open path read-only, require regular file, read UTF-8 from the same fd
+ * (avoids path-based stat-then-read races; CodeQL js/file-system-race).
+ */
+function readRegularFileUtf8(absPath: string): string {
+    const fd = openSync(absPath, 'r');
+    try {
+        if (!fstatSync(fd).isFile()) {
+            throw Object.assign(new Error('Path is not a regular file'), { code: 'ENOTREG' });
+        }
+        return readFileSync(fd, 'utf-8') as string;
+    } finally {
+        closeSync(fd);
+    }
+}
+
+/** Absolute paths to `.md` names under root, sorted lexicographically (presence as file verified at read time). */
 function collectMdFiles(absRoot: string, recursive: boolean): string[] {
     if (!recursive) {
         const dirents = readdirSync(absRoot, { withFileTypes: true });
         const paths: string[] = [];
         for (const d of dirents) {
-            if (!d.isFile() || !isMdFileName(d.name)) continue;
+            if (!isMdFileName(d.name)) continue;
             paths.push(join(absRoot, d.name));
         }
         return paths.sort((a, b) => a.localeCompare(b));
@@ -30,15 +46,7 @@ function collectMdFiles(absRoot: string, recursive: boolean): string[] {
     const paths: string[] = [];
     for (const rel of relEntries) {
         if (!rel || !isMdFileName(rel)) continue;
-        const full = join(absRoot, rel);
-        let st;
-        try {
-            st = statSync(full);
-        } catch {
-            continue;
-        }
-        if (!st.isFile()) continue;
-        paths.push(full);
+        paths.push(join(absRoot, rel));
     }
     return paths.sort((a, b) => a.localeCompare(b));
 }
@@ -67,9 +75,9 @@ export function mintCommand(program: Command): void {
             ) => {
                 const openBrowser = !program.opts()['noBrowser'];
                 try {
-                    let st;
+                    let fd: number;
                     try {
-                        st = statSync(inputPath);
+                        fd = openSync(inputPath, 'r');
                     } catch (e) {
                         if (e instanceof Error && 'code' in e && (e as NodeJS.ErrnoException).code === 'ENOENT') {
                             writeError(`Path not found: ${inputPath}`);
@@ -77,6 +85,14 @@ export function mintCommand(program: Command): void {
                         }
                         throw e;
                     }
+
+                    let fdClosed = false;
+                    const closeFd = (): void => {
+                        if (!fdClosed) {
+                            closeSync(fd);
+                            fdClosed = true;
+                        }
+                    };
 
                     const mintOptions: { llmModelId?: string; force?: boolean } = {};
                     if (options.model) {
@@ -88,16 +104,24 @@ export function mintCommand(program: Command): void {
 
                     const client = new ApiClient(undefined, openBrowser);
 
-                    if (st.isFile()) {
-                        const markdown = readFileSync(inputPath, 'utf-8');
-                        const response = await client.mint(markdown, mintOptions);
-                        writeJson(response);
-                        return;
-                    }
-
-                    if (!st.isDirectory()) {
-                        writeError(`Not a file or directory: ${inputPath}`);
-                        process.exit(1);
+                    try {
+                        const fst = fstatSync(fd);
+                        if (fst.isFile()) {
+                            const markdown = readFileSync(fd, 'utf-8');
+                            closeFd();
+                            const response = await client.mint(markdown, mintOptions);
+                            writeJson(response);
+                            return;
+                        }
+                        if (!fst.isDirectory()) {
+                            closeFd();
+                            writeError(`Not a file or directory: ${inputPath}`);
+                            process.exit(1);
+                        }
+                        closeFd();
+                    } catch (err) {
+                        closeFd();
+                        throw err;
                     }
 
                     const absRoot = resolve(inputPath);
@@ -114,7 +138,7 @@ export function mintCommand(program: Command): void {
                     for (const filePath of mdFiles) {
                         const relPath = jsonPathForResult(absRoot, filePath);
                         try {
-                            const markdown = readFileSync(filePath, 'utf-8');
+                            const markdown = readRegularFileUtf8(filePath);
                             const response = await client.mint(markdown, mintOptions);
                             results.push({
                                 path: relPath,

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -126,7 +126,7 @@ Create protocols from generic to detailed. The generic chain comes first and mus
 
 **Slug convention — deterministic protocol linking:**
 
-Every protocol gets a `slug` — a short, unique, lowercase-hyphenated key for deterministic linking. The engine auto-generates it from the H1 title. Add explicit `slug:` frontmatter only when the auto-generated value is too long or ambiguous.
+Every protocol gets a `slug` — a short, unique, lowercase-hyphenated key for deterministic linking via `kairos_begin(key: "slug")`. The engine auto-generates it from the H1 title. Add explicit `slug:` frontmatter only when the auto-generated value is too long or ambiguous.
 
 ```yaml
 ---
@@ -135,9 +135,31 @@ slug: jira-markdown-formatting
 # Jira Description Markdown Formatting via MCP
 ```
 
-- Use `kairos_begin(key: "slug")` for protocol-to-protocol routing (deterministic, exact match).
-- Use `kairos_search` only for user discovery (Natural Language Triggers) and runtime type-dispatch where the target depends on a variable.
-- Router slug matches the family prefix: `compose`, `create-jira-ticket-in-bib`, `standardize-project`.
+**When to use slugs vs. search:**
+
+- `kairos_begin(key: "slug")` — protocol-to-protocol routing (deterministic, exact match). Use when the author knows the target at write time.
+- `kairos_search` — user discovery (Natural Language Triggers) and runtime type-dispatch where the target depends on a runtime variable (e.g., `kairos_search("Standardize {project_type}")`).
+
+**Slug naming rules:**
+
+1. **Families (router + extensions):** hierarchical. The router slug is the family prefix. Each child expands the parent by one hyphenated segment per routing level:
+   - `jira` → `jira-bib` → `jira-bib-bug`
+   - `compose` → `compose-email`
+   - `standardize` → `standardize-analyze`
+   - An agent can derive the parent slug by stripping the last segment. This enables mechanical traversal without search.
+
+2. **Standalone protocols (no family):** action-oriented. Describe what the protocol does, not where it lives. The bundle directory is the namespace — the slug does not repeat it.
+   - Good: `create-merge-request`, `makefile-setup`, `migrate-tf-to-git-sha`
+   - Bad: `gitlab-create-merge-request` (redundant — it's already in `gitlab/`)
+
+3. **Shared utilities:** prefix with the family they serve, at the family root level:
+   - `jira-markdown-formatting` (used by all `jira-*` children)
+   - `jira-alternative-mcp-unavailable`
+
+4. **General rules:**
+   - Lowercase, hyphen-separated. No underscores, no camelCase.
+   - Short as possible while remaining unambiguous. Target 2–4 segments.
+   - The slug is a technical address — Natural Language Triggers handle discoverability. The slug does not need to sound like a sentence.
 
 **Protocol structure rules:**
 

--- a/src/ui/components/Layout.tsx
+++ b/src/ui/components/Layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Outlet, NavLink, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
+/** Emitted as `/ui/assets/*.svg` — `build.assetsInlineLimit: 0` so Helmet `img-src 'self'` allows it. */
 import logoSvg from "../../../logo/kaiiros-mcp.svg";
 
 const isWideContentRoute = (path: string) =>

--- a/tests/integration/cli-mint-batch.test.ts
+++ b/tests/integration/cli-mint-batch.test.ts
@@ -1,0 +1,149 @@
+/**
+ * CLI mint batch: directory and --recursive
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  execAsync,
+  BASE_URL,
+  CLI_PATH,
+  setupServerCheck,
+  setupCliConfigWithLogin
+} from './cli-commands-shared.js';
+
+function minimalProtocolMd(title: string): string {
+  return `# ${title}
+
+## Natural Language Triggers
+
+Run when user says "${title}".
+
+## Step 1: Setup
+
+Basic setup.
+
+\`\`\`json
+{"challenge":{"type":"shell","shell":{"cmd":"echo ok","timeout_seconds":5},"required":true}}
+\`\`\`
+
+## Completion Rule
+
+Done.
+`;
+}
+
+describe('CLI mint directory batch', () => {
+  let serverAvailable = false;
+  let cliLoggedIn = false;
+
+  beforeAll(async () => {
+    serverAvailable = await setupServerCheck();
+    cliLoggedIn = await setupCliConfigWithLogin();
+  }, 60000);
+
+  test('mint directory mints all root .md files and returns batch JSON', async () => {
+    if (!serverAvailable || !cliLoggedIn) return;
+
+    const ts = Date.now();
+    const dir = mkdtempSync(join(tmpdir(), 'kairos-mint-batch-'));
+    try {
+      writeFileSync(join(dir, 'z-second.md'), minimalProtocolMd(`CLI Batch Z ${ts}`), 'utf-8');
+      writeFileSync(join(dir, 'a-first.md'), minimalProtocolMd(`CLI Batch A ${ts}`), 'utf-8');
+
+      const { stdout, stderr } = await execAsync(
+        `node ${CLI_PATH} mint --url ${BASE_URL} --force "${dir}"`,
+        { timeout: 120000 }
+      );
+
+      expect(stderr).toBe('');
+      const result = JSON.parse(stdout) as {
+        batch: boolean;
+        root: string;
+        results: Array<{ path: string; ok: boolean; status?: string; items?: unknown[]; error?: string }>;
+      };
+      expect(result.batch).toBe(true);
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0]!.path).toBe('a-first.md');
+      expect(result.results[1]!.path).toBe('z-second.md');
+      expect(result.results.every(r => r.ok)).toBe(true);
+      expect(result.results.every(r => r.status === 'stored')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  test('mint --recursive includes nested .md files', async () => {
+    if (!serverAvailable || !cliLoggedIn) return;
+
+    const ts = Date.now();
+    const dir = mkdtempSync(join(tmpdir(), 'kairos-mint-rec-'));
+    try {
+      mkdirSync(join(dir, 'nested'), { recursive: true });
+      writeFileSync(join(dir, 'root.md'), minimalProtocolMd(`CLI Rec Root ${ts}`), 'utf-8');
+      writeFileSync(join(dir, 'nested', 'deep.md'), minimalProtocolMd(`CLI Rec Deep ${ts}`), 'utf-8');
+
+      const { stdout, stderr } = await execAsync(
+        `node ${CLI_PATH} mint --url ${BASE_URL} --force --recursive "${dir}"`,
+        { timeout: 120000 }
+      );
+
+      expect(stderr).toBe('');
+      const result = JSON.parse(stdout) as {
+        batch: boolean;
+        results: Array<{ path: string; ok: boolean }>;
+      };
+      expect(result.batch).toBe(true);
+      expect(result.results).toHaveLength(2);
+      const paths = result.results.map(r => r.path).sort();
+      expect(paths).toEqual(['nested/deep.md', 'root.md']);
+      expect(result.results.every(r => r.ok)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  test('mint without --recursive skips nested .md', async () => {
+    if (!serverAvailable || !cliLoggedIn) return;
+
+    const ts = Date.now();
+    const dir = mkdtempSync(join(tmpdir(), 'kairos-mint-flat-'));
+    try {
+      mkdirSync(join(dir, 'nested'), { recursive: true });
+      writeFileSync(join(dir, 'only-root.md'), minimalProtocolMd(`CLI Flat Root ${ts}`), 'utf-8');
+      writeFileSync(join(dir, 'nested', 'skip.md'), minimalProtocolMd(`CLI Flat Skip ${ts}`), 'utf-8');
+
+      const { stdout, stderr } = await execAsync(
+        `node ${CLI_PATH} mint --url ${BASE_URL} --force "${dir}"`,
+        { timeout: 120000 }
+      );
+
+      expect(stderr).toBe('');
+      const result = JSON.parse(stdout) as { batch: boolean; results: unknown[] };
+      expect(result.batch).toBe(true);
+      expect(result.results).toHaveLength(1);
+      expect((result.results[0] as { path: string }).path).toBe('only-root.md');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  test('mint empty directory exits with error', async () => {
+    if (!serverAvailable || !cliLoggedIn) return;
+
+    const dir = mkdtempSync(join(tmpdir(), 'kairos-mint-empty-'));
+    try {
+      try {
+        await execAsync(`node ${CLI_PATH} mint --url ${BASE_URL} "${dir}"`, { timeout: 30000 });
+        expect(true).toBe(false);
+      } catch (e: unknown) {
+        const err = e as { code?: number; stderr?: string };
+        expect(err.code).toBe(1);
+        expect(String(err.stderr ?? '')).toMatch(/No \.md files/);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60000);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     },
   },
   build: {
+    /** CSP sets `img-src 'self'` (helmet). Inlined `data:image/*` logos are blocked — emit assets as /ui/assets/* URLs. */
+    assetsInlineLimit: 0,
     outDir: path.resolve(__dirname, "dist/ui"),
     emptyOutDir: true,
     chunkSizeWarningLimit: 600,


### PR DESCRIPTION
## Summary

- **CLI:** `kairos mint` accepts a directory of `.md` files (sorted), optional `--recursive` and `--fail-fast`; batch JSON on stdout; integration tests when server + CLI login are available.
- **Security / CodeQL:** Safer directory mint reads; CodeQL config excludes false-positive `js/file-access-to-http` on CLI mint client.
- **UI:** Helmet sets `img-src 'self'`; Vite was inlining the sidebar SVG as `data:`, which the browser blocked. Set `build.assetsInlineLimit: 0` so the logo is served under `/ui/assets/*.svg`.

## Test plan

- [ ] `npm run ui:build` (logo emitted as `.svg` asset, not `data:`)
- [ ] `npm run test:ui`
- [ ] `npm run dev:deploy && npm run dev:test` (or targeted integration tests)