### PR TITLE
test(integration): adapter space move and fork (MCP, API, CLI)

### DIFF
--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -224,10 +224,38 @@ export class ApiClient {
         );
     }
 
-    async tune(uris: string[], markdownDoc?: SafeMarkdownUpload[], updates?: Record<string, unknown>): Promise<TuneOutput> {
+    async tune(
+        uris: string[],
+        opts?: {
+            markdownDoc?: SafeMarkdownUpload[];
+            updates?: Record<string, unknown>;
+            space?: string;
+        }
+    ): Promise<TuneOutput> {
+        const body: Record<string, unknown> = { uris };
+        if (opts?.markdownDoc) body['markdown_doc'] = opts.markdownDoc;
+        if (opts?.updates) body['updates'] = opts.updates;
+        const sp = typeof opts?.space === 'string' ? opts.space.trim() : '';
+        if (sp.length > 0) body['space'] = sp;
         return this.request<TuneOutput>('/api/tune', {
             method: 'POST',
-            body: JSON.stringify({ uris, markdown_doc: markdownDoc, updates }),
+            body: JSON.stringify(body),
+        });
+    }
+
+    /** JSON body train (space, source_adapter_uri fork, etc.); distinct from markdown POST /api/train/raw. */
+    async trainJson(body: {
+        llm_model_id: string;
+        force_update?: boolean;
+        space?: string;
+        source_adapter_uri?: string;
+        markdown_doc?: string;
+        protocol_version?: string;
+    }): Promise<TrainOutput> {
+        return this.request<TrainOutput>('/api/train', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
         });
     }
 

