### PR TITLE
fix(auth): OIDC logout → continue-signin → login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 
 # Python (skills-ref, lint_skills.py)
 .venv/
+**/__pycache__/
+*.py[cod]
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/scripts/configure-keycloak-realms.py
+++ b/scripts/configure-keycloak-realms.py
@@ -118,18 +118,28 @@ def dev_app_port_bounds(env: dict) -> tuple[int, int]:
     return lo, hi
 
 
-def build_kairos_mcp_dev_redirect_lists(env: dict) -> tuple[list[str], list[str]]:
+def build_kairos_mcp_dev_redirect_lists(env: dict) -> tuple[list[str], list[str], str]:
     """
     Build redirectUris and webOrigins for kairos-mcp (dev) from port range + optional callback base.
+    Also returns post.logout.redirect.uris (##-separated) for OIDC RP-initiated logout → continue-signin.
     """
     lo, hi = dev_app_port_bounds(env)
     redirect_uris: list[str] = []
     web_origins: list[str] = []
+    post_logout: list[str] = []
     for port in range(lo, hi + 1):
         redirect_uris.extend(
             (
                 f"http://localhost:{port}/auth/callback",
                 f"http://127.0.0.1:{port}/auth/callback",
+                f"http://localhost:{port}/auth/continue-signin",
+                f"http://127.0.0.1:{port}/auth/continue-signin",
+            )
+        )
+        post_logout.extend(
+            (
+                f"http://localhost:{port}/auth/continue-signin",
+                f"http://127.0.0.1:{port}/auth/continue-signin",
             )
         )
         web_origins.extend((f"http://localhost:{port}", f"http://127.0.0.1:{port}"))
