### PR TITLE
fix(mcp): create-new-protocol challenge types + kairos-bug-fix skill

### DIFF
--- a/.cursor/skills/kairos-bug-fix/SKILL.md
+++ b/.cursor/skills/kairos-bug-fix/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: kairos-bug-fix
+description: "Runs end-to-end bug fix for kairos-mcp from a bug report: reproduce on KAIROS live MCP, add a failing dev test, implement fix, deploy and test dev, open PR, monitor CI, iterate until green, then report merge-ready. Use when fixing KAIROS MCP bugs, working from reports/mcp-bug-*.md, or when the user asks for the KAIROS bug-fix workflow."
+---
+
+# KAIROS bug fix (from bug report)
+
+**Input:** A bug report (path under `reports/` or pasted content). If none exists yet, use the **mcp-bug-report** agent skill only to **capture** the incident; this skill owns **fixing** it.
+
+**Authority:** Tool behavior on **live** is authoritative for “does the bug exist?” Local code and tests prove regression coverage after the fix.
+
+---
+
+## Flow (execute in order; loop where noted)
+
+### 1. Confirm on KAIROS live MCP
+
+- Read the bug report: tool name, arguments, expected vs actual, reproduction steps.
+- **Reproduce using the live MCP server** (connected KAIROS tools), not by inferring from `src/` alone. Read each tool’s schema under the host’s MCP descriptors before calling.
+- If live behavior matches the report → proceed. If not, stop and reconcile (stale report, env mismatch, or different server); do not “fix” code for an unconfirmed symptom.
+
+### 2. Failing test in dev
+
+- Add an **automated** test under `tests/` (or extend an existing one) that **fails on current main** and encodes the bug (minimal, deterministic).
+- Run **only** that test against dev stack if practical, or run the narrowest `npm run` / vitest filter the repo supports, until the new test fails for the right reason.
+
+### 3. Fix and confirm with tests
+
+- Implement the minimal code change that addresses the root cause.
+- Run the new test until it passes; run related tests if the change touches shared code.
+
+### 4. Build and deploy dev
+
+From repo root:
+
+```bash
+npm run dev:deploy && npm run dev:test
+```
+
+If the project’s full gate is required (per change scope), use `npm test` per [AGENTS.md](../../../AGENTS.md) / [CLAUDE.md](../../../CLAUDE.md) guidance.
+
+### 5. Commit, push, PR
+
+- Branch: `fix/<short-topic>` or team convention.
+- Commit with a clear message (what broke, what changed).
+- Push and open PR to `main` (`gh pr create` or equivalent).
+
+### 6. Monitor if the PR succeeded
+
+- Watch required checks (e.g. `gh pr checks <number> --watch`, or the Actions UI).
+
+### 7. On failure → return to step 3
+
+- If CI fails, fix code or tests, push, and repeat from **step 3** until checks pass or the user stops.
+
+### 8. Report merge-ready
+
+When CI is green, give the user a short **merge-ready** summary:
+
+- Bug (one line) and confirmation it reproduced on live MCP.
+- Test added (file + what it asserts).
+- Fix (files / behavior).
+- Verification: `dev:deploy` + `dev:test` (and anything else run).
+- PR link and status (checks green).
+
+---
+
+## MUST / MUST NOT
+
+**MUST**
+
+- Treat live MCP reproduction as the gate before coding.
+- Add a regression test before or alongside the fix (test must fail pre-fix when possible).
+- Redact secrets in any pasted logs or PR text.
+
+**MUST NOT**
+
+- Close the loop on “looks fixed in code” without dev deploy + automated test signal.
+- Compute or guess KAIROS challenge fields (`proof_hash`, `nonce`, run IDs); always echo server values per product rules.
+
+---
+
+## Optional reference
+
+- Bug report template and filename rules: `reports/mcp-bug-*.md` (see mcp-bug-report skill when drafting).

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -186,12 +186,12 @@ slug: jira-markdown-formatting
 | `mcp` | Agent must call a specific tool | Tool called successfully |
 | `shell` | Agent must run a command | Exit code 0 |
 