--- a/src/cli/commands/cli-train.ts
+++ b/src/cli/commands/cli-train.ts
@@ -45,17 +45,63 @@ export function trainCliCommand(program: Command): void {
   program
     .command('train')
     .description('Register a new KAIROS adapter from markdown (file or directory of .md files)')
-    .argument('<path>', 'Path to a markdown file or a directory of .md files')
+    .argument(
+      '[path]',
+      'Path to a markdown file or a directory of .md files (omit when using --source-adapter-uri)'
+    )
     .option('--model <model>', 'LLM model ID for attribution (e.g., "gpt-4", "claude-3")')
     .option('--force', 'Force update if an adapter with the same label already exists')
     .option('--recursive', 'When path is a directory, include nested .md files')
+    .option(
+      '--source-adapter-uri <uri>',
+      'Fork from an existing adapter via POST /api/train (requires --model); optional --space for target space'
+    )
+    .option('--space <space>', 'Target space for train or fork (personal or group display name)')
     .option('--allow-sensitive-upload', 'Allow uploads that contain token-like or private-key-like text')
     .action(
       async (
-        target: string,
-        options: { model?: string; force?: boolean; recursive?: boolean; allowSensitiveUpload?: boolean }
+        target: string | undefined,
+        options: {
+          model?: string;
+          force?: boolean;
+          recursive?: boolean;
+          allowSensitiveUpload?: boolean;
+          sourceAdapterUri?: string;
+          space?: string;
+        }
       ) => {
         try {
+          const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+          const src = typeof options.sourceAdapterUri === 'string' ? options.sourceAdapterUri.trim() : '';
+          if (src.length > 0) {
+            if (target) {
+              writeError('Do not pass a path when using --source-adapter-uri');
+              process.exit(1);
+              return;
+            }
+            const model = options.model?.trim();
+            if (!model) {
+              writeError('--model is required when using --source-adapter-uri');
+              process.exit(1);
+              return;
+            }
+            const spaceOpt = typeof options.space === 'string' ? options.space.trim() : '';
+            const response = await client.trainJson({
+              llm_model_id: model,
+              force_update: Boolean(options.force),
+              source_adapter_uri: src,
+              ...(spaceOpt.length > 0 ? { space: spaceOpt } : {})
+            });
+            writeJson(response);
+            return;
+          }
+
+          if (!target) {
+            writeError('Missing path: provide a markdown file/directory or use --source-adapter-uri');
+            process.exit(1);
+            return;
+          }
+
           const abs = resolve(target);
           const st = statSync(abs, { throwIfNoEntry: false });
           if (!st) {
@@ -63,7 +109,6 @@ export function trainCliCommand(program: Command): void {
             process.exit(1);
           }
 
-          const client = new ApiClient(getResolvedApiBaseFromProgram(program));
           const trainOptions: { llmModelId?: string; force?: boolean } = {};
           if (options.model) trainOptions.llmModelId = options.model;
           if (options.force) trainOptions.force = options.force;

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -17,15 +17,32 @@ export function updateCommand(program: Command): void {
         .option('--file <file>', 'Path to markdown file to apply to all specified URIs')
         .option('--files <files...>', 'Paths to markdown files, one per URI (must match number of URIs)')
         .option('--updates <json>', 'Updates object as JSON string (alternative to --file/--files)')
+        .option(
+            '--space <space>',
+            'Move all layers of each target adapter to this space (e.g. personal or a group name). Use without --file for move-only.'
+        )
         .option('--allow-sensitive-upload', 'Allow uploads that contain token-like or private-key-like text')
         .action(async (
             uris: string[],
-            options: { file?: string; files?: string[]; updates?: string; allowSensitiveUpload?: boolean }
+            options: {
+                file?: string;
+                files?: string[];
+                updates?: string;
+                space?: string;
+                allowSensitiveUpload?: boolean;
+            }
         ) => {
             try {
                 const client = new ApiClient(getResolvedApiBaseFromProgram(program));
                 let markdownDoc: SafeMarkdownUpload[] | undefined;
                 let updates: Record<string, any> | undefined;
+                const rawSpace = typeof options.space === 'string' ? options.space.trim() : '';
+
+                if (rawSpace.length > 0 && !options.file && !options.files && !options.updates) {
+                    const response = await client.tune(uris, { space: rawSpace });
+                    writeJson(response);
+                    return;
+                }
 
                 if (options.files) {
                     // Multiple files, one per URI
@@ -54,12 +71,20 @@ export function updateCommand(program: Command): void {
                         return;
                     }
                 } else {
-                    writeError('Must provide either --file or --updates');
+                    writeError('Must provide either --file, --updates, or --space alone for move-only');
                     process.exit(1);
                     return;
                 }
 
-                const response = await client.tune(uris, markdownDoc, updates);
+                const tuneOpts: {
+                    markdownDoc?: SafeMarkdownUpload[];
+                    updates?: Record<string, unknown>;
+                    space?: string;
+                } = {};
+                if (markdownDoc) tuneOpts.markdownDoc = markdownDoc;
+                if (updates) tuneOpts.updates = updates;
+                if (rawSpace.length > 0) tuneOpts.space = rawSpace;
+                const response = await client.tune(uris, tuneOpts);
                 writeJson(response);
             } catch (error) {
                 if (error instanceof Error && error.message.includes('ENOENT')) {

--- a/tests/integration/adapter-space-fork.test.ts
+++ b/tests/integration/adapter-space-fork.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Group → personal: `train` with `source_adapter_uri` + `space: personal` copies (new adapter id).
+ * MCP, REST API, CLI (--source-adapter-uri).
+ */
+
+import { parseMcpJson, withRawOnFail } from '../utils/expect-with-raw.js';
+import { getAuthHeaders, getTestAuthBaseUrl } from '../utils/auth-headers.js';
+import {
+  buildSpaceMoveMarkdown,
+  locationsForAdapterTitle,
+  parseAdapterUuidFromUri,
+  sleepMs
+} from '../utils/adapter-space-test-helpers.js';
+import {
+  adapterSpaceSkipReason,
+  openAdapterSpaceMcpBundle
+} from './utils/adapter-space-mcp-context.js';
+import { BASE_URL, CLI_PATH, execAsync, setupCliConfigWithLogin, setupServerCheck } from './cli-commands-shared.js';
+
+const API_BASE = `${getTestAuthBaseUrl()}/api`;
+
+function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...(init?.headers as Record<string, string>) }
+  });
+}
+
+describe('Adapter fork copy (group → personal)', () => {
+  let bundle: Awaited<ReturnType<typeof openAdapterSpaceMcpBundle>> = null;
+  let serverOk = false;
+  let cliOk = false;
+
+  beforeAll(async () => {
+    serverOk = await setupServerCheck();
+    cliOk = await setupCliConfigWithLogin();
+    bundle = await openAdapterSpaceMcpBundle();
+  }, 120000);
+
+  afterAll(async () => {
+    if (bundle?.mcp) await bundle.mcp.close();
+  });
+
+  test('MCP: train fork copies group adapter into personal (group original unchanged)', async () => {
+    const why = adapterSpaceSkipReason(bundle, serverOk);
+    if (why || !bundle) {
+      console.warn(`[adapter-space-fork] skip MCP fork: ${why}`);
+      return;
+    }
+    expect.hasAssertions();
+    const { mcp, groupSpaceName, loadSpacesViaMcp } = bundle;
+    const title = `SpaceForkMCP ${Date.now()}`;
+    const md = buildSpaceMoveMarkdown(title);
+
+    const trainGroupCall = {
+      name: 'train',
+      arguments: {
+        markdown_doc: md,
+        llm_model_id: 'test-space-fork-mcp',
+        space: groupSpaceName,
+        force_update: true
+      }
+    };
+    const trainGroupRes = await mcp.client.callTool(trainGroupCall);
+    const stored = parseMcpJson(trainGroupRes, 'train-fork-mcp-group');
+    withRawOnFail({ call: trainGroupCall, result: trainGroupRes }, () => {
+      expect(stored.status).toBe('stored');
+    });
+    const sourceUri = stored.items[0].adapter_uri as string;
+    const sourceId = parseAdapterUuidFromUri(sourceUri);
+
+    await sleepMs(3500);
+    let spaces = await loadSpacesViaMcp();
+    let loc = locationsForAdapterTitle(spaces, title);
+    withRawOnFail({ call: trainGroupCall, result: trainGroupRes }, () => {
+      expect(loc.filter((l) => l.type === 'group').length).toBe(1);
+      expect(loc.some((l) => l.type === 'personal')).toBe(false);
+    });
+
+    const forkCall = {
+      name: 'train',
+      arguments: {
+        llm_model_id: 'test-space-fork-mcp-copy',
+        source_adapter_uri: sourceUri,
+        space: 'personal',
+        force_update: true
+      }
+    };
+    const forkRes = await mcp.client.callTool(forkCall);
+    const forked = parseMcpJson(forkRes, 'train-fork-mcp-personal');
+    withRawOnFail({ call: forkCall, result: forkRes }, () => {
+      expect(forked.status).toBe('stored');
+    });
+    const copyUri = forked.items[0].adapter_uri as string;
+    const copyId = parseAdapterUuidFromUri(copyUri);
+    expect(copyId).not.toBe(sourceId);
+
+    await sleepMs(3500);
+    spaces = await loadSpacesViaMcp();
+    loc = locationsForAdapterTitle(spaces, title);
+    withRawOnFail({ call: forkCall, result: forkRes }, () => {
+      expect(loc.filter((l) => l.type === 'group').length).toBe(1);
+      expect(loc.filter((l) => l.type === 'personal').length).toBe(1);
+      expect(loc.find((l) => l.type === 'group')?.adapterId.toLowerCase()).toBe(sourceId);
+      expect(loc.find((l) => l.type === 'personal')?.adapterId.toLowerCase()).toBe(copyId);
+    });
+  }, 120000);
+
+  test('API: POST /api/train fork copies group adapter into personal', async () => {
+    const why = adapterSpaceSkipReason(bundle, serverOk);
+    if (why || !bundle) {
+      console.warn(`[adapter-space-fork] skip API fork: ${why}`);
+      return;
+    }
+    expect.hasAssertions();
+    const { groupSpaceName, loadSpacesViaMcp } = bundle;
+    const title = `SpaceForkAPI ${Date.now()}`;
+    const md = buildSpaceMoveMarkdown(title);
+
+    const tr = await apiFetch('/train', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        markdown_doc: md,
+        llm_model_id: 'test-space-fork-api-g',
+        space: groupSpaceName,
+        force_update: true
+      })
+    });
+    expect(tr.status).toBe(200);
+    const stored = (await tr.json()) as { items: Array<{ adapter_uri: string }> };
+    const sourceUri = stored.items[0]!.adapter_uri;
+    const sourceId = parseAdapterUuidFromUri(sourceUri);
+
+    await sleepMs(3500);
+
+    const fr = await apiFetch('/train', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        llm_model_id: 'test-space-fork-api-p',
+        source_adapter_uri: sourceUri,
+        space: 'personal',
+        force_update: true
+      })
+    });
+    expect(fr.status).toBe(200);
+    const forked = (await fr.json()) as { items: Array<{ adapter_uri: string }> };
+    const copyId = parseAdapterUuidFromUri(forked.items[0]!.adapter_uri);
+    expect(copyId).not.toBe(sourceId);
+
+    await sleepMs(3500);
+    const spaces = await loadSpacesViaMcp();
+    const loc = locationsForAdapterTitle(spaces, title);
+    expect(loc.filter((l) => l.type === 'group').length).toBe(1);
+    expect(loc.filter((l) => l.type === 'personal').length).toBe(1);
+    expect(loc.find((l) => l.type === 'group')?.adapterId.toLowerCase()).toBe(sourceId);
+    expect(loc.find((l) => l.type === 'personal')?.adapterId.toLowerCase()).toBe(copyId);
+  }, 120000);
+
+  test('CLI: train --source-adapter-uri copies group adapter into personal', async () => {
+    const why = adapterSpaceSkipReason(bundle, serverOk);
+    if (!cliOk || why || !bundle) {
+      console.warn(`[adapter-space-fork] skip CLI fork: ${why ?? 'CLI not logged in'}`);
+      return;
+    }
+    expect.hasAssertions();
+    const { groupSpaceName, loadSpacesViaMcp } = bundle;
+    const title = `SpaceForkCLI ${Date.now()}`;
+    const md = buildSpaceMoveMarkdown(title);
+
+    const tr = await apiFetch('/train', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        markdown_doc: md,
+        llm_model_id: 'test-space-fork-cli-g',
+        space: groupSpaceName,
+        force_update: true
+      })
+    });
+    expect(tr.status).toBe(200);
+    const stored = (await tr.json()) as { items: Array<{ adapter_uri: string }> };
+    const sourceUri = stored.items[0]!.adapter_uri;
+    const sourceId = parseAdapterUuidFromUri(sourceUri);
+
+    await sleepMs(3500);
+
+    const forkOut = await execAsync(
+      `node ${CLI_PATH} train --url ${BASE_URL} --model test-space-fork-cli-p --force --source-adapter-uri "${sourceUri}" --space personal`,
+      { timeout: 60000 }
+    );
+    expect(forkOut.stderr).toBe('');
+    const forked = JSON.parse(forkOut.stdout) as { items: Array<{ adapter_uri: string }> };
+    const copyId = parseAdapterUuidFromUri(forked.items[0]!.adapter_uri);
+    expect(copyId).not.toBe(sourceId);
+
+    await sleepMs(3500);
+    const spaces = await loadSpacesViaMcp();
+    const loc = locationsForAdapterTitle(spaces, title);
+    expect(loc.filter((l) => l.type === 'group').length).toBe(1);
+    expect(loc.filter((l) => l.type === 'personal').length).toBe(1);
+    expect(loc.find((l) => l.type === 'group')?.adapterId.toLowerCase()).toBe(sourceId);
+    expect(loc.find((l) => l.type === 'personal')?.adapterId.toLowerCase()).toBe(copyId);
+  }, 180000);
+});