@@ -139,10 +149,16 @@ def build_kairos_mcp_dev_redirect_lists(env: dict) -> tuple[list[str], list[str]
         callback = f"{base}/auth/callback"
         if callback not in redirect_uris:
             redirect_uris.append(callback)
+        resume = f"{base}/auth/continue-signin"
+        if resume not in redirect_uris:
+            redirect_uris.append(resume)
+        if resume not in post_logout:
+            post_logout.append(resume)
         if base not in web_origins:
             web_origins.append(base)
 
-    return redirect_uris, web_origins
+    post_logout_uris = "##".join(post_logout)
+    return redirect_uris, web_origins, post_logout_uris
 
 
 def apply_kairos_mcp_dev_client_urls(desired: dict, env: dict, realm_name: str) -> None:
@@ -152,12 +168,16 @@ def apply_kairos_mcp_dev_client_urls(desired: dict, env: dict, realm_name: str) 
     """
     if realm_name != "kairos-dev":
         return
-    redirect_uris, web_origins = build_kairos_mcp_dev_redirect_lists(env)
+    redirect_uris, web_origins, post_logout_uris = build_kairos_mcp_dev_redirect_lists(env)
     for client in desired.get("clients") or []:
         if client.get("clientId") != "kairos-mcp":
             continue
         client["redirectUris"] = redirect_uris
         client["webOrigins"] = web_origins
+        attrs = dict(client.get("attributes") or {})
+        attrs["post.logout.redirect.uris"] = post_logout_uris
+        attrs["logout.confirmation.enabled"] = "false"
+        client["attributes"] = attrs
         break
 
 
@@ -320,6 +340,11 @@ def push_kairos_mcp_redirect_config(
         patch["redirectUris"] = list(ru)
     if wo is not None:
         patch["webOrigins"] = list(wo)
+    att = mcp_desired.get("attributes")
+    if isinstance(att, dict) and att:
+        merged = dict(patch.get("attributes") or {})
+        merged.update(att)
+        patch["attributes"] = merged
 
     url = f"{base_url.rstrip('/')}/admin/realms/{realm_name}/clients/{internal_id}"
     payload = json.dumps(patch).encode("utf-8")

--- a/scripts/keycloak/import/kairos-dev-realm.json
+++ b/scripts/keycloak/import/kairos-dev-realm.json
@@ -34,14 +34,22 @@
         "http://localhost:3300/auth/callback",
         "http://localhost:3301/auth/callback",
         "http://127.0.0.1:3300/auth/callback",
-        "http://127.0.0.1:3301/auth/callback"
+        "http://127.0.0.1:3301/auth/callback",
+        "http://localhost:3300/auth/continue-signin",
+        "http://localhost:3301/auth/continue-signin",
+        "http://127.0.0.1:3300/auth/continue-signin",
+        "http://127.0.0.1:3301/auth/continue-signin"
       ],
       "webOrigins": [
         "http://localhost:3300",
         "http://localhost:3301",
         "http://127.0.0.1:3300",
         "http://127.0.0.1:3301"
-      ]
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3300/auth/continue-signin##http://localhost:3301/auth/continue-signin##http://127.0.0.1:3300/auth/continue-signin##http://127.0.0.1:3301/auth/continue-signin",
+        "logout.confirmation.enabled": "false"
+      }
     },
     {
       "clientId": "kairos-cli",

--- a/scripts/keycloak/import/kairos-prod-realm.json
+++ b/scripts/keycloak/import/kairos-prod-realm.json
@@ -29,12 +29,18 @@
       "directAccessGrantsEnabled": false,
       "redirectUris": [
         "http://localhost:3000/auth/callback",
-        "http://127.0.0.1:3000/auth/callback"
+        "http://127.0.0.1:3000/auth/callback",
+        "http://localhost:3000/auth/continue-signin",
+        "http://127.0.0.1:3000/auth/continue-signin"
       ],
       "webOrigins": [
         "http://localhost:3000",
         "http://127.0.0.1:3000"
-      ]
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3000/auth/continue-signin##http://127.0.0.1:3000/auth/continue-signin",
+        "logout.confirmation.enabled": "false"
+      }
     },
     {
       "clientId": "kairos-cli",

--- a/src/http/http-auth-callback.ts
+++ b/src/http/http-auth-callback.ts
@@ -18,7 +18,12 @@ import {
   OIDC_GROUPS_ALLOWLIST
 } from '../config.js';
 import { structuredLogger } from '../utils/structured-logger.js';
-import { getStateStore, SESSION_COOKIE_NAME } from './http-auth-middleware.js';
+import {
+  buildOidcEndSessionRedirectUrl,
+  getOidcStateStore,
+  redirectBrowserToOidcLogin
+} from './http-auth-oidc-redirect.js';
+import { peekOidcIdTokenHintFromSession, SESSION_COOKIE_NAME } from './http-auth-middleware.js';
 import {
   applyOidcGroupsAllowlist,
   decodeJwtPayloadSegment,
@@ -43,6 +48,16 @@ const useSecureCookie = AUTH_CALLBACK_BASE_URL.trim().toLowerCase().startsWith('
 /** Cookie options must match those used when setting the session (Path=/) so the browser clears it. */
 const COOKIE_CLEAR_OPTIONS = { path: '/', httpOnly: true, sameSite: 'lax' as const, secure: useSecureCookie };
 
+/** Keycloak post_logout_redirect_uri target: immediately starts a new OIDC login (no logged-out landing in our app). */
+const AUTH_CONTINUE_SIGNIN_PATH = '/auth/continue-signin';
+
+function redirectContinueSignin(_req: Request, res: Response): void {
+  if (AUTH_ENABLED && redirectBrowserToOidcLogin(res)) {
+    return;
+  }
+  res.redirect(302, '/ui/');
+}
+
 export function setupAuthCallback(app: express.Express): void {
   // Base /auth: redirect to UI (browser) or 404 for API
   app.get('/auth', (_req: Request, res: Response) => {
@@ -54,14 +69,32 @@ export function setupAuthCallback(app: express.Express): void {
     res.redirect(302, '/ui/');
   });
 
-  app.get('/auth/logout', (_req: Request, res: Response) => {
+  /**
+   * Clear Kairos session, end Keycloak SSO (RP-initiated logout), then continue at continue-signin → OIDC login.
+   * id_token_hint (when present in session) avoids Keycloak static logged-out confirmation where supported.
+   */
+  app.get('/auth/logout', (req: Request, res: Response) => {
+    const idHint = peekOidcIdTokenHintFromSession(req);
     res.clearCookie(SESSION_COOKIE_NAME, COOKIE_CLEAR_OPTIONS);
+    const base = AUTH_CALLBACK_BASE_URL?.trim().replace(/\/$/, '');
+    if (AUTH_ENABLED && base) {
+      const resume = `${base}${AUTH_CONTINUE_SIGNIN_PATH}`;
+      const endSession = buildOidcEndSessionRedirectUrl(resume, idHint);
+      if (endSession) {
+        res.redirect(302, endSession);
+        return;
+      }
+    }
+    if (AUTH_ENABLED && redirectBrowserToOidcLogin(res)) {
+      return;
+    }
     res.redirect(302, '/ui/');
   });
 
-  app.get('/auth/logged-out', (_req: Request, res: Response) => {
-    res.redirect(302, '/ui/');
-  });
+  app.get(AUTH_CONTINUE_SIGNIN_PATH, redirectContinueSignin);
+
+  /** Optional IdP post-logout redirect target (same as continue-signin). */
+  app.get('/auth/logged-out', redirectContinueSignin);
 
   app.get('/auth/callback', async (req: Request, res: Response) => {
     if (!AUTH_ENABLED || !KEYCLOAK_URL || !SESSION_SECRET || !AUTH_CALLBACK_BASE_URL) {
@@ -76,7 +109,7 @@ export function setupAuthCallback(app: express.Express): void {
       res.redirect(302, '/?error=missing_code_or_state');
       return;
     }
-    const store = getStateStore();
+    const store = getOidcStateStore();
     const entry = store.get(state);
     store.delete(state);
     if (!entry) {
@@ -141,9 +174,10 @@ export function setupAuthCallback(app: express.Express): void {
     const { merged } = mergedResult;
     merged.groups = applyOidcGroupsAllowlist(merged.groups, OIDC_GROUPS_ALLOWLIST);
     const exp = Math.floor(Date.now() / 1000) + SESSION_MAX_AGE_SEC;
-    const sessionPayload: MergedCallbackClaims & { exp: number } = {
+    const sessionPayload: MergedCallbackClaims & { exp: number; oidc_id_token?: string } = {
       ...merged,
-      exp
+      exp,
+      ...(idToken ? { oidc_id_token: idToken } : {})
     };
     const cookieValue = signSession(sessionPayload);
     res.setHeader('Set-Cookie', [

--- a/src/http/http-auth-middleware.ts
+++ b/src/http/http-auth-middleware.ts
@@ -6,13 +6,11 @@
 import type { Request, Response, NextFunction } from 'express';
 import { METHODS } from 'node:http';
 import crypto from 'crypto';
+import { createOidcLoginUrlForApiResponse, redirectBrowserToOidcLogin } from './http-auth-oidc-redirect.js';
 import { fromBase64url, toBase64url } from '@exodus/bytes/base64.js';
 import { utf8toString } from '@exodus/bytes/utf8.js';
 import {
   AUTH_ENABLED,
-  KEYCLOAK_URL,
-  KEYCLOAK_REALM,
-  KEYCLOAK_CLIENT_ID,
   AUTH_CALLBACK_BASE_URL,
   SESSION_SECRET,
   AUTH_MODE,
@@ -28,38 +26,7 @@ import { structuredLogger } from '../utils/structured-logger.js';
 export type { AuthPayload };
 
 const SESSION_COOKIE_NAME = 'kairos_session';
-const STATE_TTL_MS = 600_000; // 10 min
 const KNOWN_HTTP_METHODS = new Set<string>(METHODS);
-
-interface StateEntry {
-  codeVerifier: string;
-  createdAt: number;
-}
-const stateStore = new Map<string, StateEntry>();
-
-function pruneStateStore(): void {
-  const now = Date.now();
-  for (const [k, v] of stateStore.entries()) {
-    if (now - v.createdAt > STATE_TTL_MS) stateStore.delete(k);
-  }
-}
-
-function buildLoginUrl(state: string, codeChallenge: string): string {
-  const base = KEYCLOAK_URL.replace(/\/$/, '');
-  const redirectUri = `${AUTH_CALLBACK_BASE_URL.replace(/\/$/, '')}/auth/callback`;
-  const params = new URLSearchParams({
-    client_id: KEYCLOAK_CLIENT_ID,
-    redirect_uri: redirectUri,
-    response_type: 'code',
-    scope: 'openid profile email',
-    state,
-    code_challenge: codeChallenge,
-    code_challenge_method: 'S256',
-    // Force login page so a second browser gets a fresh login instead of SSO "already logged in" errors.
-    prompt: 'login'
-  });
-  return `${base}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/auth?${params.toString()}`;
-}
 
 function getSessionCookie(req: Request): string | null {
   const raw = req.get('cookie');
@@ -74,8 +41,8 @@ function hasValidSession(req: Request): boolean {
   return getSessionPayload(req) !== null;
 }
 
-/** Decode and verify session cookie; returns AuthPayload or null. */
-function getSessionPayload(req: Request): AuthPayload | null {
+/** Verify HMAC and parse session cookie JSON; does not check exp/sub. */
+function parseVerifiedSessionRecord(req: Request): Record<string, unknown> | null {
   const cookie = getSessionCookie(req);
   if (!cookie || !SESSION_SECRET) return null;
   try {
@@ -85,49 +52,63 @@ function getSessionPayload(req: Request): AuthPayload | null {
       new Uint8Array(crypto.createHmac('sha256', SESSION_SECRET).update(payloadB64).digest())
     );
     if (sig !== expectedSig) return null;
-    const payload = JSON.parse(utf8toString(fromBase64url(payloadB64))) as {
-      sub?: string;
-      groups?: string[];
-      iss?: string;
-      realm?: string;
-      exp?: number;
-      preferred_username?: string;
-      name?: string;
-      given_name?: string;
-      family_name?: string;
-      email?: string;
-      email_verified?: boolean;
-      identity_provider?: string;
-      account_kind?: string;
-      account_label?: string;
-    };
-    if (payload.exp && payload.exp < Date.now() / 1000) return null;
-    const sub = typeof payload.sub === 'string' ? payload.sub : '';
-    if (!sub) return null;
-    const rawGroups = Array.isArray(payload.groups) ? payload.groups.filter((g): g is string => typeof g === 'string') : [];
-    const groups = applyOidcGroupsAllowlist(rawGroups, OIDC_GROUPS_ALLOWLIST);
-    const realm = typeof payload.realm === 'string' ? payload.realm : 'default';
-    const iss =
-      typeof payload.iss === 'string' && payload.iss.length > 0
-        ? payload.iss
-        : `realm:${realm}`;
-    const result: AuthPayload = { sub, groups, realm, iss };
-    if (typeof payload.preferred_username === 'string' && payload.preferred_username.length > 0)
-      result.preferred_username = payload.preferred_username;
-    if (typeof payload.name === 'string' && payload.name.length > 0) result.name = payload.name;
-    if (typeof payload.given_name === 'string' && payload.given_name.length > 0) result.given_name = payload.given_name;
-    if (typeof payload.family_name === 'string' && payload.family_name.length > 0) result.family_name = payload.family_name;
-    if (typeof payload.email === 'string' && payload.email.length > 0) result.email = payload.email;
-    if (payload.email_verified === true || payload.email_verified === false) result.email_verified = payload.email_verified;
-    if (typeof payload.identity_provider === 'string' && payload.identity_provider.length > 0)
-      result.identity_provider = payload.identity_provider;
-    if (payload.account_kind === 'local' || payload.account_kind === 'sso') result.account_kind = payload.account_kind;
-    if (typeof payload.account_label === 'string' && payload.account_label.length > 0)
-      result.account_label = payload.account_label;
-    return result;
+    return JSON.parse(utf8toString(fromBase64url(payloadB64))) as Record<string, unknown>;
   } catch {
     return null;
   }
+}
+
+/**
+ * OIDC id_token from login callback, stored only in the httpOnly session cookie for RP-initiated logout
+ * (id_token_hint → Keycloak can skip the static logged-out confirmation screen when configured).
+ */
+export function peekOidcIdTokenHintFromSession(req: Request): string | null {
+  const payload = parseVerifiedSessionRecord(req);
+  if (!payload) return null;
+  const exp = payload['exp'];
+  if (typeof exp === 'number' && exp < Date.now() / 1000) return null;
+  const t = payload['oidc_id_token'];
+  return typeof t === 'string' && t.length > 0 ? t : null;
+}
+
+/** Decode and verify session cookie; returns AuthPayload or null. */
+function getSessionPayload(req: Request): AuthPayload | null {
+  const payload = parseVerifiedSessionRecord(req);
+  if (!payload) return null;
+  const exp = payload['exp'];
+  if (typeof exp === 'number' && exp < Date.now() / 1000) return null;
+  const sub = typeof payload['sub'] === 'string' ? payload['sub'] : '';
+  if (!sub) return null;
+  const rawGroups = Array.isArray(payload['groups'])
+    ? payload['groups'].filter((g): g is string => typeof g === 'string')
+    : [];
+  const groups = applyOidcGroupsAllowlist(rawGroups, OIDC_GROUPS_ALLOWLIST);
+  const realm = typeof payload['realm'] === 'string' ? payload['realm'] : 'default';
+  const issRaw = payload['iss'];
+  const iss =
+    typeof issRaw === 'string' && issRaw.length > 0
+      ? issRaw
+      : `realm:${realm}`;
+  const result: AuthPayload = { sub, groups, realm, iss };
+  const pu = payload['preferred_username'];
+  if (typeof pu === 'string' && pu.length > 0) result.preferred_username = pu;
+  const name = payload['name'];
+  if (typeof name === 'string' && name.length > 0) result.name = name;
+  const gn = payload['given_name'];
+  if (typeof gn === 'string' && gn.length > 0) result.given_name = gn;
+  const fn = payload['family_name'];
+  if (typeof fn === 'string' && fn.length > 0) result.family_name = fn;
+  const em = payload['email'];
+  if (typeof em === 'string' && em.length > 0) result.email = em;
+  const ev = payload['email_verified'];
+  if (ev === true || ev === false) result.email_verified = ev;
+  const idp = payload['identity_provider'];
+  if (typeof idp === 'string' && idp.length > 0) result.identity_provider = idp;
+  const ak = payload['account_kind'];
+  if (ak === 'local' || ak === 'sso') result.account_kind = ak;
+  const al = payload['account_label'];
+  if (typeof al === 'string' && al.length > 0) result.account_label = al;
+  return result;
 }
 
 function getBearerToken(req: Request): string | null {
@@ -302,22 +283,18 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     return;
   }
 
-  const loginUrl = (s: string, cc: string) => buildLoginUrl(s, cc);
-  const state = crypto.randomBytes(16).toString('base64url');
-  const codeVerifier = crypto.randomBytes(32).toString('base64url');
-  const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url').replace(/=/g, '');
-  stateStore.set(state, { codeVerifier, createdAt: Date.now() });
-  pruneStateStore();
-
   // MCP client must receive 401 + WWW-Authenticate to show "Needs authentication" / Connect.
   // Redirect (302) would prevent discovery; always return 401 for /mcp.
   const isMcp = req.path === '/mcp';
   // codeql[js/user-controlled-bypass]: Redirect only when method is GET and listed in node:http METHODS; any other verb gets 401 JSON.
   if (isRecognizedGetRequest(req) && !isMcp) {
     structuredLogger.info(`[auth] 302 ${req.method} ${req.path} redirect to login`);
-    res.redirect(302, loginUrl(state, codeChallenge));
+    redirectBrowserToOidcLogin(res);
     return;
   }
+
+  const loginUrlForJson = createOidcLoginUrlForApiResponse();
+
   structuredLogger.info(
     `[auth] 401 ${req.method} ${req.path}${isMcp ? ' (announcing auth need for MCP client)' : ''}`
   );
@@ -325,12 +302,8 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
   res.status(401).json({
     error: 'Unauthorized',
     message: 'Authentication required',
-    login_url: loginUrl(state, codeChallenge)
+    login_url: loginUrlForJson
   });
-}
-
-export function getStateStore(): Map<string, StateEntry> {
-  return stateStore;
 }
 
 export { SESSION_COOKIE_NAME };

--- a/src/http/http-auth-oidc-redirect.ts
+++ b/src/http/http-auth-oidc-redirect.ts
@@ -1,0 +1,87 @@
+/**
+ * Browser OIDC login redirect + PKCE state shared by auth middleware and /auth/logout.
+ */
+import type { Response } from 'express';
+import crypto from 'crypto';
+import { KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID, AUTH_CALLBACK_BASE_URL } from '../config.js';
+
+const STATE_TTL_MS = 600_000; // 10 min
+
+export interface OidcStateEntry {
+  codeVerifier: string;
+  createdAt: number;
+}
+
+const stateStore = new Map<string, OidcStateEntry>();
+
+export function pruneOidcStateStore(): void {
+  const now = Date.now();
+  for (const [k, v] of stateStore.entries()) {
+    if (now - v.createdAt > STATE_TTL_MS) stateStore.delete(k);
+  }
+}
+
+export function getOidcStateStore(): Map<string, OidcStateEntry> {
+  return stateStore;
+}
+
+export function buildOidcAuthorizationUrl(state: string, codeChallenge: string): string {
+  if (!AUTH_CALLBACK_BASE_URL) {
+    throw new Error('AUTH_CALLBACK_BASE_URL is required for OIDC login URL');
+  }
+  const base = KEYCLOAK_URL.replace(/\/$/, '');
+  const redirectUri = `${AUTH_CALLBACK_BASE_URL.replace(/\/$/, '')}/auth/callback`;
+  const params = new URLSearchParams({
+    client_id: KEYCLOAK_CLIENT_ID,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'openid profile email',
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    prompt: 'login'
+  });
+  return `${base}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/auth?${params.toString()}`;
+}
+
+/**
+ * RP-initiated OIDC logout URL. After the IdP clears the SSO session it redirects to
+ * postLogoutRedirectUri (must be registered as a valid post-logout redirect for the client).
+ */
+export function buildOidcEndSessionRedirectUrl(postLogoutRedirectUri: string, idTokenHint: string | null): string | null {
+  if (!KEYCLOAK_URL || !KEYCLOAK_REALM || !KEYCLOAK_CLIENT_ID) {
+    return null;
+  }
+  const base = KEYCLOAK_URL.replace(/\/$/, '');
+  const u = new URL(`${base}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/logout`);
+  u.searchParams.set('client_id', KEYCLOAK_CLIENT_ID);
+  u.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+  if (idTokenHint) {
+    u.searchParams.set('id_token_hint', idTokenHint);
+  }
+  return u.toString();
+}
+
+/** Allocate PKCE state and redirect the browser to the IdP authorization endpoint. */
+export function redirectBrowserToOidcLogin(res: Response): boolean {
+  if (!AUTH_CALLBACK_BASE_URL) {
+    return false;
+  }
+  const state = crypto.randomBytes(16).toString('base64url');
+  const codeVerifier = crypto.randomBytes(32).toString('base64url');
+  const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url').replace(/=/g, '');
+  stateStore.set(state, { codeVerifier, createdAt: Date.now() });
+  pruneOidcStateStore();
+  res.redirect(302, buildOidcAuthorizationUrl(state, codeChallenge));
+  return true;
+}
+
+/** Register PKCE state and return the authorization URL (for JSON login_url). */
+export function createOidcLoginUrlForApiResponse(): string {
+  const state = crypto.randomBytes(16).toString('base64url');
+  const codeVerifier = crypto.randomBytes(32).toString('base64url');
+  const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url').replace(/=/g, '');
+  stateStore.set(state, { codeVerifier, createdAt: Date.now() });
+  pruneOidcStateStore();
+  return buildOidcAuthorizationUrl(state, codeChallenge);
+}


### PR DESCRIPTION
## Summary
Improves browser logout so users return to the OIDC login flow instead of lingering on the SPA or Keycloak’s static logged-out page where possible.

## Changes
- **`http-auth-oidc-redirect.ts`**: shared PKCE state, authorization URL builder, end-session (logout) URL builder, `redirectBrowserToOidcLogin`, `createOidcLoginUrlForApiResponse`.
- **`/auth/logout`**: clear `kairos_session`, then redirect to Keycloak `openid-connect/logout` with `post_logout_redirect_uri` pointing at `/auth/continue-signin`; `id_token_hint` taken from the signed session when an `id_token` was stored at callback (httpOnly, not exposed on `/api/me`).
- **`/auth/continue-signin`** and **`/auth/logged-out`**: immediately start the same OIDC login redirect as unauthenticated `GET /ui`.
- **Keycloak `kairos-mcp` client**: valid `/auth/continue-signin` URIs, `post.logout.redirect.uris`, `logout.confirmation.enabled=false`; `configure-keycloak-realms.py` applies `attributes` on client PUT and expands dev post-logout URIs.
- **`.gitignore`**: `**/__pycache__/`, `*.py[cod]`.

## Validation
- `npm test` (dev deploy + integration suite) passed locally.

## Notes
- After merge, run the usual Keycloak realm sync in each environment so client attributes and redirect URIs match.
- Untracked `scripts/env/create-env.sh` was left out of this PR (optional helper).