### PR TITLE
fix(mcp): expose embedded prompts in listOfferingsForUI

### DIFF
--- a/src/http/http-mcp-handler.ts
+++ b/src/http/http-mcp-handler.ts
@@ -6,6 +6,7 @@ import { LOG_LEVEL, AUTH_ENABLED, MAX_CONCURRENT_MCP_REQUESTS_RAW } from '../con
 import { resolveMaxConcurrentRequests } from '../utils/concurrency-limit.js';
 import { setWwwAuthenticate } from './http-auth-middleware.js';
 import { getSpaceContext, runWithSpaceContextAsync } from '../utils/tenant-context.js';
+import { listPromptOfferings } from '../resources/prompt-resources.js';
 import { createServer } from '../server.js';
 import type { MemoryQdrantStore } from '../services/memory/store.js';
 import { KairosError } from '../types/index.js';
@@ -135,7 +136,11 @@ export function setupMcpRoutes(app: express.Express, memoryStore: MemoryQdrantSt
             }
             res.status(200).json({
                 jsonrpc: '2.0',
-                result: { tools: [], prompts: [], resources: [] },
+                result: {
+                    tools: [],
+                    prompts: listPromptOfferings(),
+                    resources: []
+                },
                 id
             });
             return;

--- a/src/resources/prompt-resources.ts
+++ b/src/resources/prompt-resources.ts
@@ -1,4 +1,4 @@
-import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import type { GetPromptResult, Prompt } from '@modelcontextprotocol/sdk/types.js';
 import { getPrompts, getPrompt } from './embedded-mcp-resources.js';
 import { logger } from '../utils/structured-logger.js';
 
