### PR TITLE
eslint: enforce CodeQL line comment integrity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ test-*.js
 
 # Test files that might be created during development
 *.test.js
+!tests/unit/kairos-codeql-line-comments.rule.test.js
 *.test.cjs
 *.spec.js
 *.spec.cjs

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,5 +1,6 @@
 // eslint.config.cjs — thin entry; full flat config lives under eslint/
 // Forbidden tokens (incl. standalone v10): eslint/plugins/kairos-forbidden-text.cjs
+// CodeQL `// codeql[js/…]:` line integrity: eslint/plugins/kairos-codeql-line-comments.cjs
 // MCP Apps widgets (handshake + HTML shell): eslint/plugins/kairos-mcp-widget.cjs
 // Scope: src/, scripts/, tests/ code + **/*.md + context7.json (see eslint/flat-config.cjs)
 // Inline eslint-disable / file comments cannot change rules (linterOptions.noInlineConfig).

--- a/eslint/flat-config.cjs
+++ b/eslint/flat-config.cjs
@@ -7,6 +7,7 @@ const {
 } = require('./rules/shared-snippets.cjs');
 const { markdownPlainTextParser } = require('./parsers/markdown-plain-text.cjs');
 const { kairosForbiddenTextPlugin } = require('./plugins/kairos-forbidden-text.cjs');
+const { kairosCodeqlLineCommentsPlugin } = require('./plugins/kairos-codeql-line-comments.cjs');
 const { kairosMcpWidgetPlugin } = require('./plugins/kairos-mcp-widget.cjs');
 
 const tsParser = require('@typescript-eslint/parser');
@@ -191,6 +192,7 @@ function createFlatConfig(rootDir) {
       },
       plugins: {
         '@typescript-eslint': tsPlugin,
+        'kairos-codeql-comments': kairosCodeqlLineCommentsPlugin,
       },
       rules: {
         'max-lines': [
@@ -209,6 +211,7 @@ function createFlatConfig(rootDir) {
             caughtErrorsIgnorePattern: '^_',
           },
         ],
+        'kairos-codeql-comments/codeql-line-comment-integrity': 'error',
         ...NO_AUTH_ENABLED_OVERRIDE_RULE,
       },
     },

