### PR TITLE
release: 3.4.0-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.3.3",
+  "version": "3.4.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "3.3.3",
+      "version": "3.4.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "3.3.3",
+  "version": "3.4.0-rc.0",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/kairos/SKILL.md
+++ b/skills/kairos/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   /kairos. Do not require the user to mention tools or protocols. For
   first-time install and server setup, use the kairos-install skill instead.
 metadata:
-  version: "3.3.3"
+  version: "3.4.0-rc.0"
   author: kairos-mcp
 allowed-tools: kairos_search kairos_begin kairos_next kairos_mint kairos_attest kairos_dump kairos_update kairos_delete kairos_spaces
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.3"
+version: "3.4.0-rc.0"
 slug: create-new-protocol
 title: Create New KAIROS Protocol Chain
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.3"
+version: "3.4.0-rc.0"
 slug: refine-search
 title: Get help refining your search
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.3"
+version: "3.4.0-rc.0"
 slug: create-new-protocol-review
 title: Review and Publish New KAIROS Protocol
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
@@ -1,5 +1,5 @@
 ---
-version: "3.3.3"
+version: "3.4.0-rc.0"
 slug: challenge-type-guide
 title: Challenge Type Selection Guide
 ---


### PR DESCRIPTION
Version bump to **3.4.0-rc.0** (release candidate).

**Version rationale:** There is no `CHANGELOG.md` in this repository. Semver was inferred from commits on `main` since tag `v3.3.3`:
- `feat: shell challenge fields, chain scroll, mem boot idempotency` → **minor** (next line is 3.4.x)
- `fix: align boot mem frontmatter version with package.json (3.3.3)` → patch-level alongside the feat

Used `npm version preminor --preid=rc` (not `release:rc` / `prerelease`) so the RC targets **3.4.0-rc.0** rather than **3.3.4-rc.0**.

Tags are expected from CI after merge (see `.github/workflows/release-tag-on-version-bump.yml`).