@@ -10,31 +10,59 @@ type PromptOverride = {
 
 const promptOverrides: Record<string, PromptOverride> = {};
 
+type RegisteredPrompt = Prompt & {
+  resultDescription: string;
+  text: string;
+};
+
+function formatPromptTitle(key: string): string {
+  return key.replace(/[-_]/g, ' ').replace(/\b\w/g, (letter: string) => letter.toUpperCase());
+}
+
+function buildRegisteredPrompt(key: string, text: string): RegisteredPrompt {
+  const override = promptOverrides[key] ?? {};
+  const title = override.title ?? formatPromptTitle(key);
+  const description = override.description ?? `Prompt: ${title}`;
+
+  return {
+    name: key,
+    title,
+    description,
+    resultDescription: override.resultDescription ?? description,
+    text
+  };
+}
+
+/** Prompt entries for `prompts/list`-shaped surfaces (for example `listOfferingsForUI`). */
+export function listPromptOfferings(): Prompt[] {
+  const prompts = getPrompts() as Record<string, string>;
+  return Object.entries(prompts).map(([key, text]) => {
+    const { name, title, description } = buildRegisteredPrompt(key, text);
+    return { name, title, description };
+  });
+}
+
 /**
  * Register all prompts from embedded-mcp-resources
  */
 export function registerPromptResources(server: any) {
   logger.info('Registering prompts dynamically from embedded resources');
 
-  const prompts = getPrompts();
+  const prompts = getPrompts() as Record<string, string>;
 
   for (const [key, text] of Object.entries(prompts)) {
-    const override = promptOverrides[key] ?? {};
-    const title =
-      override.title || key.replace(/[-_]/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase());
-    const description = override.description || `Prompt: ${title}`;
-    const resultDescription = override.resultDescription || description;
+    const prompt = buildRegisteredPrompt(key, text);
 
     server.registerPrompt(
-      key,
+      prompt.name,
       {
-        title,
-        description
+        title: prompt.title,
+        description: prompt.description
       },
       async (): Promise<GetPromptResult> => {
-        const promptText = getPrompt(key) || text;
+        const promptText = getPrompt(prompt.name) ?? prompt.text;
         const result: GetPromptResult = {
-          description: resultDescription,
+          description: prompt.resultDescription,
           messages: [
             {
               role: 'user',
@@ -51,4 +79,3 @@ export function registerPromptResources(server: any) {
     );
   }
 }
-

--- a/tests/integration/kairos-uri-resource-proxy.test.ts
+++ b/tests/integration/kairos-uri-resource-proxy.test.ts
@@ -60,6 +60,23 @@ describe('MCP Tools and Resources', () => {
     }
   }, 30000);
 
+  test('prompts/list and prompts/get expose the embedded contextual prompt', async () => {
+    const prompts = await mcp.client.listPrompts();
+    const contextualPrompt = prompts.prompts.find((prompt: { name: string }) => prompt.name === 'contextual-prompt');
+
+    expect(contextualPrompt).toBeDefined();
+    expect(contextualPrompt?.title).toBe('Contextual Prompt');
+
+    const prompt = await mcp.client.getPrompt({ name: 'contextual-prompt' });
+    const firstMessage = prompt.messages[0];
+
+    expect(firstMessage).toBeDefined();
+    expect(firstMessage?.content.type).toBe('text');
+    expect(firstMessage?.content.text).toBe(
+      (mcpResources.prompts as Record<string, string>)['contextual-prompt']
+    );
+  }, 30000);
+
   test('resources/list returns registered resources', async () => {
     const resources = await mcp.client.listResources();
     expect(Array.isArray(resources.resources)).toBe(true);

--- a/tests/integration/mcp-list-offerings-for-ui.test.ts
+++ b/tests/integration/mcp-list-offerings-for-ui.test.ts
@@ -1,0 +1,65 @@
+/**
+ * MCP Apps discovery: `listOfferingsForUI` is handled in http-mcp-handler (not SDK).
+ */
+import { waitForHealthCheck } from '../utils/health-check.js';
+import { getTestAuthBaseUrl, getAuthHeaders } from '../utils/auth-headers.js';
+
+const BASE_URL = getTestAuthBaseUrl();
+
+function postMcp(body: object) {
+  return fetch(`${BASE_URL}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...getAuthHeaders()
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+describe('MCP listOfferingsForUI', () => {
+  let serverAvailable = false;
+
+  beforeAll(async () => {
+    try {
+      await waitForHealthCheck({ url: `${BASE_URL}/health`, timeoutMs: 60000, intervalMs: 500 });
+      serverAvailable = true;
+    } catch {
+      serverAvailable = false;
+    }
+  }, 60000);
+
+  test('returns embedded prompts (not empty) while tools/resources stay empty stubs', async () => {
+    if (!serverAvailable) return;
+
+    const res = await postMcp({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'listOfferingsForUI',
+      params: {}
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      jsonrpc?: string;
+      id?: number;
+      result?: { tools?: unknown[]; prompts?: unknown[]; resources?: unknown[] };
+    };
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.id).toBe(1);
+    expect(body.result).toBeDefined();
+    expect(Array.isArray(body.result?.tools)).toBe(true);
+    expect(body.result?.tools).toHaveLength(0);
+    expect(Array.isArray(body.result?.resources)).toBe(true);
+    expect(body.result?.resources).toHaveLength(0);
+
+    const prompts = body.result!.prompts as Array<{ name?: string; title?: string; description?: string }>;
+    expect(Array.isArray(prompts)).toBe(true);
+    expect(prompts.length).toBeGreaterThan(0);
+
+    const contextualPrompt = prompts.find((p) => p.name === 'contextual-prompt');
+    expect(contextualPrompt).toBeDefined();
+    expect(contextualPrompt?.title).toBe('Contextual Prompt');
+    expect(contextualPrompt?.description).toBe('Prompt: Contextual Prompt');
+  });
+});


### PR DESCRIPTION
## What this PR does (actual diff)

Single commit on top of `main` that fixes **empty `prompts`** in the HTTP `listOfferingsForUI` stub. `tools` and `resources` stay empty arrays as on `main`; only `prompts` is populated from the same embedded metadata as `registerPromptResources`.

## Files changed (4)

| File | Change |
|------|--------|
| `src/resources/prompt-resources.ts` | `listPromptOfferings()` + shared `buildRegisteredPrompt` used by registration |
| `src/http/http-mcp-handler.ts` | `listOfferingsForUI` result uses `listPromptOfferings()` |
| `tests/integration/mcp-list-offerings-for-ui.test.ts` | **New** — asserts non-empty prompts and `contextual-prompt` |
| `tests/integration/kairos-uri-resource-proxy.test.ts` | `prompts/list` + `prompts/get` vs embedded text |

## Scope note

This replaces the earlier oversized branch that mixed MCP Apps widgets, docs, and tooling. **That work is not in this PR.** If you still need it locally, it is on branch `wip/mcp-apps-pr223-full` (commit `c28b68e`).

## Verify

`npm run dev:deploy && npx jest --runTestsByPath tests/integration/mcp-list-offerings-for-ui.test.ts tests/integration/kairos-uri-resource-proxy.test.ts --runInBand`