--- a/eslint/plugins/kairos-codeql-line-comments.cjs
+++ b/eslint/plugins/kairos-codeql-line-comments.cjs
@@ -1,0 +1,93 @@
+'use strict';
+
+/** Minimum characters in the justification after `]:` (trimmed). */
+const DEFAULT_MIN_JUSTIFICATION = 20;
+
+/** Paths (POSIX, suffix match) where log-injection must be handled via sanitization, not CodeQL line annotations. */
+const NO_LOG_INJECTION_SUPPRESSION_SUFFIXES = ['src/utils/structured-logger.ts'];
+
+/**
+ * @param {string} absPath
+ * @returns {string}
+ */
+function toPosixPath(absPath) {
+  return absPath.replace(/\\/g, '/');
+}
+
+const kairosCodeqlLineCommentsPlugin = {
+  rules: {
+    'codeql-line-comment-integrity': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Require substantive `// codeql[js/...]:` justifications and forbid log-injection suppressions in structured-logger (use sanitizeLogMessage / sanitizeBindingsForAudit).',
+        },
+        schema: [
+          {
+            type: 'object',
+            properties: {
+              minJustificationLength: { type: 'integer', minimum: 1 },
+            },
+            additionalProperties: false,
+          },
+        ],
+      },
+      create(context) {
+        const minLen =
+          context.options[0] && typeof context.options[0].minJustificationLength === 'number'
+            ? context.options[0].minJustificationLength
+            : DEFAULT_MIN_JUSTIFICATION;
+        const sourceCode = context.sourceCode;
+        const posixFile = toPosixPath(context.filename || '');
+        const forbidLogInjectionHere = NO_LOG_INJECTION_SUPPRESSION_SUFFIXES.some(suffix =>
+          posixFile.endsWith(suffix),
+        );
+
+        return {
+          Program() {
+            for (const comment of sourceCode.getAllComments()) {
+              if (comment.type !== 'Line') continue;
+              const raw = comment.value;
+              const idx = raw.indexOf('codeql[');
+              if (idx === -1) continue;
+              const fromCodeql = raw.slice(idx);
+              const idMatch = fromCodeql.match(/^codeql\[([^\]\r\n]+)\]/);
+              if (!idMatch) continue;
+
+              const queryId = idMatch[1].trim();
+              const afterBracket = fromCodeql.slice(idMatch[0].length);
+              const justificationMatch = afterBracket.match(/^\s*:\s*(.*)$/);
+              const justification = justificationMatch ? justificationMatch[1].trim() : '';
+
+              const absStart = comment.range[0] + 2 + idx;
+              const absEnd = absStart + idMatch[0].length;
+              const locBracket = {
+                start: sourceCode.getLocFromIndex(absStart),
+                end: sourceCode.getLocFromIndex(absEnd),
+              };
+
+              if (forbidLogInjectionHere && /^js\/log-injection$/i.test(queryId)) {
+                context.report({
+                  loc: locBracket,
+                  message:
+                    'Do not use CodeQL line annotations for js/log-injection in structured-logger: pass messages and bindings through sanitizeLogMessage and sanitizeBindingsForAudit before the sink (same pattern as info(object, string)).',
+                });
+                continue;
+              }
+
+              if (!justificationMatch || justification.length < minLen) {
+                context.report({
+                  loc: locBracket,
+                  message: `CodeQL line comment must include ": " and at least ${minLen} characters of justification after the rule id (merge-safe rationale). Found ${justification.length} character(s).`,
+                });
+              }
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
+module.exports = { kairosCodeqlLineCommentsPlugin };

--- a/tests/unit/kairos-codeql-line-comments.rule.test.js
+++ b/tests/unit/kairos-codeql-line-comments.rule.test.js
@@ -1,0 +1,62 @@
+/**
+ * @file ESLint rule tests for kairos-codeql-comments/codeql-line-comment-integrity
+ */
+'use strict';
+
+const { RuleTester } = require('eslint');
+const tsParser = require('@typescript-eslint/parser');
+const { kairosCodeqlLineCommentsPlugin } = require('../../eslint/plugins/kairos-codeql-line-comments.cjs');
+
+const rule = kairosCodeqlLineCommentsPlugin.rules['codeql-line-comment-integrity'];
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    parserOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+  },
+});
+
+ruleTester.run('codeql-line-comment-integrity', rule, {
+  valid: [
+    {
+      code: "// codeql[js/file-access-to-http]: outbound URL is derived from normalized config, not raw text.",
+      filename: 'src/cli/example.ts',
+    },
+    {
+      code: 'const x = 1;\n// codeql[js/user-controlled-bypass]: Method is restricted to GET and allowlisted verbs only.\nconst y = 2;',
+      filename: 'src/http/middleware.ts',
+    },
+  ],
+  invalid: [
+    {
+      code: '// codeql[js/foo]: short',
+      filename: 'src/x.ts',
+      errors: [
+        {
+          message: /at least 20 characters/,
+        },
+      ],
+    },
+    {
+      code: '// codeql[js/bar]',
+      filename: 'src/x.ts',
+      errors: [
+        {
+          message: /at least 20 characters/,
+        },
+      ],
+    },
+    {
+      code: '// codeql[js/log-injection]: false positive',
+      filename: 'src/utils/structured-logger.ts',
+      errors: [
+        {
+          message: /Do not use CodeQL line annotations for js\/log-injection/,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Adds a local ESLint rule (`kairos-codeql-comments/codeql-line-comment-integrity`) so `// codeql[js/…]` line annotations stay reviewable: each must include `: ` plus at least 20 characters of justification (avoids merge churn that wipes rationale).

For `src/utils/structured-logger.ts`, `js/log-injection` annotations are rejected in favor of the existing sanitization path (`sanitizeLogMessage` / `sanitizeBindingsForAudit`).

## Test plan

- `npx eslint .`
- `npx jest tests/unit/kairos-codeql-line-comments.rule.test.js`