--- a/tests/integration/adapter-space-move.test.ts
+++ b/tests/integration/adapter-space-move.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Personal → group: `tune` with `space` moves the adapter (same adapter id).
+ * MCP, REST API, CLI (--space move-only).
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseMcpJson, withRawOnFail } from '../utils/expect-with-raw.js';
+import { getAuthHeaders, getTestAuthBaseUrl } from '../utils/auth-headers.js';
+import {
+  buildSpaceMoveMarkdown,
+  locationsForAdapterTitle,
+  parseAdapterUuidFromUri,
+  sleepMs
+} from '../utils/adapter-space-test-helpers.js';
+import {
+  adapterSpaceSkipReason,
+  openAdapterSpaceMcpBundle
+} from './utils/adapter-space-mcp-context.js';
+import {
+  BASE_URL,
+  CLI_PATH,
+  execAsync,
+  setupCliConfigWithLogin,
+  setupServerCheck
+} from './cli-commands-shared.js';
+
+const API_BASE = `${getTestAuthBaseUrl()}/api`;
+
+function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...(init?.headers as Record<string, string>) }
+  });
+}
+
+describe('Adapter space move (personal → group)', () => {
+  let bundle: Awaited<ReturnType<typeof openAdapterSpaceMcpBundle>> = null;
+  let serverOk = false;
+  let cliOk = false;
+
+  beforeAll(async () => {
+    serverOk = await setupServerCheck();
+    cliOk = await setupCliConfigWithLogin();
+    bundle = await openAdapterSpaceMcpBundle();
+  }, 120000);
+
+  afterAll(async () => {
+    if (bundle?.mcp) await bundle.mcp.close();
+  });
+
+  test('MCP: tune(space) moves personal adapter into group', async () => {
+    const why = adapterSpaceSkipReason(bundle, serverOk);
+    if (why || !bundle) {
+      console.warn(`[adapter-space-move] skip MCP move: ${why}`);
+      return;
+    }
+    expect.hasAssertions();
+    const { mcp, groupSpaceName, loadSpacesViaMcp } = bundle;
+    const title = `SpaceMoveMCP ${Date.now()}`;
+    const md = buildSpaceMoveMarkdown(title);
+
+    const trainCall = {
+      name: 'train',
+      arguments: { markdown_doc: md, llm_model_id: 'test-space-move-mcp', space: 'personal', force_update: true }
+    };
+    const trainRes = await mcp.client.callTool(trainCall);
+    const trained = parseMcpJson(trainRes, 'train-move-mcp');
+    withRawOnFail({ call: trainCall, result: trainRes }, () => {
+      expect(trained.status).toBe('stored');
+      expect(Array.isArray(trained.items)).toBe(true);
+      expect(trained.items.length).toBeGreaterThan(0);
+    });
+    const adapterUri = trained.items[0].adapter_uri as string;
+    const sourceId = parseAdapterUuidFromUri(adapterUri);
+
+    await sleepMs(3500);
+    let spaces = await loadSpacesViaMcp();
+    let locBefore = locationsForAdapterTitle(spaces, title);
+    withRawOnFail({ call: trainCall, result: trainRes }, () => {
+      expect(locBefore.some((l) => l.type === 'personal')).toBe(true);
+    });
+
+    const tuneCall = {
+      name: 'tune',
+      arguments: { uris: [adapterUri], space: groupSpaceName }
+    };
+    const tuneRes = await mcp.client.callTool(tuneCall);
+    const tuned = parseMcpJson(tuneRes, 'tune-move-mcp');
+    withRawOnFail({ call: tuneCall, result: tuneRes }, () => {
+      expect(tuned.total_updated).toBeGreaterThanOrEqual(1);
+      expect(tuned.results?.[0]?.status).toBe('updated');
+    });
+
+    await sleepMs(2000);
+    spaces = await loadSpacesViaMcp();
+    const locAfter = locationsForAdapterTitle(spaces, title);
+    withRawOnFail({ call: tuneCall, result: tuneRes }, () => {
+      expect(locAfter.some((l) => l.type === 'group')).toBe(true);
+      expect(locAfter.some((l) => l.type === 'personal')).toBe(false);
+      const groupHit = locAfter.find((l) => l.type === 'group');
+      expect(groupHit?.adapterId.toLowerCase()).toBe(sourceId);
+    });
+  }, 120000);
+
+  test('API: POST /api/tune with space moves personal adapter into group', async () => {
+    const why = adapterSpaceSkipReason(bundle, serverOk);
+    if (why || !bundle) {
+      console.warn(`[adapter-space-move] skip API move: ${why}`);
+      return;
+    }
+    expect.hasAssertions();
+    const { groupSpaceName, loadSpacesViaMcp } = bundle;
+    const title = `SpaceMoveAPI ${Date.now()}`;
+    const md = buildSpaceMoveMarkdown(title);
+
+    const trainBody = {
+      markdown_doc: md,
+      llm_model_id: 'test-space-move-api',
+      space: 'personal',
+      force_update: true
+    };
+    const tr = await apiFetch('/train', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(trainBody)
+    });
+    expect(tr.status).toBe(200);
+    const trained = (await tr.json()) as { status: string; items: Array<{ adapter_uri: string }> };
+    expect(trained.status).toBe('stored');
+    const adapterUri = trained.items[0]!.adapter_uri;
+    const sourceId = parseAdapterUuidFromUri(adapterUri);
+
+    await sleepMs(3500);
+    let spaces = await loadSpacesViaMcp();
+    expect(locationsForAdapterTitle(spaces, title).some((l) => l.type === 'personal')).toBe(true);
+
+    const tu = await apiFetch('/tune', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uris: [adapterUri], space: groupSpaceName })
+    });
+    expect(tu.status).toBe(200);
+    const tuned = (await tu.json()) as { total_updated: number };
+    expect(tuned.total_updated).toBeGreaterThanOrEqual(1);
+
+    await sleepMs(2000);
+    spaces = await loadSpacesViaMcp();
+    const locAfter = locationsForAdapterTitle(spaces, title);
+    expect(locAfter.some((l) => l.type === 'group')).toBe(true);
+    expect(locAfter.some((l) => l.type === 'personal')).toBe(false);
+    expect(locAfter.find((l) => l.type === 'group')?.adapterId.toLowerCase()).toBe(sourceId);
+  }, 120000);
+
+  test('CLI: tune --space moves personal adapter into group', async () => {
+    const why = adapterSpaceSkipReason(bundle, serverOk);
+    if (!cliOk || why || !bundle) {
+      console.warn(`[adapter-space-move] skip CLI move: ${why ?? 'CLI not logged in'}`);
+      return;
+    }
+    expect.hasAssertions();
+    const { groupSpaceName, loadSpacesViaMcp } = bundle;
+    const title = `SpaceMoveCLI ${Date.now()}`;
+    const dir = mkdtempSync(join(tmpdir(), 'kairos-space-cli-'));
+    const mdPath = join(dir, 'proto.md');
+    try {
+      writeFileSync(mdPath, buildSpaceMoveMarkdown(title), 'utf8');
+      const mint = await execAsync(
+        `node ${CLI_PATH} train --url ${BASE_URL} --force --model test-space-move-cli "${mdPath}"`,
+        { timeout: 60000 }
+      );
+      expect(mint.stderr).toBe('');
+      const minted = JSON.parse(mint.stdout) as { items: Array<{ adapter_uri: string }> };
+      const adapterUri = minted.items[0]!.adapter_uri;
+      const sourceId = parseAdapterUuidFromUri(adapterUri);
+
+      await sleepMs(3500);
+      let spaces = await loadSpacesViaMcp();
+      expect(locationsForAdapterTitle(spaces, title).some((l) => l.type === 'personal')).toBe(true);
+
+      const tuneOut = await execAsync(
+        `node ${CLI_PATH} tune --url ${BASE_URL} --space ${JSON.stringify(groupSpaceName!)} ${JSON.stringify(adapterUri)}`,
+        { timeout: 60000 }
+      );
+      expect(tuneOut.stderr).toBe('');
+      const tuned = JSON.parse(tuneOut.stdout) as { total_updated: number };
+      expect(tuned.total_updated).toBeGreaterThanOrEqual(1);
+
+      await sleepMs(2000);
+      spaces = await loadSpacesViaMcp();
+      const locAfter = locationsForAdapterTitle(spaces, title);
+      expect(locAfter.some((l) => l.type === 'group')).toBe(true);
+      expect(locAfter.some((l) => l.type === 'personal')).toBe(false);
+      expect(locAfter.find((l) => l.type === 'group')?.adapterId.toLowerCase()).toBe(sourceId);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 180000);
+});