-**Challenge JSON format** (place at end of each step):
+**Challenge JSON format** (place at end of each step). Use a **single** concrete `type` per step (`comment`, `user_input`, `mcp`, or `shell`). Do not use pipe-separated placeholders inside `type` — each ` ```json ` block with `{"challenge":...}` becomes its own chain step when minted.
 
-```json
+```text
 {
   "challenge": {
-    "type": "comment|user_input|mcp|shell",
+    "type": "comment",
     "comment": { "min_length": 50 },
     "required": true
   }

--- a/src/services/memory/validate-protocol-structure.ts
+++ b/src/services/memory/validate-protocol-structure.ts
@@ -19,6 +19,9 @@ const MISSING_COMPLETION_RULE = 'completion_rule';
 const MISSING_H1 = 'h1_title';
 const MISSING_CHALLENGE_BLOCK = 'challenge_block';
 const MIXED_CHALLENGE_FENCES = 'mixed_challenge_fences';
+const INVALID_CHALLENGE_TYPE = 'invalid_challenge_type';
+
+const ALLOWED_CHALLENGE_TYPES = new Set(['shell', 'mcp', 'user_input', 'comment']);
 
 /**
  * Extract H1 and H2 headings from markdown, ignoring lines inside fenced code blocks.
@@ -142,6 +145,15 @@ export function validateProtocolStructure(markdownDoc: string): ValidationResult
     missing.push(MISSING_CHALLENGE_BLOCK);
   }
 
+  for (const block of challengeBlocks) {
+    const t = block.proof.type;
+    if (t === undefined) continue;
+    if (typeof t !== 'string' || !ALLOWED_CHALLENGE_TYPES.has(t)) {
+      missing.push(INVALID_CHALLENGE_TYPE);
+      break;
+    }
+  }
+
   const valid = missing.length === 0;
   let message: string;
   if (valid) {
@@ -153,6 +165,9 @@ export function validateProtocolStructure(markdownDoc: string): ValidationResult
       if (m === MISSING_COMPLETION_RULE) return 'Completion Rule (last H2)';
       if (m === MISSING_CHALLENGE_BLOCK) return 'at least one ```json challenge block';
       if (m === MIXED_CHALLENGE_FENCES) return 'use only ```json for challenge blocks (no plain ``` with challenge)';
+      if (m === INVALID_CHALLENGE_TYPE) {
+        return 'each ```json challenge must set type to exactly shell, mcp, user_input, or comment (no placeholders or combined values)';
+      }
       return m;
     });
     message = `Protocol is missing required structure: ${parts.join(', ')}. Run the creation protocol for guided help.`;

--- a/src/tools/kairos-challenge-display.ts
+++ b/src/tools/kairos-challenge-display.ts
@@ -1,0 +1,50 @@
+import type { ProofOfWorkDefinition, ProofOfWorkType } from '../types/memory.js';
+import { structuredLogger } from '../utils/structured-logger.js';
+import { GENESIS_HASH } from './kairos-genesis-proof-hash.js';
+
+function isAllowedStoredChallengeType(t: unknown): t is ProofOfWorkType {
+  return t === 'shell' || t === 'mcp' || t === 'user_input' || t === 'comment';
+}
+
+/** Build challenge shape from proof only (no nonce, no store). For read-only display e.g. kairos_dump. */
+export function buildChallengeShapeForDisplay(proof?: ProofOfWorkDefinition): Record<string, unknown> {
+  const base: Record<string, unknown> = proof ? (() => {
+    let proofType: ProofOfWorkType;
+    if (proof.type === undefined) {
+      proofType = 'shell';
+    } else if (isAllowedStoredChallengeType(proof.type)) {
+      proofType = proof.type;
+    } else {
+      structuredLogger.warn(
+        { event: 'invalid_stored_challenge_type', storedType: proof.type },
+        'Invalid proof_of_work.type in stored step; coercing to comment for MCP output schema compliance'
+      );
+      proofType = 'comment';
+    }
+    const result: Record<string, unknown> = { type: proofType, description: '' };
+    if (proofType === 'shell') {
+      const cmd = proof.shell?.cmd || proof.cmd || 'No command specified';
+      const timeout = proof.shell?.timeout_seconds || proof.timeout_seconds || 30;
+      result['description'] = `Execute shell command: ${cmd}. You MUST actually run this command and report the real exit_code/stdout/stderr; do not fabricate.`;
+      result['shell'] = { cmd, timeout_seconds: timeout };
+    } else if (proofType === 'mcp') {
+      const toolName = proof.mcp?.tool_name || 'No tool specified';
+      result['description'] = `Call MCP tool: ${toolName}. You MUST actually call this tool and report its real result; do not fabricate.`;
+      result['mcp'] = { tool_name: toolName, expected_result: proof.mcp?.expected_result };
+    } else if (proofType === 'user_input') {
+      const prompt = proof.user_input?.prompt || 'Confirm completion';
+      result['description'] = `User confirmation: ${prompt}. You MUST show this prompt to the user and use only their reply as user_input.confirmation; do not assume or invent it.`;
+      result['user_input'] = { prompt };
+    } else if (proofType === 'comment') {
+      const minLength = proof.comment?.min_length || 10;
+      result['description'] = `Provide a verification comment (minimum ${minLength} characters) that genuinely summarises what was done in this step; do not paste unrelated text.`;
+      result['comment'] = { min_length: minLength };
+    }
+    return result;
+  })() : {
+    type: 'comment' as ProofOfWorkType,
+    description: 'Provide a verification comment describing how you completed this step. Write a genuine summary; do not paste unrelated text.'
+  };
+  base['proof_hash'] = GENESIS_HASH;
+  return base;
+}

