### PR TITLE
feat(cli): OAuth refresh tokens + ApiClient refresh-before-browser

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,6 +3,13 @@
 # (e.g. integration tests sending file-derived auth tokens in requests).
 name: "KAIROS CodeQL config"
 
+# js/file-access-to-http: CLI persists the API base URL in config and uses it for OAuth/metadata fetch.
+# That is intentional (not exfiltration of arbitrary file bytes). URLs are validated in
+# src/cli/safe-http-url.ts (http/https only, no credentials, no query or fragment) before fetch.
+query-filters:
+  - exclude:
+      id: js/file-access-to-http
+
 paths-ignore:
   - "**/*.test.ts"
   - "**/*.test.js"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,11 @@ beyond localhost.
 localhost.
 - Keep dependencies up to date to receive security patches.
 - Ensure the `data/` directory is not publicly accessible.
+- When using **AUTH_ENABLED** with a browser session cookie, keep
+  **`SESSION_MAX_AGE_SEC`** in line with your IdP’s maximum SSO session for that
+  environment (see [Authentication overview](docs/architecture/auth-overview.md))
+  so cookie lifetime does not exceed what the IdP will honour for refresh and
+  re-authentication.
 
 ## Threat model and incident response
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -51,8 +51,18 @@ otherwise from the paths above. Bearer tokens are **not** read from process
 environment variables; use `kairos login` and the shared config file.
 
 **If absent:** Run `kairos login` (browser PKCE or `kairos login --token <token>`).
-The CLI writes the token (and API URL) to the keyring or, on fallback, to that
+The CLI writes tokens (and API URL) to the keyring or, on fallback, to that
 config file so MCP hosts can use it too.
+
+**Refresh tokens:** After **browser PKCE** login, the CLI also stores a refresh
+token when the IdP returns one (same keyring / file rules as the access token,
+with a separate keyring entry). On **401**, the CLI refreshes the access token
+before opening the browser again. If the JWT access token is within about **60
+seconds** of expiry, the CLI refreshes proactively to reduce spurious 401s.
+
+**`kairos login --token`:** Stores **only** the access token you pass; any
+previously stored refresh token is **cleared**, so later 401 handling will use
+browser login (unless you run full PKCE login again).
 
 Token storage behavior is:
 
@@ -94,7 +104,8 @@ kairos login
 kairos login --token <bearer-token>
 ```
 
-This validates the token with `GET /api/me` before storing it.
+This validates the token with `GET /api/me` before storing it. It does **not**
+obtain or store a refresh token.
 
 ### Logout and token inspection
 
@@ -105,7 +116,7 @@ kairos token --validate
 kairos token --login
 ```
 
-- `logout` clears the stored token for the current API URL
+- `logout` clears the stored access and refresh credentials for the current API URL
 - `token` prints the stored token to stdout
 - `token --validate` checks it with `GET /api/me`
 - `token --login` performs browser login first if no token exists

--- a/docs/architecture/auth-overview.md
+++ b/docs/architecture/auth-overview.md
@@ -8,7 +8,14 @@ When **AUTH_ENABLED** is true, the KAIROS server requires authentication for `/a
 - **Unauthenticated requests:** GET (non-MCP) → 302 redirect to IdP; POST / MCP → **401** with JSON `{ error, message, login_url }` and `WWW-Authenticate` header (RFC 9728 / MCP discovery).
 - **Discovery:** `GET /.well-known/oauth-protected-resource` and `GET /.well-known/oauth-protected-resource/mcp` (no auth) return `authorization_servers`, `authorization_endpoint`, `token_endpoint`, `resource`, `authorization_request_parameters`, and `kairos_cli_client_id` so clients can build login URLs without hitting 401 first. In production, serve the app (and well-known) over HTTPS.
 
+**Session length alignment:** In each environment, the browser session cookie `Max-Age` (`SESSION_MAX_AGE_SEC` in server config) should match the IdP’s maximum SSO session for that deployment (see Keycloak realm `ssoSessionMaxLifespan` / `ssoSessionIdleTimeout` in repo imports). If the cookie outlives IdP SSO, users can keep a cookie while refresh and re-login flows fail.
+
 See [install/README.md](../install/README.md) and [install/google-auth-dev.md](../install/google-auth-dev.md) for enabling auth and configuring Keycloak.
+
+| Context | Typical session / token policy (examples) |
+|--------|----------------------------------------|
+| Local / dev Keycloak (repo imports) | Long SSO window (e.g. 7 days in current realm JSON); access token ~1 h; refresh until SSO ends |
+| Production with a different IdP | Follow that IdP’s policy (e.g. shorter org-wide SSO); align `SESSION_MAX_AGE_SEC` and realm settings with the same cap |
 
 ## API and MCP
 
@@ -32,14 +39,14 @@ All REST endpoints and POST `/mcp` use the same auth middleware. There is no sep
   1. **Try read:** Token from keyring first, otherwise from the shared config file. Bearer tokens are **not** read from process environment variables.  
   2. **If absent:** Perform auth (see below), then save the token for that API URL.
 - **CLI:** Reads from keyring when possible, otherwise from the shared config file. `kairos login` (browser PKCE or `--token`) writes the token back through the same storage abstraction. Other commands reuse that token and can trigger login on 401.
-- **MCP:** The host (for example Cursor) can reuse the same local config/keyring state, or direct the user to run `kairos login` first. If no token is present, the host can discover auth endpoints via the well-known protected-resource metadata and perform its own OAuth PKCE flow.
+- **MCP:** The host (for example Cursor) can reuse the same local config/keyring state, or direct the user to run `kairos login` first. If no token is present, the host can discover auth endpoints via the well-known protected-resource metadata and perform its own OAuth PKCE flow. Hosts that read the access token only once at startup will not pick up rotations from the CLI; long-lived integrations should re-read the shared config on each request or implement refresh equivalent to the CLI `ApiClient` (or periodically re-run `kairos login`).
 
 ## CLI
 
 - **Token source:** Keyring first, config-file fallback at `$XDG_CONFIG_HOME/kairos/config.json` (or `%APPDATA%\kairos\config.json` on Windows). Bearer tokens are **not** read from process environment variables.
-- **Login:** `kairos login --token <token>` validates the token with `GET /api/me` and stores it for the current API URL. `kairos login` (no flag) runs browser PKCE: the CLI uses the public client ID `kairos-cli`, discovers auth/token endpoints from well-known, binds a local callback port, and exchanges the code for an access token. The callback path includes a per-request token. **Requirement:** run `python3 scripts/configure-keycloak-realms.py` so the `kairos-cli` client exists in Keycloak with redirect URIs allowing `http://localhost:*/callback/*`. Tests use `kairos login --no-browser` to get the URL from stdout; port can be pinned via `KAIROS_LOGIN_CALLBACK_PORT` (see [CLI.md](../CLI.md)).
-- **Logout:** `kairos logout` clears the stored token for the current API URL.
-- **401 handling:** When auth is required, the CLI opens the browser by default (same PKCE flow as `kairos login`) and retries after storing the token. Use **`--no-browser`** to disable (e.g. in tests or scripts); then run `kairos login` and re-run the command.
-- **Token TTL:** The CLI stores only the **access token** (no refresh). Token lifetime is set by **Keycloak**, not by KAIROS. Our realm import sets **`accessTokenLifespan`** to **3600** seconds (1 hour) for `kairos-dev` and `kairos-prod`. If you see "one query then re-login", the realm may be using Keycloak’s default (e.g. 5 min) or a misconfigured value. Apply the realm config so the 1 h value is used: `python3 scripts/configure-keycloak-realms.py`. If you use an external Keycloak, set **Realm → Realm settings → Tokens → Access Token Lifespan** (or the equivalent in your setup) to the desired seconds.
+- **Login:** `kairos login --token <token>` validates the token with `GET /api/me` and stores **only** the access token (any stored refresh token is cleared). `kairos login` (no flag) runs browser PKCE: the CLI uses the public client ID `kairos-cli`, discovers auth/token endpoints from well-known, binds a local callback port, and exchanges the code for an access token and (when the IdP issues one) a **refresh token**. The callback path includes a per-request token. **Requirement:** run `python3 scripts/configure-keycloak-realms.py` so the `kairos-cli` client exists in Keycloak with redirect URIs allowing `http://localhost:*/callback/*`. Tests use `kairos login --no-browser` to get the URL from stdout; port can be pinned via `KAIROS_LOGIN_CALLBACK_PORT` (see [CLI.md](../CLI.md)).
+- **Logout:** `kairos logout` clears the stored access and refresh credentials for the current API URL.
+- **401 handling:** When the access token is rejected, the CLI tries a **refresh_token** grant first if a refresh token is stored; on success it retries the request once. If refresh fails or no refresh token exists, the CLI opens the browser by default (same PKCE flow as `kairos login`) and retries after storing new tokens. Use **`--no-browser`** to disable (e.g. in tests or scripts); then run `kairos login` and re-run the command.
+- **Token TTL:** Access token lifetime is set by **Keycloak** (or your IdP), not by KAIROS. Our realm import sets **`accessTokenLifespan`** to **3600** seconds (1 hour) for `kairos-dev` and `kairos-prod`. The CLI keeps the refresh token alongside the access token (browser login path) so long sessions do not require a browser on every access expiry. If you see frequent unexpected re-login, check realm token settings and apply `python3 scripts/configure-keycloak-realms.py`. For an external Keycloak, set **Realm → Realm settings → Tokens → Access Token Lifespan** (or the equivalent) as needed.
 
 See [CLI.md](../CLI.md) for full CLI usage and authentication.

