### PR TITLE
feat(integrations): Cursor plugin bundle + install docs

### DIFF
--- a/docs/INSTALL-MCP.md
+++ b/docs/INSTALL-MCP.md
@@ -14,6 +14,18 @@ in the root [README](../README.md).
 If your server is running elsewhere, replace `http://localhost:3000` with your
 actual base URL.
 
+## Install modes
+
+You can connect in two ways:
+
+1. **Manual MCP JSON** — add a streamable HTTP server under `mcpServers` in
+   Cursor (see [Manual config](#manual-config)). This does not use Cursor plugin
+   packaging; the small icon next to a tool run is usually generic host chrome.
+2. **Local Cursor plugin** — install the bundled plugin under
+   `integrations/cursor/plugin` (see [Cursor plugin bundle](#cursor-plugin-bundle-branded-tool-row)).
+   The manifest includes a `logo` path so Cursor can show KAIROS branding on
+   the tool row while requests still go to the same HTTP MCP URL you configure.
+
 ## One-click install
 
 The following Cursor deeplink pre-fills a local HTTP MCP server (current tool
@@ -48,6 +60,22 @@ Open **Settings → MCP → Edit config** in Cursor and add:
 
 `alwaysAllow` is optional, but without it Cursor may prompt before running each
 tool.
+
+## Cursor plugin bundle (branded tool row)
+
+For a **plugin-packaged** install with a manifest `logo`, use the directory
+`integrations/cursor/plugin` in this repository. It contains:
+
+- `.cursor-plugin/plugin.json` — plugin metadata and `logo: "assets/logo.svg"`
+- `assets/logo.svg` — same artwork as `logo/kaiiros-mcp.svg`
+- `mcp/mcp.json` — `mcpServers` block (defaults to `http://localhost:3300/mcp`,
+  matching the common local dev port in `.cursor/mcp.json` examples in this
+  repo)
+
+Point Cursor at that folder per [Cursor plugin
+building](https://cursor.com/docs/plugins/building). Edit `mcp/mcp.json` if
+your server URL or port differs. Step-by-step notes live in
+`integrations/cursor/plugin/README.md`.
 
 ## In-chat widgets (MCP Apps) and alternate HTML profile
 
@@ -104,9 +132,11 @@ the same calls still return full structured content on the wire.
 
 The small logo next to a tool run in chat is **host chrome** (Cursor or a
 bundled MCP plugin), not something the streamable HTTP MCP wire defines. A plain
-`mcp.json` entry usually does not add a custom icon; marketplace or extension
-packaging does. For KAIROS artwork you can reuse `logo/kaiiros-mcp.svg` in your
-own connector or docs.
+user `mcp.json` entry usually does not add a custom icon. To get the KAIROS mark
+on the tool row, install the **local Cursor plugin** under
+`integrations/cursor/plugin` (see [Cursor plugin bundle](#cursor-plugin-bundle-branded-tool-row)).
+You can still reuse `logo/kaiiros-mcp.svg` in your own connector assets or docs
+if you maintain a custom package.
 
 ## Auth-enabled servers
 

--- a/integrations/cursor/plugin/.cursor-plugin/plugin.json
+++ b/integrations/cursor/plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "kairos-mcp",
+  "version": "1.0.0",
+  "description": "KAIROS MCP over streamable HTTP — persistent memory and deterministic adapter execution for agents.",
+  "author": {
+    "name": "Jakub Plichcinski",
+    "email": "kuba@xpl.pl"
+  },
+  "homepage": "https://github.com/debian777/kairos-mcp",
+  "repository": "https://github.com/debian777/kairos-mcp",
+  "license": "MIT",
+  "keywords": ["kairos", "mcp", "memory", "adapters", "workflows"],
+  "logo": "assets/logo.svg",
+  "mcpServers": "mcp/mcp.json"
+}

--- a/integrations/cursor/plugin/README.md
+++ b/integrations/cursor/plugin/README.md
@@ -1,0 +1,48 @@
+# KAIROS MCP — Cursor plugin (local)
+
+This folder is a **Cursor plugin** bundle: manifest, logo, and MCP server config
+for connecting to the KAIROS streamable HTTP endpoint. Use it when you want
+Cursor’s tool row to show the KAIROS logo (plugin metadata), not only a manual
+`mcp.json` entry.
+
+Official artwork matches [logo/kaiiros-mcp.svg](../../../logo/kaiiros-mcp.svg)
+in the repository root (copied here as `assets/logo.svg`).
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `.cursor-plugin/plugin.json` | Plugin manifest (`logo`, `mcpServers` → `mcp/mcp.json`) |
+| `assets/logo.svg` | Logo referenced by the manifest |
+| `mcp/mcp.json` | `mcpServers` block (same shape as user-level MCP config) |
+
+## Prerequisites
+
+- A running KAIROS server on the URL you configure (default in `mcp/mcp.json` is
+  `http://localhost:3300/mcp`, aligned with local dev in this repo).
+- Cursor with support for [Cursor
+  plugins](https://cursor.com/docs/plugins/building).
+
+## Install (local plugin directory)
+
+1. Start KAIROS and confirm health on the base URL you will use (for example
+   `curl http://localhost:3300/health`).
+2. If your server is not on port **3300**, edit
+   `mcp/mcp.json` and set `"url"` to your `/mcp` endpoint.
+3. In Cursor, install this directory as a plugin: use the folder that **contains**
+   `.cursor-plugin` (that is, this `integrations/cursor/plugin` directory), per
+   Cursor’s plugin docs. If your Cursor build only offers user-level MCP JSON,
+   use [docs/INSTALL-MCP.md](../../../docs/INSTALL-MCP.md) instead.
+
+## Verify
+
+1. Open a chat that can call MCP tools.
+2. Run **`spaces`** (empty `{}` is enough).
+3. Confirm the **KAIROS** logo appears next to the tool run in the tool row and
+   that the call still hits your HTTP MCP server (same behavior as a manual
+   `mcp.json` entry).
+
+## Trademark
+
+The name and logo are governed by [TRADEMARK.md](../../../TRADEMARK.md). Use this
+bundle to connect to **official** KAIROS MCP, not for unrelated distributions.

--- a/integrations/cursor/plugin/assets/logo.svg
+++ b/integrations/cursor/plugin/assets/logo.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <title>KAIROS Logo 16 - Deterministic Path</title>
+  <defs>
+  <linearGradient id="grad-a" x1="64" y1="64" x2="448" y2="448" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#7C3AED"/>
+    <stop offset="0.5" stop-color="#06B6D4"/>
+    <stop offset="1" stop-color="#22C55E"/>
+  </linearGradient>
+  <linearGradient id="grad-b" x1="96" y1="416" x2="416" y2="96" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#F97316"/>
+    <stop offset="1" stop-color="#FACC15"/>
+  </linearGradient>
+</defs>
+  <rect width="512" height="512" rx="112" fill="#08111F"/>
+  <path d="M118 336c48 0 48-160 96-160s48 160 96 160s48-160 96-160" fill="none" stroke="#223454" stroke-width="24" stroke-linecap="round"/>
+  <path d="M118 336c48 0 48-160 96-160s48 160 96 160s48-160 96-160" fill="none" stroke="url(#grad-a)" stroke-width="12" stroke-linecap="round"/>
+  <g>
+    <circle cx="118" cy="336" r="20" fill="#F8FAFC"/>
+    <circle cx="214" cy="176" r="20" fill="#F97316"/>
+    <circle cx="310" cy="336" r="20" fill="#06B6D4"/>
+    <circle cx="406" cy="176" r="20" fill="#22C55E"/>
+  </g>
+</svg>

--- a/integrations/cursor/plugin/mcp/mcp.json
+++ b/integrations/cursor/plugin/mcp/mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "DEVELOPMENT_KAIROS": {
+      "type": "streamable-http",
+      "url": "http://localhost:3300/mcp",
+      "alwaysAllow": [
+        "activate",
+        "forward",
+        "train",
+        "reward",
+        "tune",
+        "delete",
+        "export",
+        "spaces"
+      ],
+      "disabled": false,
+      "disabledTools": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a local **Cursor plugin** layout under `integrations/cursor/plugin/` (manifest with `logo`, `mcp/mcp.json` for streamable HTTP) so hosts can show KAIROS branding on the tool row while traffic stays HTTP MCP.

Updates `docs/INSTALL-MCP.md` with **install modes**: manual `mcp.json` vs plugin bundle, and points the tool-row icon section at the plugin path.

## Defaults

- `mcp/mcp.json` uses `DEVELOPMENT_KAIROS` and `http://localhost:3300/mcp` to align with maintainer `.cursor/mcp.json` / local dev in this repo. Users on Docker quick start (port 3000) should edit the URL.

## Note

Branch `feat/integrations` already contains a similar plugin with different naming (`assets/kaiiros-mcp.svg`, `KAIROS` @ 3000). This PR targets `main` as requested; maintainers may want to reconcile the two branches.

## Verification

Manual: install plugin folder in Cursor, run `spaces`, confirm tool-row logo (host-dependent).