--- a/tests/integration/cli-help.test.ts
+++ b/tests/integration/cli-help.test.ts
@@ -1,7 +1,7 @@
 import { CLI_PATH, execAsync } from './cli-commands-shared.js';
 
 describe('CLI usage help', () => {
-  test('train missing required path prints train help', async () => {
+  test('train without path or --source-adapter-uri prints error', async () => {
     try {
       await execAsync(`node ${CLI_PATH} train`, { timeout: 10000 });
       throw new Error('Expected train without path to fail');
@@ -10,10 +10,8 @@ describe('CLI usage help', () => {
       const stderr = String(err.stderr ?? '');
 
       expect(err.code).toBe(1);
-      expect(stderr).toContain("error: missing required argument 'path'");
-      expect(stderr).toContain('Usage: kairos train');
-      expect(stderr).toContain('Path to a markdown file or a directory of .md files');
-      expect(stderr).toContain('--recursive');
+      expect(stderr).toContain('Missing path:');
+      expect(stderr).toContain('--source-adapter-uri');
     }
   });
 
@@ -46,8 +44,8 @@ describe('CLI usage help', () => {
       expect(err.code).toBe(1);
       expect(stderr).toContain("error: unknown option '--modl'");
       expect(stderr).toContain('(Did you mean --model?)');
-      expect(stderr).toContain('Usage: kairos train [options] <path>');
-      expect(stderr).toContain('Path to a markdown file or a directory of .md files');
+      expect(stderr).toContain('Usage: kairos train [options] [path]');
+      expect(stderr).toContain('markdown file');
     }
   });
 });

--- a/tests/integration/utils/adapter-space-mcp-context.ts
+++ b/tests/integration/utils/adapter-space-mcp-context.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared MCP + spaces snapshot for adapter space integration tests.
+ */
+
+import { createMcpConnection } from '../../utils/mcp-client-utils.js';
+import { parseMcpJson } from '../../utils/expect-with-raw.js';
+import { hasAuthToken, serverRequiresAuth } from '../../utils/auth-headers.js';
+import type { SpaceRow } from '../../utils/adapter-space-test-helpers.js';
+
+export type AdapterSpaceMcpBundle = {
+  mcp: Awaited<ReturnType<typeof createMcpConnection>>;
+  groupSpaceName: string | null;
+  personalSpaceName: string | null;
+  loadSpacesViaMcp: () => Promise<SpaceRow[]>;
+  skipReason: (serverOk: boolean) => string | null;
+};
+
+export async function openAdapterSpaceMcpBundle(): Promise<AdapterSpaceMcpBundle | null> {
+  if (!serverRequiresAuth() || !hasAuthToken()) return null;
+  const mcp = await createMcpConnection();
+  const spacesRes = await mcp.client.callTool({
+    name: 'spaces',
+    arguments: { include_adapter_titles: true }
+  });
+  const parsed = parseMcpJson(spacesRes, 'spaces-adapter-move');
+  const rows = (parsed.spaces ?? []) as SpaceRow[];
+  const g = rows.find((s) => s.type === 'group');
+  const p = rows.find((s) => s.type === 'personal');
+  const groupSpaceName = g?.name ?? null;
+  const personalSpaceName = p?.name ?? null;
+
+  const loadSpacesViaMcp = async (): Promise<SpaceRow[]> => {
+    const result = await mcp.client.callTool({
+      name: 'spaces',
+      arguments: { include_adapter_titles: true }
+    });
+    const pr = parseMcpJson(result, 'spaces');
+    return (pr.spaces ?? []) as SpaceRow[];
+  };
+
+  const skipReason = (serverOk: boolean): string | null => {
+    if (!serverRequiresAuth() || !hasAuthToken()) return 'auth disabled or no token';
+    if (!serverOk) return 'server unavailable';
+    if (!groupSpaceName) return 'no group space in token (kairos-tester needs a group membership)';
+    if (!personalSpaceName) return 'no personal space';
+    return null;
+  };
+
+  return { mcp, groupSpaceName, personalSpaceName, loadSpacesViaMcp, skipReason };
+}
+
+/** Null bundle means auth off or missing token (see {@link openAdapterSpaceMcpBundle}). */
+export function adapterSpaceSkipReason(
+  bundle: AdapterSpaceMcpBundle | null,
+  serverOk: boolean
+): string | null {
+  if (bundle == null) {
+    if (!serverRequiresAuth() || !hasAuthToken()) return 'auth disabled or no token';
+    return 'MCP connection failed';
+  }
+  return bundle.skipReason(serverOk);
+}

--- a/tests/utils/adapter-space-test-helpers.ts
+++ b/tests/utils/adapter-space-test-helpers.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared helpers for adapter space move / fork integration tests.
+ */
+
+export interface SpaceRow {
+  name: string;
+  space_id: string;
+  type: 'personal' | 'group' | 'app' | 'other';
+  adapters?: Array<{ adapter_id: string; title: string }>;
+}
+
+export function buildSpaceMoveMarkdown(title: string): string {
+  return `# ${title}
+
+## Activation Patterns
+Space move / fork integration test.
+
+## Step 1
+Body.
+
+\`\`\`json
+{"contract": {"type": "comment", "comment": {"min_length": 10}, "required": true}}
+\`\`\`
+
+## Reward Signal
+Done.`;
+}
+
+export function parseAdapterUuidFromUri(adapterUri: string): string {
+  const m = /^kairos:\/\/adapter\/([0-9a-f-]{36})$/i.exec(adapterUri.trim());
+  if (!m) throw new Error(`Not an adapter URI: ${adapterUri}`);
+  return m[1]!.toLowerCase();
+}
+
+export function locationsForAdapterTitle(
+  spaces: SpaceRow[],
+  title: string
+): Array<{ type: string; spaceName: string; adapterId: string }> {
+  const out: Array<{ type: string; spaceName: string; adapterId: string }> = [];
+  for (const s of spaces) {
+    const hit = s.adapters?.find((a) => a.title === title);
+    if (hit) out.push({ type: s.type, spaceName: s.name, adapterId: hit.adapter_id });
+  }
+  return out;
+}
+
+export async function sleepMs(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}


### PR DESCRIPTION
## Summary
Adds integration coverage for adapter space workflows and small CLI gaps so they can be exercised like the REST and MCP paths.

### Behaviour under test
- **Personal → group:** `tune` with `space` only moves layers (same adapter id).
- **Group → personal:** `train` with `source_adapter_uri` and `space: personal` creates a copy (new adapter id).

### Changes
- New tests: `tests/integration/adapter-space-move.test.ts`, `adapter-space-fork.test.ts`, shared helpers and MCP fixture.
- **CLI:** `tune --space` for move-only; `train --source-adapter-uri` + `--model` (optional `--space`) for JSON fork via `POST /api/train`.
- **ApiClient:** `tune` sends optional `space`; `trainJson` for JSON train.
- **cli-help** expectations updated for optional `[path]` on `train`.

### Notes
- Space tests skip when auth is off or the token has no **group** space (give `kairos-tester` a group to run them end-to-end).
- Full `npm test` once hit a transient MCP `fetch failed` in `kairos-search-access` right after dev restart; the same file passed on an isolated re-run.

KAIROS `activate` for this task matched **GitHub PR with gh**; PR opened with `gh` accordingly.