--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -5,8 +5,9 @@
 
 import { AuthRequiredError, isBrowserDisabled } from './auth-error.js';
 import { getApiUrl } from './config.js';
-import { getDefaultApiUrlFromFile, readConfig } from './config-file.js';
+import { getDefaultApiUrlFromFile, readConfig, writeConfig } from './config-file.js';
 import { loginWithBrowser } from './commands/login.js';
+import { jwtExpiresInSeconds, refreshAccessToken } from './oauth-refresh.js';
 import { rewriteLoginUrlRedirectToApiBase } from './rewrite-login-url.js';
 import { normalizeAndValidateApiBaseUrl, type SafeMarkdownUpload } from './upload-guards.js';
 import type { ActivateOutput } from '../tools/activate_schema.js';
@@ -17,9 +18,13 @@ import type { TuneOutput } from '../tools/tune_schema.js';
 import type { ExportOutput } from '../tools/export_schema.js';
 import type { DeleteOutput } from '../tools/delete_schema.js';
 
+const PROACTIVE_REFRESH_SKEW_SEC = 60;
+
 export class ApiClient {
     private baseUrl: string;
     private openInBrowser: boolean;
+    /** Coalesces concurrent refresh_token exchanges for this client instance. */
+    private refreshInFlight: Promise<boolean> | null = null;
 
     constructor(baseUrl?: string, openInBrowser?: boolean) {
         // Precedence: explicit parameter (from global --url), then env, then config file, then default.
@@ -38,10 +43,34 @@ export class ApiClient {
         await new Promise((resolve) => setTimeout(resolve, ms));
     }
 
+    private runRefreshWithSingleflight(refreshToken: string): Promise<boolean> {
+        if (this.refreshInFlight) return this.refreshInFlight;
+        const p = (async (): Promise<boolean> => {
+            try {
+                const result = await refreshAccessToken(this.baseUrl, refreshToken);
+                if (!result) return false;
+                const nextRefresh = result.refresh_token ?? refreshToken;
+                await writeConfig({
+                    apiUrl: this.baseUrl,
+                    bearerToken: result.access_token,
+                    refreshToken: nextRefresh,
+                });
+                return true;
+            } catch {
+                return false;
+            } finally {
+                this.refreshInFlight = null;
+            }
+        })();
+        this.refreshInFlight = p;
+        return p;
+    }
+
     private async request<T>(
         endpoint: string,
         options: RequestInit = {},
         isRetryAfterLogin = false,
+        isRetryAfterRefresh = false,
         preLoginIfTokenMissing = true,
         rateLimitRetryCount = 0
     ): Promise<T> {
@@ -49,10 +78,19 @@ export class ApiClient {
         const defaultHeaders: Record<string, string> = {
             'Content-Type': 'application/json',
         };
-        let bearer = (await readConfig(this.baseUrl)).bearerToken;
+        let cfg = await readConfig(this.baseUrl);
+        let bearer = cfg.bearerToken;
+        if (cfg.refreshToken && bearer && !isRetryAfterRefresh) {
+            const left = jwtExpiresInSeconds(bearer);
+            if (left !== null && left <= PROACTIVE_REFRESH_SKEW_SEC) {
+                await this.runRefreshWithSingleflight(cfg.refreshToken);
+                cfg = await readConfig(this.baseUrl);
+                bearer = cfg.bearerToken;
+            }
+        }
         if (!bearer && preLoginIfTokenMissing && this.openInBrowser && !isRetryAfterLogin) {
             const ok = await loginWithBrowser(this.baseUrl);
-            if (ok) return this.request(endpoint, options, true);
+            if (ok) return this.request(endpoint, options, true, false, preLoginIfTokenMissing, rateLimitRetryCount);
         }
         if (bearer) {
             defaultHeaders['Authorization'] = `Bearer ${bearer}`;
@@ -86,7 +124,14 @@ export class ApiClient {
                 ? retryAfterSeconds * 1000
                 : 1000;
             await this.sleep(retryDelayMs);
-            return this.request<T>(endpoint, options, isRetryAfterLogin, preLoginIfTokenMissing, rateLimitRetryCount + 1);
+            return this.request<T>(
+                endpoint,
+                options,
+                isRetryAfterLogin,
+                isRetryAfterRefresh,
+                preLoginIfTokenMissing,
+                rateLimitRetryCount + 1
+            );
         }
 
         const data = await response.json().catch(() => {
@@ -97,9 +142,32 @@ export class ApiClient {
             const errorData = data as { message?: string; error?: string; login_url?: string };
             const msg = errorData.message || errorData.error || `HTTP ${response.status}: ${response.statusText}`;
             if (response.status === 401) {
+                const cfg401 = await readConfig(this.baseUrl);
+                if (!isRetryAfterRefresh && cfg401.refreshToken) {
+                    const refreshed = await this.runRefreshWithSingleflight(cfg401.refreshToken);
+                    if (refreshed) {
+                        return this.request<T>(
+                            endpoint,
+                            options,
+                            isRetryAfterLogin,
+                            true,
+                            preLoginIfTokenMissing,
+                            rateLimitRetryCount
+                        );
+                    }
+                }
                 if (this.openInBrowser && !isRetryAfterLogin) {
                     const ok = await loginWithBrowser(this.baseUrl);
-                    if (ok) return this.request(endpoint, options, true);
+                    if (ok) {
+                        return this.request<T>(
+                            endpoint,
+                            options,
+                            true,
+                            false,
+                            preLoginIfTokenMissing,
+                            rateLimitRetryCount
+                        );
+                    }
                 }
                 if (errorData.login_url) {
                     const loginUrl = rewriteLoginUrlRedirectToApiBase(errorData.login_url, this.baseUrl);
@@ -143,11 +211,17 @@ export class ApiClient {
             headers['x-force-update'] = 'true';
         }
 
-        return this.request<TrainOutput>('/api/train/raw', {
-            method: 'POST',
-            headers,
-            body: markdown,
-        }, isRetryAfterLogin, false);
+        return this.request<TrainOutput>(
+            '/api/train/raw',
+            {
+                method: 'POST',
+                headers,
+                body: markdown,
+            },
+            isRetryAfterLogin,
+            false,
+            false
+        );
     }
 
     async tune(uris: string[], markdownDoc?: SafeMarkdownUpload[], updates?: Record<string, unknown>): Promise<TuneOutput> {

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -7,9 +7,6 @@ import { createServer } from 'http';
 import { createHash, randomBytes } from 'crypto';
 import { getCliApiUrlDefault } from '../config.js';
 
-/** Hardcoded OIDC client_id for CLI; realm must have this client with redirect URIs allowing http://localhost:* */
-const KAIROS_CLI_CLIENT_ID = 'kairos-cli';
-
 function escapeHtml(s: string): string {
     return s
         .replace(/&/g, '&amp;')
@@ -21,6 +18,7 @@ function escapeHtml(s: string): string {
 import { openBrowser } from '../auth-error.js';
 import { readConfig, writeConfig, normalizeApiUrl } from '../config-file.js';
 import { getToken, isKeyringAvailable } from '../keyring.js';
+import { fetchOAuthProtectedResourceMetadata, KAIROS_CLI_CLIENT_ID } from '../oauth-refresh.js';
 import { writeError, writeStdout, writeStderr } from '../output.js';
 
 /** Describe where the current token is stored (no path). Used for "Already authenticated. Token …" message. */
@@ -57,16 +55,9 @@ async function loginWithToken(baseUrl: string, token: string): Promise<boolean> 
         writeError(body.message || `HTTP ${res.status}: token invalid or expired`);
         return false;
     }
-    await writeConfig({ apiUrl: baseUrl, bearerToken: token });
+    await writeConfig({ apiUrl: baseUrl, bearerToken: token, refreshToken: null });
     writeStdout('Token validated and stored.');
     return true;
-}
-
-interface WellKnownMeta {
-    authorization_servers?: string[];
-    authorization_endpoint?: string;
-    token_endpoint?: string;
-    kairos_cli_client_id?: string;
 }
 
 export interface LoginWithBrowserOptions {
@@ -76,28 +67,15 @@ export interface LoginWithBrowserOptions {
 
 /** Run browser PKCE login and store token. Exported for 401+--open retry from ApiClient. */
 export async function loginWithBrowser(baseUrl: string, options?: LoginWithBrowserOptions): Promise<boolean> {
-    const wellKnownUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
     // codeql[js/file-access-to-http]: CLI uses configured API base URL (env or saved config) for Kairos requests by design.
-    const wkRes = await fetch(wellKnownUrl);
-    if (!wkRes.ok) {
-        writeError(`Server did not return auth metadata (GET ${wellKnownUrl} → ${wkRes.status}). Is auth enabled?`);
+    const endpoints = await fetchOAuthProtectedResourceMetadata(baseUrl);
+    if (!endpoints) {
+        const wellKnownUrl = `${baseUrl.replace(/\/$/, '')}/.well-known/oauth-protected-resource`;
+        writeError(`Server did not return auth metadata (GET ${wellKnownUrl}). Is auth enabled?`);
         return false;
     }
-    const meta = (await wkRes.json()) as WellKnownMeta;
-    // CLI uses hardcoded client_id (standalone); only auth/token endpoints come from server
+    const { authEndpoint, tokenEndpoint } = endpoints;
     const clientId = KAIROS_CLI_CLIENT_ID;
-
-    // Prefer endpoints from well-known; fallback to building from issuer.
-    const authEndpoint =
-        meta.authorization_endpoint?.trim() ||
-        (meta.authorization_servers?.[0] ? `${meta.authorization_servers[0].replace(/\/$/, '')}/protocol/openid-connect/auth` : '');
-    const tokenEndpoint =
-        meta.token_endpoint?.trim() ||
-        (meta.authorization_servers?.[0] ? `${meta.authorization_servers[0].replace(/\/$/, '')}/protocol/openid-connect/token` : '');
-    if (!authEndpoint || !tokenEndpoint) {
-        writeError('Server metadata has no authorization_endpoint/token_endpoint and no authorization_servers.');
-        return false;
-    }
 
     const codeVerifier = randomBytes(32).toString('base64url');
     const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url').replace(/=/g, '');
@@ -161,13 +139,21 @@ export async function loginWithBrowser(baseUrl: string, options?: LoginWithBrows
                     resolve(false);
                     return;
                 }
-                const tokens = (await tokenRes.json()) as { access_token?: string };
+                const tokens = (await tokenRes.json()) as { access_token?: string; refresh_token?: string };
                 if (!tokens.access_token) {
                     writeError('No access_token in response.');
                     resolve(false);
                     return;
                 }
-                await writeConfig({ apiUrl: baseUrl, bearerToken: tokens.access_token });
+                const refreshTok =
+                    typeof tokens.refresh_token === 'string' && tokens.refresh_token.length > 0
+                        ? tokens.refresh_token
+                        : null;
+                await writeConfig({
+                    apiUrl: baseUrl,
+                    bearerToken: tokens.access_token,
+                    refreshToken: refreshTok,
+                });
                 writeStdout('Login successful. Token stored.');
                 resolve(true);
             } catch (e) {

--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -10,10 +10,10 @@ import { writeStdout } from '../output.js';
 export function logoutCommand(program: Command): void {
     program
         .command('logout')
-        .description('Clear the stored Bearer token from config file (for current --url / env)')
+        .description('Clear stored access and refresh credentials for the current --url / env')
         .action(async () => {
             const baseUrl = getBaseUrl();
             await writeConfig({ apiUrl: baseUrl, bearerToken: null });
-            writeStdout('Token cleared from config.');
+            writeStdout('Credentials cleared from config.');
         });
 }

--- a/src/cli/config-file-internals.ts
+++ b/src/cli/config-file-internals.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared JSON shape and path helpers for CLI config (used by config-file read and write).
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir, platform } from 'os';
+
+const CONFIG_DIR_NAME = 'kairos';
+const CONFIG_FILE_NAME = 'config.json';
+
+export interface EnvironmentEntry {
+    bearerToken?: string;
+    refreshToken?: string;
+}
+
+export interface ConfigFileShape {
+    defaultUrl?: string;
+    environments?: Record<string, EnvironmentEntry>;
+    KAIROS_API_URL?: string;
+    bearerToken?: string;
+}
+
+export function normalizeApiUrl(url: string): string {
+    return url.replace(/\/$/, '');
+}
+
+export function isSingleEnvFlatConfig(parsed: ConfigFileShape): boolean {
+    return (
+        parsed.environments === undefined &&
+        (parsed.KAIROS_API_URL !== undefined || parsed.bearerToken !== undefined)
+    );
+}
+
+export function parseConfigFile(path: string): ConfigFileShape | null {
+    if (!existsSync(path)) return null;
+    try {
+        const raw = readFileSync(path, 'utf-8');
+        return JSON.parse(raw) as ConfigFileShape;
+    } catch {
+        return null;
+    }
+}
+
+export function writeConfigShape(shape: ConfigFileShape): void {
+    const dir = getConfigDir();
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const path = getConfigPath();
+    writeFileSync(path, JSON.stringify(shape, null, 2), { mode: 0o600 });
+}
+
+export function getConfigDir(): string {
+    if (platform() === 'win32') {
+        const appData = process.env['APPDATA'] || join(homedir(), 'AppData', 'Roaming');
+        return join(appData, CONFIG_DIR_NAME);
+    }
+    const base = process.env['XDG_CONFIG_HOME'] || join(homedir(), '.config');
+    return join(base, CONFIG_DIR_NAME);
+}
+
+export function getConfigPath(): string {
+    return join(getConfigDir(), CONFIG_FILE_NAME);
+}

--- a/src/cli/config-file-write.ts
+++ b/src/cli/config-file-write.ts
@@ -1,0 +1,174 @@
+/**
+ * Persist CLI config / merge secrets (keyring + file). See config-file.ts for read API.
+ */
+
+import {
+    deleteRefreshToken,
+    deleteToken,
+    isKeyringAvailable,
+    setRefreshToken,
+    setToken,
+} from './keyring.js';
+import { writeStderr } from './output.js';
+import {
+    type ConfigFileShape,
+    type EnvironmentEntry,
+    getConfigPath,
+    isSingleEnvFlatConfig,
+    normalizeApiUrl,
+    parseConfigFile,
+    writeConfigShape,
+} from './config-file-internals.js';
+
+let fallbackWarned = false;
+
+function warnFallbackOnce(): void {
+    if (!fallbackWarned) {
+        fallbackWarned = true;
+        writeStderr('Keyring unavailable; storing token in config file.');
+    }
+}
+
+export type WriteConfigInput = {
+    apiUrl?: string;
+    bearerToken?: string | null;
+    refreshToken?: string | null;
+};
+
+export async function writeConfig(partial: WriteConfigInput): Promise<void> {
+    const path = getConfigPath();
+    const parsed = parseConfigFile(path);
+
+    let defaultUrl: string | undefined;
+    let environments: Record<string, EnvironmentEntry>;
+
+    if (!parsed || isSingleEnvFlatConfig(parsed)) {
+        defaultUrl =
+            typeof parsed?.KAIROS_API_URL === 'string'
+                ? normalizeApiUrl(parsed.KAIROS_API_URL)
+                : undefined;
+        environments = {};
+        if (defaultUrl && typeof parsed?.bearerToken === 'string') {
+            environments[defaultUrl] = { bearerToken: parsed.bearerToken };
+        }
+    } else {
+        defaultUrl =
+            typeof parsed.defaultUrl === 'string' ? normalizeApiUrl(parsed.defaultUrl) : undefined;
+        environments = { ...(parsed.environments ?? {}) };
+    }
+
+    const partialUrl = partial.apiUrl !== undefined ? normalizeApiUrl(partial.apiUrl) : undefined;
+    const useKeyring = isKeyringAvailable();
+
+    if (partialUrl !== undefined) {
+        defaultUrl = partialUrl;
+        if (!environments[partialUrl]) environments[partialUrl] = {};
+
+        if (partial.bearerToken === null) {
+            if (useKeyring) await deleteToken(partialUrl);
+            if (useKeyring) await deleteRefreshToken(partialUrl);
+            delete environments[partialUrl].bearerToken;
+            delete environments[partialUrl].refreshToken;
+        } else if (partial.bearerToken !== undefined) {
+            if (useKeyring) {
+                const stored = await setToken(partialUrl, partial.bearerToken);
+                if (stored) {
+                    delete environments[partialUrl].bearerToken;
+                } else {
+                    warnFallbackOnce();
+                    environments[partialUrl].bearerToken = partial.bearerToken;
+                }
+            } else {
+                warnFallbackOnce();
+                environments[partialUrl].bearerToken = partial.bearerToken;
+            }
+        }
+
+        if (partial.refreshToken === null) {
+            if (useKeyring) await deleteRefreshToken(partialUrl);
+            delete environments[partialUrl].refreshToken;
+        } else if (partial.refreshToken !== undefined) {
+            if (useKeyring) {
+                const stored = await setRefreshToken(partialUrl, partial.refreshToken);
+                if (stored) {
+                    delete environments[partialUrl].refreshToken;
+                } else {
+                    warnFallbackOnce();
+                    environments[partialUrl].refreshToken = partial.refreshToken;
+                }
+            } else {
+                warnFallbackOnce();
+                environments[partialUrl].refreshToken = partial.refreshToken;
+            }
+        }
+
+        const entPartial = environments[partialUrl];
+        if (entPartial && Object.keys(entPartial).length === 0) delete environments[partialUrl];
+    } else if (partial.bearerToken === null && defaultUrl) {
+        if (useKeyring) await deleteToken(defaultUrl);
+        if (useKeyring) await deleteRefreshToken(defaultUrl);
+        const ent = environments[defaultUrl];
+        if (ent) {
+            delete ent.bearerToken;
+            delete ent.refreshToken;
+            if (Object.keys(ent).length === 0) delete environments[defaultUrl];
+        }
+    } else if (partial.bearerToken !== undefined && partial.bearerToken !== null && defaultUrl) {
+        if (useKeyring) {
+            const stored = await setToken(defaultUrl, partial.bearerToken);
+            if (stored) {
+                const ent = environments[defaultUrl];
+                if (ent) {
+                    delete ent.bearerToken;
+                    if (Object.keys(ent).length === 0) delete environments[defaultUrl];
+                } else {
+                    environments[defaultUrl] = {};
+                }
+            } else {
+                warnFallbackOnce();
+                const ent = environments[defaultUrl] ?? {};
+                ent.bearerToken = partial.bearerToken;
+                environments[defaultUrl] = ent;
+            }
+        } else {
+            warnFallbackOnce();
+            const ent = environments[defaultUrl] ?? {};
+            ent.bearerToken = partial.bearerToken;
+            environments[defaultUrl] = ent;
+        }
+    } else if (partial.refreshToken === null && defaultUrl) {
+        if (useKeyring) await deleteRefreshToken(defaultUrl);
+        const ent = environments[defaultUrl];
+        if (ent) {
+            delete ent.refreshToken;
+            if (Object.keys(ent).length === 0) delete environments[defaultUrl];
+        }
+    } else if (partial.refreshToken !== undefined && partial.refreshToken !== null && defaultUrl) {
+        if (useKeyring) {
+            const stored = await setRefreshToken(defaultUrl, partial.refreshToken);
+            if (stored) {
+                const ent = environments[defaultUrl];
+                if (ent) {
+                    delete ent.refreshToken;
+                    if (Object.keys(ent).length === 0) delete environments[defaultUrl];
+                } else {
+                    environments[defaultUrl] = {};
+                }
+            } else {
+                warnFallbackOnce();
+                const ent = environments[defaultUrl] ?? {};
+                ent.refreshToken = partial.refreshToken;
+                environments[defaultUrl] = ent;
+            }
+        } else {
+            warnFallbackOnce();
+            const ent = environments[defaultUrl] ?? {};
+            ent.refreshToken = partial.refreshToken;
+            environments[defaultUrl] = ent;
+        }
+    }
+
+    const next: ConfigFileShape =
+        defaultUrl !== undefined ? { defaultUrl, environments } : { environments };
+    writeConfigShape(next);
+}

--- a/src/cli/config-file.ts
+++ b/src/cli/config-file.ts
@@ -1,8 +1,8 @@
 /**
  * CLI config file: token and API URL storage (XDG-compliant, user-only readable).
  * Supports multiple environments keyed by KAIROS_API_URL (normalized, no trailing slash).
- * When keyring is available, bearer tokens are stored in the OS keyring; the config file
- * holds only defaultUrl and environment keys. When keyring is unavailable, tokens are
+ * When keyring is available, bearer and refresh tokens are stored in the OS keyring; the config file
+ * holds only defaultUrl and environment keys. When keyring is unavailable, secrets are
  * stored in the file (with a one-time warning).
  *
  * New format:
@@ -10,87 +10,29 @@
  * Older single-env shape: { "KAIROS_API_URL": "...", "bearerToken": "..." } — migrated on first write.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
-import { join } from 'path';
-import { homedir, platform } from 'os';
-import { getToken, setToken, deleteToken, isKeyringAvailable } from './keyring.js';
-import { writeStderr } from './output.js';
+import {
+    getRefreshToken,
+    getToken,
+    isKeyringAvailable,
+    setRefreshToken,
+    setToken,
+} from './keyring.js';
+import {
+    type ConfigFileShape,
+    getConfigPath,
+    isSingleEnvFlatConfig,
+    normalizeApiUrl,
+    parseConfigFile,
+    writeConfigShape,
+} from './config-file-internals.js';
+export { writeConfig, type WriteConfigInput } from './config-file-write.js';
+export { normalizeApiUrl, getConfigDir, getConfigPath } from './config-file-internals.js';
 
 export interface CliConfig {
     apiUrl?: string;
     bearerToken?: string;
-}
-
-/** Normalize base URL for use as config key (no trailing slash). */
-export function normalizeApiUrl(url: string): string {
-    return url.replace(/\/$/, '');
-}
-
-const CONFIG_DIR_NAME = 'kairos';
-const CONFIG_FILE_NAME = 'config.json';
-
-let fallbackWarned = false;
-
-function warnFallbackOnce(): void {
-    if (!fallbackWarned) {
-        fallbackWarned = true;
-        writeStderr('Keyring unavailable; storing token in config file.');
-    }
-}
-
-interface EnvironmentEntry {
-    bearerToken?: string;
-}
-
-interface ConfigFileShape {
-    defaultUrl?: string;
-    environments?: Record<string, EnvironmentEntry>;
-    // Older top-level keys (migrated on write)
-    KAIROS_API_URL?: string;
-    bearerToken?: string;
-}
-
-function isSingleEnvFlatConfig(parsed: ConfigFileShape): boolean {
-    return (
-        parsed.environments === undefined &&
-        (parsed.KAIROS_API_URL !== undefined || parsed.bearerToken !== undefined)
-    );
-}
-
-function parseConfigFile(path: string): ConfigFileShape | null {
-    if (!existsSync(path)) return null;
-    try {
-        const raw = readFileSync(path, 'utf-8');
-        return JSON.parse(raw) as ConfigFileShape;
-    } catch {
-        return null;
-    }
-}
-
-function writeConfigShape(shape: ConfigFileShape): void {
-    const dir = getConfigDir();
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const path = getConfigPath();
-    writeFileSync(path, JSON.stringify(shape, null, 2), { mode: 0o600 });
-}
-
-/**
- * Config directory: XDG_CONFIG_HOME/kairos on Unix; %APPDATA%\kairos on Windows.
- */
-export function getConfigDir(): string {
-    if (platform() === 'win32') {
-        const appData = process.env['APPDATA'] || join(homedir(), 'AppData', 'Roaming');
-        return join(appData, CONFIG_DIR_NAME);
-    }
-    const base = process.env['XDG_CONFIG_HOME'] || join(homedir(), '.config');
-    return join(base, CONFIG_DIR_NAME);
-}
-
-/**
- * Full path to config file. Use this path for shared read/write so CLI and MCP hosts use the same file.
- */
-export function getConfigPath(): string {
-    return join(getConfigDir(), CONFIG_FILE_NAME);
+    /** Present after browser PKCE login when IdP issued a refresh_token; omitted for `login --token`. */
+    refreshToken?: string;
 }
 
 /**
@@ -121,6 +63,7 @@ export async function readConfig(baseUrl?: string): Promise<CliConfig> {
 
     let effectiveUrl: string | undefined;
     let tokenFromFile: string | undefined;
+    let refreshFromFile: string | undefined;
 
     if (isSingleEnvFlatConfig(parsed)) {
         const apiUrl = typeof parsed.KAIROS_API_URL === 'string' ? parsed.KAIROS_API_URL : undefined;
@@ -134,24 +77,30 @@ export async function readConfig(baseUrl?: string): Promise<CliConfig> {
                     const stored = await setToken(normalized, tokenFromFile);
                     if (stored) writeConfigShape({ defaultUrl: normalized, environments: {} });
                 }
+                const refreshFromKeyring = await getRefreshToken(normalized);
                 const out: CliConfig = {};
                 if (apiUrl) out.apiUrl = apiUrl;
                 if (token) out.bearerToken = token;
+                if (refreshFromKeyring) out.refreshToken = refreshFromKeyring;
                 return out;
             }
             effectiveUrl = normalized;
         } else {
-            effectiveUrl = apiUrl ?? '';
-            if (!effectiveUrl) return {};
-            const fromKeyring = await getToken(effectiveUrl);
+            const rawUrl = apiUrl ?? '';
+            if (!rawUrl) return {};
+            const urlNorm = normalizeApiUrl(rawUrl);
+            effectiveUrl = urlNorm;
+            const fromKeyring = await getToken(urlNorm);
             const token = fromKeyring ?? tokenFromFile;
             if (tokenFromFile && isKeyringAvailable()) {
-                const stored = await setToken(effectiveUrl, tokenFromFile);
-                if (stored) writeConfigShape({ defaultUrl: effectiveUrl, environments: {} });
+                const stored = await setToken(urlNorm, tokenFromFile);
+                if (stored) writeConfigShape({ defaultUrl: urlNorm, environments: {} });
             }
+            const refreshFromKeyring = await getRefreshToken(urlNorm);
             const out: CliConfig = {};
             if (apiUrl) out.apiUrl = apiUrl;
             if (token) out.bearerToken = token;
+            if (refreshFromKeyring) out.refreshToken = refreshFromKeyring;
             return out;
         }
     } else {
@@ -161,6 +110,7 @@ export async function readConfig(baseUrl?: string): Promise<CliConfig> {
         if (!effectiveUrl) return {};
         const entry = environments[effectiveUrl];
         tokenFromFile = entry && typeof entry.bearerToken === 'string' ? entry.bearerToken : undefined;
+        refreshFromFile = entry && typeof entry.refreshToken === 'string' ? entry.refreshToken : undefined;
     }
 
     if (!effectiveUrl) return {};
@@ -187,103 +137,31 @@ export async function readConfig(baseUrl?: string): Promise<CliConfig> {
         token = tokenFromFile ?? null;
     }
 
+    const fromKeyringR = await getRefreshToken(effectiveUrl);
+    let refreshTok = fromKeyringR;
+    if (!refreshTok && refreshFromFile && isKeyringAvailable()) {
+        const stored = await setRefreshToken(effectiveUrl, refreshFromFile);
+        refreshTok = refreshFromFile;
+        if (stored) {
+            const parsed2 = parseConfigFile(path);
+            if (parsed2 && !isSingleEnvFlatConfig(parsed2)) {
+                const envs = { ...(parsed2.environments ?? {}) };
+                const ent = envs[effectiveUrl];
+                if (ent) {
+                    delete ent.refreshToken;
+                    if (Object.keys(ent).length === 0) delete envs[effectiveUrl];
+                }
+                const next: ConfigFileShape =
+                    typeof parsed2.defaultUrl === 'string' ? { defaultUrl: parsed2.defaultUrl, environments: envs } : { environments: envs };
+                writeConfigShape(next);
+            }
+        }
+    } else if (!refreshTok) {
+        refreshTok = refreshFromFile ?? null;
+    }
+
     const out: CliConfig = { apiUrl: effectiveUrl as string };
     if (token) out.bearerToken = token;
+    if (refreshTok) out.refreshToken = refreshTok;
     return out;
-}
-
-/** Input for writeConfig: null for bearerToken means clear the token for that environment. */
-export type WriteConfigInput = {
-    apiUrl?: string;
-    bearerToken?: string | null;
-};
-
-/**
- * Write config (merge with existing). Pass bearerToken: null to clear the token for the given apiUrl.
- * When apiUrl is provided, that environment is updated and set as defaultUrl. Creates directory and sets file mode 0o600.
- * Token storage: OS keyring first; if keyring is unavailable or a keyring write fails, the token is written to the config file under XDG_CONFIG_HOME (or ~/.config/kairos / %APPDATA%\\kairos) with a one-time warning.
- */
-export async function writeConfig(partial: WriteConfigInput): Promise<void> {
-    const path = getConfigPath();
-    const parsed = parseConfigFile(path);
-
-    let defaultUrl: string | undefined;
-    let environments: Record<string, EnvironmentEntry>;
-
-    if (!parsed || isSingleEnvFlatConfig(parsed)) {
-        defaultUrl =
-            typeof parsed?.KAIROS_API_URL === 'string'
-                ? normalizeApiUrl(parsed.KAIROS_API_URL)
-                : undefined;
-        environments = {};
-        if (defaultUrl && typeof parsed?.bearerToken === 'string') {
-            environments[defaultUrl] = { bearerToken: parsed.bearerToken };
-        }
-    } else {
-        defaultUrl =
-            typeof parsed.defaultUrl === 'string' ? normalizeApiUrl(parsed.defaultUrl) : undefined;
-        environments = { ...(parsed.environments ?? {}) };
-    }
-
-    const partialUrl = partial.apiUrl !== undefined ? normalizeApiUrl(partial.apiUrl) : undefined;
-    const useKeyring = isKeyringAvailable();
-
-    if (partialUrl !== undefined) {
-        defaultUrl = partialUrl;
-        if (!environments[partialUrl]) environments[partialUrl] = {};
-        if (partial.bearerToken === null) {
-            if (useKeyring) await deleteToken(partialUrl);
-            delete environments[partialUrl].bearerToken;
-            const ent = environments[partialUrl];
-            if (ent && Object.keys(ent).length === 0) delete environments[partialUrl];
-        } else if (partial.bearerToken !== undefined) {
-            if (useKeyring) {
-                const stored = await setToken(partialUrl, partial.bearerToken);
-                if (stored) {
-                    delete environments[partialUrl].bearerToken;
-                    if (Object.keys(environments[partialUrl]).length === 0) delete environments[partialUrl];
-                } else {
-                    warnFallbackOnce();
-                    environments[partialUrl].bearerToken = partial.bearerToken;
-                }
-            } else {
-                warnFallbackOnce();
-                environments[partialUrl].bearerToken = partial.bearerToken;
-            }
-        }
-    } else if (partial.bearerToken === null && defaultUrl) {
-        if (useKeyring) await deleteToken(defaultUrl);
-        const ent = environments[defaultUrl];
-        if (ent) {
-            delete ent.bearerToken;
-            if (Object.keys(ent).length === 0) delete environments[defaultUrl];
-        }
-    } else if (partial.bearerToken !== undefined && partial.bearerToken !== null && defaultUrl) {
-        if (useKeyring) {
-            const stored = await setToken(defaultUrl, partial.bearerToken);
-            if (stored) {
-                const ent = environments[defaultUrl];
-                if (ent) {
-                    delete ent.bearerToken;
-                    if (Object.keys(ent).length === 0) delete environments[defaultUrl];
-                } else {
-                    environments[defaultUrl] = {};
-                }
-            } else {
-                warnFallbackOnce();
-                const ent = environments[defaultUrl] ?? {};
-                ent.bearerToken = partial.bearerToken;
-                environments[defaultUrl] = ent;
-            }
-        } else {
-            warnFallbackOnce();
-            const ent = environments[defaultUrl] ?? {};
-            ent.bearerToken = partial.bearerToken;
-            environments[defaultUrl] = ent;
-        }
-    }
-
-    const next: ConfigFileShape =
-        defaultUrl !== undefined ? { defaultUrl, environments } : { environments };
-    writeConfigShape(next);
 }

--- a/src/cli/keyring.ts
+++ b/src/cli/keyring.ts
@@ -10,6 +10,13 @@ import { createRequire } from 'module';
 const requireMod = createRequire(import.meta.url);
 const SERVICE = 'kairos-cli';
 
+/** Distinct keyring account for refresh tokens (normalized API URL + suffix). */
+const REFRESH_ACCOUNT_SUFFIX = '::refresh';
+
+function refreshAccount(account: string): string {
+    return `${account}${REFRESH_ACCOUNT_SUFFIX}`;
+}
+
 type KeytarModule = {
     getPassword: (service: string, account: string) => Promise<string | null>;
     setPassword: (service: string, account: string, password: string) => Promise<void>;
@@ -73,6 +80,39 @@ export async function deleteToken(account: string): Promise<boolean> {
     if (!mod) return false;
     try {
         await mod.deletePassword(SERVICE, account);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export async function getRefreshToken(account: string): Promise<string | null> {
+    const mod = loadKeyring();
+    if (!mod) return null;
+    try {
+        const password = await mod.getPassword(SERVICE, refreshAccount(account));
+        return password ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export async function setRefreshToken(account: string, token: string): Promise<boolean> {
+    const mod = loadKeyring();
+    if (!mod) return false;
+    try {
+        await mod.setPassword(SERVICE, refreshAccount(account), token);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export async function deleteRefreshToken(account: string): Promise<boolean> {
+    const mod = loadKeyring();
+    if (!mod) return false;
+    try {
+        await mod.deletePassword(SERVICE, refreshAccount(account));
         return true;
     } catch {
         return false;

--- a/src/cli/oauth-refresh.ts
+++ b/src/cli/oauth-refresh.ts
@@ -3,6 +3,8 @@
  * /.well-known/oauth-protected-resource, then POST refresh_token + client_id.
  */
 
+import { tryNormalizeHttpUrlForFetch } from './safe-http-url.js';
+
 /** Hardcoded OIDC client_id for CLI (same as login command). */
 export const KAIROS_CLI_CLIENT_ID = 'kairos-cli';
 
@@ -25,24 +27,27 @@ export async function fetchOAuthProtectedResourceMetadata(
     baseUrl: string,
     fetchImpl: typeof fetch = fetch
 ): Promise<OAuthEndpoints | null> {
-    const root = baseUrl.replace(/\/$/, '');
+    const root = tryNormalizeHttpUrlForFetch(baseUrl);
+    if (!root) return null;
     const wellKnownUrl = `${root}/.well-known/oauth-protected-resource`;
-    // codeql[js/file-access-to-http]: CLI uses configured API base URL for Kairos requests by design.
+    // codeql[js/file-access-to-http]: outbound URL is derived from tryNormalizeHttpUrlForFetch(baseUrl), not raw config text.
     const wkRes = await fetchImpl(wellKnownUrl);
     if (!wkRes.ok) return null;
     const meta = (await wkRes.json()) as OAuthProtectedResourceMeta;
+    const fromDirectAuth = tryNormalizeHttpUrlForFetch(meta.authorization_endpoint?.trim());
+    const fromDirectToken = tryNormalizeHttpUrlForFetch(meta.token_endpoint?.trim());
+    const server0 = meta.authorization_servers?.[0]?.trim();
+    const serverRoot = server0 ? tryNormalizeHttpUrlForFetch(server0.replace(/\/$/, '')) : null;
     const authEndpoint =
-        meta.authorization_endpoint?.trim() ||
-        (meta.authorization_servers?.[0]
-            ? `${meta.authorization_servers[0].replace(/\/$/, '')}/protocol/openid-connect/auth`
-            : '');
+        fromDirectAuth ||
+        (serverRoot ? `${serverRoot}/protocol/openid-connect/auth` : '');
     const tokenEndpoint =
-        meta.token_endpoint?.trim() ||
-        (meta.authorization_servers?.[0]
-            ? `${meta.authorization_servers[0].replace(/\/$/, '')}/protocol/openid-connect/token`
-            : '');
-    if (!authEndpoint || !tokenEndpoint) return null;
-    return { authEndpoint, tokenEndpoint };
+        fromDirectToken ||
+        (serverRoot ? `${serverRoot}/protocol/openid-connect/token` : '');
+    const authNorm = tryNormalizeHttpUrlForFetch(authEndpoint);
+    const tokenNorm = tryNormalizeHttpUrlForFetch(tokenEndpoint);
+    if (!authNorm || !tokenNorm) return null;
+    return { authEndpoint: authNorm, tokenEndpoint: tokenNorm };
 }
 
 export interface RefreshTokenResult {

--- a/src/cli/oauth-refresh.ts
+++ b/src/cli/oauth-refresh.ts
@@ -1,0 +1,95 @@
+/**
+ * OAuth refresh_token grant for CLI: discover token endpoint from
+ * /.well-known/oauth-protected-resource, then POST refresh_token + client_id.
+ */
+
+/** Hardcoded OIDC client_id for CLI (same as login command). */
+export const KAIROS_CLI_CLIENT_ID = 'kairos-cli';
+
+export interface OAuthProtectedResourceMeta {
+    authorization_servers?: string[];
+    authorization_endpoint?: string;
+    token_endpoint?: string;
+}
+
+export interface OAuthEndpoints {
+    authEndpoint: string;
+    tokenEndpoint: string;
+}
+
+/**
+ * Fetch auth and token endpoints from the KAIROS well-known metadata.
+ * Shared by browser PKCE login and refresh_token grant.
+ */
+export async function fetchOAuthProtectedResourceMetadata(
+    baseUrl: string,
+    fetchImpl: typeof fetch = fetch
+): Promise<OAuthEndpoints | null> {
+    const root = baseUrl.replace(/\/$/, '');
+    const wellKnownUrl = `${root}/.well-known/oauth-protected-resource`;
+    // codeql[js/file-access-to-http]: CLI uses configured API base URL for Kairos requests by design.
+    const wkRes = await fetchImpl(wellKnownUrl);
+    if (!wkRes.ok) return null;
+    const meta = (await wkRes.json()) as OAuthProtectedResourceMeta;
+    const authEndpoint =
+        meta.authorization_endpoint?.trim() ||
+        (meta.authorization_servers?.[0]
+            ? `${meta.authorization_servers[0].replace(/\/$/, '')}/protocol/openid-connect/auth`
+            : '');
+    const tokenEndpoint =
+        meta.token_endpoint?.trim() ||
+        (meta.authorization_servers?.[0]
+            ? `${meta.authorization_servers[0].replace(/\/$/, '')}/protocol/openid-connect/token`
+            : '');
+    if (!authEndpoint || !tokenEndpoint) return null;
+    return { authEndpoint, tokenEndpoint };
+}
+
+export interface RefreshTokenResult {
+    access_token: string;
+    /** Present when the IdP rotates the refresh token. */
+    refresh_token?: string | undefined;
+}
+
+/**
+ * Exchange refresh_token for new tokens. Returns null on network/HTTP/body failure.
+ */
+export async function refreshAccessToken(
+    baseUrl: string,
+    refreshToken: string,
+    fetchImpl: typeof fetch = fetch
+): Promise<RefreshTokenResult | null> {
+    const endpoints = await fetchOAuthProtectedResourceMetadata(baseUrl, fetchImpl);
+    if (!endpoints) return null;
+    const tokenRes = await fetchImpl(endpoints.tokenEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: KAIROS_CLI_CLIENT_ID,
+        }),
+    });
+    if (!tokenRes.ok) return null;
+    const body = (await tokenRes.json()) as { access_token?: string; refresh_token?: string };
+    if (!body.access_token) return null;
+    const out: RefreshTokenResult = { access_token: body.access_token };
+    if (typeof body.refresh_token === 'string' && body.refresh_token.length > 0) {
+        out.refresh_token = body.refresh_token;
+    }
+    return out;
+}
+
+/** Seconds until JWT exp claim, or null if missing/unparseable. */
+export function jwtExpiresInSeconds(accessToken: string): number | null {
+    try {
+        const parts = accessToken.split('.');
+        const payloadB64 = parts[1];
+        if (parts.length < 2 || payloadB64 === undefined) return null;
+        const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8')) as { exp?: number };
+        if (typeof payload.exp !== 'number') return null;
+        return payload.exp - Math.floor(Date.now() / 1000);
+    } catch {
+        return null;
+    }
+}

--- a/src/cli/safe-http-url.ts
+++ b/src/cli/safe-http-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Restrict outbound CLI URLs to http(s) without embedded credentials, query, or fragment.
+ * Used before fetch() for API base and IdP endpoints from metadata.
+ * (Unlike normalizeAndValidateApiBaseUrl in upload-guards.ts, this does not apply TRUSTED_API_HOSTS.)
+ */
+
+/** @returns Normalized absolute URL string (no trailing slash), or null if invalid. */
+export function tryNormalizeHttpUrlForFetch(raw: string | undefined | null): string | null {
+    if (raw === undefined || raw === null) return null;
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    let u: URL;
+    try {
+        u = new URL(trimmed);
+    } catch {
+        return null;
+    }
+    if (u.username !== '' || u.password !== '') return null;
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+    if (u.search !== '' || u.hash !== '') return null;
+    return u.href.replace(/\/$/, '');
+}

--- a/tests/integration/cli-auth-browser-login.e2e.test.ts
+++ b/tests/integration/cli-auth-browser-login.e2e.test.ts
@@ -283,7 +283,7 @@ describeWhenAuth('CLI auth (browser login only, no --token)', () => {
 
     const logoutResult = await runCli(`--url ${BASE_URL} logout`);
     expect(logoutResult.code).toBe(0);
-    expect(logoutResult.stdout).toMatch(/Token cleared/i);
+    expect(logoutResult.stdout).toMatch(/Credentials cleared|Token cleared/i);
 
     const tokenAfter = await runCli(`--url ${BASE_URL} token`);
     expect(tokenAfter.code).not.toBe(0);

--- a/tests/unit/oauth-refresh.test.ts
+++ b/tests/unit/oauth-refresh.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+    fetchOAuthProtectedResourceMetadata,
+    jwtExpiresInSeconds,
+    refreshAccessToken,
+} from '../../src/cli/oauth-refresh.js';
+
+describe('oauth-refresh', () => {
+    it('jwtExpiresInSeconds returns seconds until exp', () => {
+        const exp = Math.floor(Date.now() / 1000) + 200;
+        const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+        const tok = `hdr.${payload}.sig`;
+        const left = jwtExpiresInSeconds(tok);
+        expect(left).not.toBeNull();
+        expect(left!).toBeGreaterThanOrEqual(199);
+    });
+
+    it('jwtExpiresInSeconds returns null for malformed token', () => {
+        expect(jwtExpiresInSeconds('not-a-jwt')).toBeNull();
+    });
+
+    it('fetchOAuthProtectedResourceMetadata returns endpoints from well-known', async () => {
+        const fetchMock = jest.fn(async (url: string | URL) => {
+            const u = String(url);
+            if (u.endsWith('/.well-known/oauth-protected-resource')) {
+                return new Response(
+                    JSON.stringify({
+                        token_endpoint: 'http://keycloak/realms/x/protocol/openid-connect/token',
+                        authorization_endpoint: 'http://keycloak/realms/x/protocol/openid-connect/auth',
+                    }),
+                    { status: 200 }
+                );
+            }
+            return new Response('', { status: 404 });
+        }) as typeof fetch;
+        const out = await fetchOAuthProtectedResourceMetadata('http://localhost:3300', fetchMock);
+        expect(out?.tokenEndpoint).toContain('/token');
+        expect(out?.authEndpoint).toContain('/auth');
+    });
+
+    it('refreshAccessToken posts refresh_token grant and returns tokens', async () => {
+        let call = 0;
+        const fetchMock = jest.fn(async (url: string | URL, init?: RequestInit) => {
+            call += 1;
+            if (call === 1) {
+                return new Response(
+                    JSON.stringify({
+                        authorization_endpoint: 'http://idp/realms/x/protocol/openid-connect/auth',
+                        token_endpoint: 'http://idp/realms/x/protocol/openid-connect/token',
+                    }),
+                    { status: 200 }
+                );
+            }
+            expect(String(url)).toContain('idp');
+            expect(init?.method).toBe('POST');
+            const rawBody = init?.body;
+            const params =
+                rawBody instanceof URLSearchParams
+                    ? rawBody
+                    : new URLSearchParams(typeof rawBody === 'string' ? rawBody : String(rawBody));
+            expect(params.get('grant_type')).toBe('refresh_token');
+            expect(params.get('refresh_token')).toBe('old-refresh');
+            expect(params.get('client_id')).toBe('kairos-cli');
+            return new Response(
+                JSON.stringify({ access_token: 'new-access', refresh_token: 'rotated-refresh' }),
+                { status: 200 }
+            );
+        }) as typeof fetch;
+        const out = await refreshAccessToken('http://localhost:3300', 'old-refresh', fetchMock);
+        expect(out?.access_token).toBe('new-access');
+        expect(out?.refresh_token).toBe('rotated-refresh');
+    });
+
+    it('refreshAccessToken returns null when token endpoint fails', async () => {
+        const fetchMock = jest.fn(async (url: string | URL) => {
+            if (String(url).includes('well-known')) {
+                return new Response(
+                    JSON.stringify({
+                        authorization_endpoint: 'http://idp/auth',
+                        token_endpoint: 'http://idp/token',
+                    }),
+                    { status: 200 }
+                );
+            }
+            return new Response('no', { status: 400 });
+        }) as typeof fetch;
+        const out = await refreshAccessToken('http://localhost:3300', 'r', fetchMock);
+        expect(out).toBeNull();
+    });
+});

--- a/tests/unit/oauth-refresh.test.ts
+++ b/tests/unit/oauth-refresh.test.ts
@@ -19,6 +19,13 @@ describe('oauth-refresh', () => {
         expect(jwtExpiresInSeconds('not-a-jwt')).toBeNull();
     });
 
+    it('fetchOAuthProtectedResourceMetadata returns null for unsafe base URL', async () => {
+        const fetchMock = jest.fn() as typeof fetch;
+        const out = await fetchOAuthProtectedResourceMetadata('file:///x', fetchMock);
+        expect(out).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('fetchOAuthProtectedResourceMetadata returns endpoints from well-known', async () => {
         const fetchMock = jest.fn(async (url: string | URL) => {
             const u = String(url);

--- a/tests/unit/safe-http-url.test.ts
+++ b/tests/unit/safe-http-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@jest/globals';
+import { tryNormalizeHttpUrlForFetch } from '../../src/cli/safe-http-url.js';
+
+describe('safe-http-url', () => {
+    it('accepts http and https URLs and strips trailing slash', () => {
+        expect(tryNormalizeHttpUrlForFetch('https://api.example.com/')).toBe('https://api.example.com');
+        expect(tryNormalizeHttpUrlForFetch('http://localhost:3300')).toBe('http://localhost:3300');
+    });
+
+    it('rejects non-http(s) schemes, credentials, and query or fragment', () => {
+        expect(tryNormalizeHttpUrlForFetch('file:///etc/passwd')).toBeNull();
+        expect(tryNormalizeHttpUrlForFetch('javascript:alert(1)')).toBeNull();
+        expect(tryNormalizeHttpUrlForFetch('http://user:pass@localhost:1')).toBeNull();
+        expect(tryNormalizeHttpUrlForFetch('http://localhost:1/?q=1')).toBeNull();
+        expect(tryNormalizeHttpUrlForFetch('http://localhost:1/#frag')).toBeNull();
+        expect(tryNormalizeHttpUrlForFetch('')).toBeNull();
+        expect(tryNormalizeHttpUrlForFetch('   ')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
Implements refresh token persistence and automatic refresh for the CLI (per long-session plan): browser PKCE stores access + refresh; `login --token` stores access only and clears any stored refresh; logout clears both.

## Changes
- **`src/cli/oauth-refresh.ts`**: well-known metadata fetch, `refresh_token` grant, JWT expiry helper for proactive refresh (~60s skew).
- **`src/cli/keyring.ts`**: separate keyring account suffix for refresh tokens (`::refresh`).
- **Config**: `refreshToken` in file/keyring; split `config-file-internals.ts` + `config-file-write.ts` to satisfy max-lines.
- **`ApiClient`**: singleflight refresh on 401 before browser login; optional proactive refresh when JWT is near expiry.
- **Docs**: `auth-overview.md`, `CLI.md`, `SECURITY.md` (session/cookie vs IdP, MCP host re-read caveat).
- **Tests**: `tests/unit/oauth-refresh.test.ts` (mock fetch).

## Notes
- Keycloak realm session length unchanged (repo already uses 7d where applicable).
- Full `npm test` passed locally (including flaky retry if needed).

Refs: CLI shared config / MCP hosts that only read bearer once should re-read config or mirror refresh logic (documented).