--- a/src/tools/kairos-genesis-proof-hash.ts
+++ b/src/tools/kairos-genesis-proof-hash.ts
@@ -1,0 +1,4 @@
+import crypto from 'node:crypto';
+
+/** Hash used as proof_hash for step 1 (no prior proof). */
+export const GENESIS_HASH = crypto.createHash('sha256').update('genesis').digest('hex');

--- a/src/tools/kairos_next-pow-helpers.ts
+++ b/src/tools/kairos_next-pow-helpers.ts
@@ -4,12 +4,13 @@ import { proofOfWorkStore, MAX_RETRIES, type ProofOfWorkResultRecord } from '../
 import { embeddingService } from '../services/embedding/service.js';
 import { extractMemoryBody } from '../utils/memory-body.js';
 import { COMMENT_SEMANTIC_VALIDATION_TIMEOUT_MS } from '../config.js';
+import { buildChallengeShapeForDisplay } from './kairos-challenge-display.js';
+
+export { GENESIS_HASH } from './kairos-genesis-proof-hash.js';
+export { buildChallengeShapeForDisplay };
 
 /** Minimum cosine similarity for comment proof to pass semantic validation. Reject if below. */
 const COMMENT_SEMANTIC_THRESHOLD = 0.25;
-
-/** Hash used as proof_hash for step 1 (no prior proof). */
-export const GENESIS_HASH = crypto.createHash('sha256').update('genesis').digest('hex');
 
 function hashProofRecord(record: ProofOfWorkResultRecord): string {
   const canonical = JSON.stringify(record, Object.keys(record).sort());
@@ -44,38 +45,6 @@ export type ProofOfWorkSubmission = {
     text: string;
   };
 };
-
-/** Build challenge shape from proof only (no nonce, no store). For read-only display e.g. kairos_dump. */
-export function buildChallengeShapeForDisplay(proof?: ProofOfWorkDefinition): Record<string, unknown> {
-  const base: Record<string, unknown> = proof ? (() => {
-    const proofType: ProofOfWorkType = proof.type || 'shell';
-    const result: Record<string, unknown> = { type: proofType, description: '' };
-    if (proofType === 'shell') {
-      const cmd = proof.shell?.cmd || proof.cmd || 'No command specified';
-      const timeout = proof.shell?.timeout_seconds || proof.timeout_seconds || 30;
-      result['description'] = `Execute shell command: ${cmd}. You MUST actually run this command and report the real exit_code/stdout/stderr; do not fabricate.`;
-      result['shell'] = { cmd, timeout_seconds: timeout };
-    } else if (proofType === 'mcp') {
-      const toolName = proof.mcp?.tool_name || 'No tool specified';
-      result['description'] = `Call MCP tool: ${toolName}. You MUST actually call this tool and report its real result; do not fabricate.`;
-      result['mcp'] = { tool_name: toolName, expected_result: proof.mcp?.expected_result };
-    } else if (proofType === 'user_input') {
-      const prompt = proof.user_input?.prompt || 'Confirm completion';
-      result['description'] = `User confirmation: ${prompt}. You MUST show this prompt to the user and use only their reply as user_input.confirmation; do not assume or invent it.`;
-      result['user_input'] = { prompt };
-    } else if (proofType === 'comment') {
-      const minLength = proof.comment?.min_length || 10;
-      result['description'] = `Provide a verification comment (minimum ${minLength} characters) that genuinely summarises what was done in this step; do not paste unrelated text.`;
-      result['comment'] = { min_length: minLength };
-    }
-    return result;
-  })() : {
-    type: 'comment' as ProofOfWorkType,
-    description: 'Provide a verification comment describing how you completed this step. Write a genuine summary; do not paste unrelated text.'
-  };
-  base['proof_hash'] = GENESIS_HASH;
-  return base;
-}
 
 export type BuildChallengeOptions = {
   /** When set, use this nonce and do not overwrite the stored nonce (e.g. for error responses so retry count is preserved). */

--- a/tests/integration/kairos-mint-validation.test.ts
+++ b/tests/integration/kairos-mint-validation.test.ts
@@ -55,6 +55,40 @@ Done.`;
     expect(body.message).toMatch(/Natural Language Triggers|required structure/i);
   });
 
+  test('kairos_mint returns PROTOCOL_STRUCTURE_INVALID for invalid challenge type placeholder', async () => {
+    const badTypeMd = `# Bad Type Protocol ${Date.now()}
+
+## Natural Language Triggers
+
+Run when testing invalid challenge types.
+
+## Step 1
+
+Bad illustrative type.
+
+\`\`\`json
+{"challenge":{"type":"comment|user_input|mcp|shell","comment":{"min_length":10},"required":true}}
+\`\`\`
+
+## Completion Rule
+
+Done.`;
+
+    const result = await mcpConnection.client.callTool({
+      name: 'kairos_mint',
+      arguments: {
+        markdown_doc: badTypeMd,
+        llm_model_id: 'minimax/minimax-m2:free'
+      }
+    });
+
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe('PROTOCOL_STRUCTURE_INVALID');
+    expect(body.missing).toContain('invalid_challenge_type');
+    expect(body.message).toMatch(/shell, mcp, user_input, or comment/i);
+  });
+
   test('kairos_mint stores valid markdown with required sections (no regression)', async () => {
     const validMd = `# Valid Protocol ${Date.now()}
 

--- a/tests/unit/chain-builder-proof.test.ts
+++ b/tests/unit/chain-builder-proof.test.ts
@@ -3,7 +3,11 @@
  * Tests that only line-start ```json blocks are parsed as steps.
  */
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { findAllChallengeBlocks } from '../../src/services/memory/chain-builder-proof.js';
+
+const ALLOWED = new Set(['shell', 'mcp', 'user_input', 'comment']);
 
 describe('chain-builder-proof', () => {
   describe('findAllChallengeBlocks', () => {
@@ -129,6 +133,18 @@ Suffix text`;
       
       expect(beforeBlock.trim()).toBe('Prefix text');
       expect(afterBlock.trim()).toBe('Suffix text');
+    });
+
+    test('embedded create-new-protocol has only valid challenge types and expected step count', () => {
+      const md = readFileSync(
+        join(process.cwd(), 'src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md'),
+        'utf8'
+      );
+      const results = findAllChallengeBlocks(md);
+      expect(results).toHaveLength(5);
+      for (const r of results) {
+        expect(ALLOWED.has(String(r.proof.type))).toBe(true);
+      }
     });
   });
 });

--- a/tests/unit/kairos-next-pow-helpers-display.test.ts
+++ b/tests/unit/kairos-next-pow-helpers-display.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for buildChallengeShapeForDisplay: MCP output schema safety for stored proofs.
+ */
+
+import { describe, expect, jest, test } from '@jest/globals';
+import { buildChallengeShapeForDisplay } from '../../src/tools/kairos-challenge-display.js';
+import { structuredLogger } from '../../src/utils/structured-logger.js';
+
+describe('buildChallengeShapeForDisplay', () => {
+  test('undefined type defaults to shell challenge shape', () => {
+    const shape = buildChallengeShapeForDisplay({
+      required: true,
+      shell: { cmd: 'echo hi', timeout_seconds: 5 }
+    } as any);
+    expect(shape.type).toBe('shell');
+    expect(shape.shell).toMatchObject({ cmd: 'echo hi', timeout_seconds: 5 });
+    expect(String(shape.description)).toContain('shell');
+  });
+
+  test('invalid stored type is coerced to comment with valid schema fields', () => {
+    const warn = jest.spyOn(structuredLogger, 'warn').mockImplementation(() => {});
+
+    const shape = buildChallengeShapeForDisplay({
+      type: 'comment|user_input|mcp|shell' as any,
+      required: true,
+      comment: { min_length: 50 }
+    } as any);
+
+    expect(shape.type).toBe('comment');
+    expect(shape.comment).toEqual({ min_length: 50 });
+    expect(String(shape.description)).toMatch(/minimum 50/);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/tests/unit/validate-protocol-structure.test.ts
+++ b/tests/unit/validate-protocol-structure.test.ts
@@ -2,6 +2,8 @@
  * Unit tests for validate-protocol-structure.ts: protocol markdown validation before mint.
  */
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   validateProtocolStructure,
   CREATION_PROTOCOL_URI
@@ -288,6 +290,40 @@ Example heading in block:
 Done.`;
     const result = validateProtocolStructure(doc);
     expect(result.valid).toBe(true);
+  });
+
+  test('rejects challenge type that is not a single allowed enum value', () => {
+    const doc = `# My Protocol
+
+## Natural Language Triggers
+
+Run when needed.
+
+## Step 1
+
+Do it.
+
+\`\`\`json
+{"challenge":{"type":"comment|user_input|mcp|shell","comment":{"min_length":10},"required":true}}
+\`\`\`
+
+## Completion Rule
+
+Done.`;
+    const result = validateProtocolStructure(doc);
+    expect(result.valid).toBe(false);
+    expect(result.missing).toContain('invalid_challenge_type');
+    expect(result.message).toMatch(/shell, mcp, user_input, or comment/);
+  });
+
+  test('embedded create-new-protocol markdown passes validation', () => {
+    const md = readFileSync(
+      join(process.cwd(), 'src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md'),
+      'utf8'
+    );
+    const result = validateProtocolStructure(md);
+    expect(result.valid).toBe(true);
+    expect(result.missing).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes `kairos_next` MCP output validation failure (`-32602`) when advancing the **Create New KAIROS Protocol Chain** meta-protocol past Gather Requirements. Root cause: an illustrative ```json``` block with a pipe-separated `type` was parsed as its own chain step, producing an invalid stored `proof_of_work.type`.

## Changes

- **Embed protocol** (`00000000-0000-0000-0000-000000002001.md`): replace illustrative JSON with a `text` example and clarify one concrete `type` per step.
- **Mint validation**: `validateProtocolStructure` rejects challenge `type` values that are not exactly `shell` | `mcp` | `user_input` | `comment`.
- **Runtime**: `buildChallengeShapeForDisplay` coerces invalid stored types to `comment` with a structured warning; split `GENESIS_HASH` and display builder into small modules to satisfy `max-lines` on `kairos_next-pow-helpers`.
- **Tests**: unit coverage + `kairos_mint` integration for `invalid_challenge_type`.
- **Cursor**: add `.cursor/skills/kairos-bug-fix/` workflow skill (bug report → live repro → test → fix → dev deploy → PR → CI).

## Ref

- Bug report: `reports/mcp-bug-kairos-next-output-validation-crash-2026-03-22.md`

## Verification

- `npm run build`
- `npm run dev:deploy` (boot re-injects embed mem with `force: true`)
- Targeted Jest unit + `kairos-mint-validation` integration tests