### PR TITLE
feat(mcp-apps): minify widget output; refine activate and forward widgets

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,8 @@
 {
     "mcpServers": {
-      "DEVELOPMENT_KAIROS_5": {
+      "DEVELOPMENT_KAIROS": {
         "type": "streamable-http",
-        "url": "http://localhost:3305/mcp",
+        "url": "http://localhost:3300/mcp",
         "alwaysAllow": [ "activate", "forward", "train", "reward", "tune", "delete", "export", "spaces" ],
         "disabled": false,
         "disabledTools": []

--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,4 @@ data/
 .devcontainer.disable/
 snapshots
 .cursor/TODO.md
+.kairos-work/

--- a/src/mcp-apps/activate-widget-html.ts
+++ b/src/mcp-apps/activate-widget-html.ts
@@ -1,6 +1,7 @@
 import { KAIROS_LOGO_SVG } from './kairos-logo-embedded.js';
 import { ACTIVATE_WIDGET_INLINE_CSS } from './activate-widget-inline-css.js';
 import { ACTIVATE_WIDGET_INLINE_SCRIPT } from './activate-widget-inline-script.js';
+import { minifyInlineWidgetHtml } from './widget-inline-minify.js';
 import { substituteWidgetPresentationToken } from './mcp-widget-presentation-inject.js';
 
 /**
@@ -9,7 +10,7 @@ import { substituteWidgetPresentationToken } from './mcp-widget-presentation-inj
  */
 export function buildActivateWidgetHtml(): string {
   const logo = KAIROS_LOGO_SVG.replaceAll('`', '&#96;');
-  return `<div id="kairos-activate-root">
+  return minifyInlineWidgetHtml(`<div id="kairos-activate-root">
   <div class="brand activate-brand-row">
     <div class="activate-brand-left">
       ${logo}
@@ -24,5 +25,5 @@ ${ACTIVATE_WIDGET_INLINE_CSS}
 </style>
 <script>
 ${substituteWidgetPresentationToken(ACTIVATE_WIDGET_INLINE_SCRIPT)}
-</script>`;
+</script>`);
 }

--- a/src/mcp-apps/activate-widget-inline-css.ts
+++ b/src/mcp-apps/activate-widget-inline-css.ts
@@ -2,6 +2,7 @@
  * Activate MCP App styles: shared chrome ({@link ./mcp-widget-chrome-inline-css.ts}) + choice list.
  */
 import { MCP_WIDGET_CHROME_INLINE_CSS } from './mcp-widget-chrome-inline-css.js';
+import { minifyInlineWidgetCss } from './widget-inline-minify.js';
 
 const ACTIVATE_WIDGET_SPECIFIC_INLINE_CSS = `
     .brand.activate-brand-row {
@@ -37,7 +38,6 @@ const ACTIVATE_WIDGET_SPECIFIC_INLINE_CSS = `
       letter-spacing: 0.02em;
       color: var(--color-text-muted);
     }
-    /* Same scale/weight as h1.header-title / .ht-brand; color = strength (green → amber). */
     .top-match-pct {
       font-size: clamp(0.875rem, 2.4vw, 1.0625rem);
       font-weight: 600;
@@ -90,7 +90,6 @@ const ACTIVATE_WIDGET_SPECIFIC_INLINE_CSS = `
       margin-bottom: 6px;
       background: var(--color-surface);
     }
-    /* Activate list: no inner scroll — host iframe resizes via ui/notifications/size-changed. */
     #kairos-activate-root #out {
       max-height: none;
       overflow: visible;
@@ -159,46 +158,30 @@ const ACTIVATE_WIDGET_SPECIFIC_INLINE_CSS = `
       color: var(--color-text-heading);
     }
     .sub { font-size: 12px; color: var(--color-text-muted); margin: 2px 0; word-break: break-word; }
-    .widget-error {
-      margin: 0;
-      padding: 0;
-    }
-    .widget-error-msg {
+    .activate-json-summary {
       margin: 0 0 6px 0;
-      font-size: var(--font-size-sm);
-      line-height: 1.45;
-      font-weight: 600;
-      color: var(--color-error);
-    }
-    .widget-error-next {
-      margin: 0 0 8px 0;
-      font-size: var(--font-size-sm);
-      line-height: 1.45;
-      color: var(--color-text-muted);
-    }
-    .widget-error-next-label {
-      font-weight: 600;
       color: var(--color-text-heading);
     }
-    .widget-error-details {
+    .activate-json-details {
       margin: 0;
       border-radius: var(--radius-md);
       border: 1px solid var(--color-border);
       background: var(--color-surface);
       padding: 5px 8px;
     }
-    .widget-error-details summary {
+    .activate-json-details summary {
       cursor: pointer;
       font-size: var(--font-size-xs);
       font-weight: 600;
       color: var(--color-text-muted);
       user-select: none;
     }
-    .widget-error-raw {
+    .activate-json-raw {
       margin: 6px 0 0 0;
       max-height: 220px;
       overflow: auto;
     }
 `.trim();
 
-export const ACTIVATE_WIDGET_INLINE_CSS = `${MCP_WIDGET_CHROME_INLINE_CSS}\n${ACTIVATE_WIDGET_SPECIFIC_INLINE_CSS}`;
+export const ACTIVATE_WIDGET_INLINE_CSS =
+  minifyInlineWidgetCss(MCP_WIDGET_CHROME_INLINE_CSS) + minifyInlineWidgetCss(ACTIVATE_WIDGET_SPECIFIC_INLINE_CSS);

--- a/src/mcp-apps/activate-widget-inline-script.ts
+++ b/src/mcp-apps/activate-widget-inline-script.ts
@@ -1,17 +1,12 @@
 /** Inline boot script for {@link ./activate-widget-html.ts} (MCP Apps HTML bundle). */
-export const ACTIVATE_WIDGET_INLINE_SCRIPT = `
+import { minifyInlineWidgetScript } from './widget-inline-minify.js';
+
+export const ACTIVATE_WIDGET_INLINE_SCRIPT = minifyInlineWidgetScript(`
     (function () {
-      var el = document.getElementById('out');
-      var headerTitle = document.getElementById('header-title');
-      var headerTopMatch = document.getElementById('header-top-match');
-      var PROTO = '2026-01-26';
-      var nextId = 1;
-      var pending = {};
-      var hostCtxState = {};
-      /** Top N visible in the main list; remaining choices live in a collapsed details block (error-panel style). */
-      var ACTIVATE_VISIBLE_CHOICES = 3;
-      var BATCH = 10;
-      var PRESENTATION_ONLY = __KAIROS_WIDGET_PRESENTATION_ONLY__;
+      var el = document.getElementById('out'), headerTitle = document.getElementById('header-title');
+      var headerTopMatch = document.getElementById('header-top-match'), PROTO = '2026-01-26';
+      var nextId = 1, pending = {}, hostCtxState = {};
+      var ACTIVATE_VISIBLE_CHOICES = 3, BATCH = 10, PRESENTATION_ONLY = __KAIROS_WIDGET_PRESENTATION_ONLY__;
 
       window.addEventListener('message', function (ev) {
         var d = ev.data;
@@ -193,83 +188,30 @@ export const ACTIVATE_WIDGET_INLINE_SCRIPT = `
           '%</span></div>';
       }
 
-      function isErrorLike(obj) {
-        if (obj == null) return false;
-        if (typeof obj === 'string') return true;
-        if (typeof obj !== 'object') return false;
-        if (obj.isError === true) return true;
-        if (typeof obj.error === 'string' && obj.error.length > 0) return true;
-        if (obj.error_code != null && String(obj.error_code).length > 0) return true;
-        return false;
+      function stringifyJson(obj) {
+        try { return JSON.stringify(obj, null, 2); } catch (e) { return String(obj); }
       }
 
-      /** Short line for humans; full server text stays in Technical details JSON only. */
-      function shortHumanErrorMessage(obj) {
-        if (obj == null) return 'Something went wrong.';
+      function summaryLineFromPayload(obj) {
+        if (obj == null) return '';
         if (typeof obj === 'string') {
           var ts = obj.trim();
-          if (!ts) return 'Something went wrong.';
+          if (!ts) return '';
           return ts.length > 90 ? ts.slice(0, 87) + '…' : ts;
         }
-        if (typeof obj !== 'object') return 'Something went wrong.';
+        if (typeof obj !== 'object') return '';
+        if (typeof obj.message === 'string' && obj.message.trim()) {
+          var msg = obj.message.trim();
+          if (msg.indexOf('Input validation error:') === 0) return 'Invalid tool input.';
+          return msg.length > 90 ? msg.slice(0, 87) + '…' : msg;
+        }
         if (typeof obj.error === 'string' && obj.error.length) {
           if (obj.error === 'INVALID_TOOL_INPUT') return 'Invalid tool input.';
           if (obj.error === 'WIDGET_BOOT') return 'Panel could not start.';
           return 'Something went wrong.';
         }
-        if (obj.isError === true) {
-          var m = typeof obj.message === 'string' ? obj.message.trim() : '';
-          if (m) {
-            if (m.indexOf('Input validation error:') === 0) return 'Invalid tool input.';
-            var dot = m.indexOf('. ');
-            if (dot > 0 && dot < 120) return m.slice(0, dot + 1);
-            return m.length > 90 ? m.slice(0, 87) + '…' : m;
-          }
-          return 'Something went wrong.';
-        }
-        if (typeof obj.message === 'string' && obj.message.trim()) {
-          var m2 = obj.message.trim();
-          if (m2.indexOf('Input validation error:') === 0) return 'Invalid tool input.';
-          return m2.length > 90 ? m2.slice(0, 87) + '…' : m2;
-        }
-        return 'Something went wrong.';
-      }
-
-      /** Prefer server next_action; else compact fallback. Keep in sync with forward-widget-inline-script. */
-      function suggestNextStep(obj) {
-        if (obj == null || typeof obj !== 'object') {
-          return 'Read the last tool response for next_action, or run activate again with a short description of your goal.';
-        }
-        var err = obj.error;
-        var tool = obj.tool;
-        if (err === 'INVALID_TOOL_INPUT' && tool === 'forward') {
-          return 'Match solution to contract.type, or omit solution on the first forward from an adapter URI.';
-        }
-        if (err === 'INVALID_TOOL_INPUT' && tool === 'activate') {
-          return 'Check query and optional space against the activate schema.';
-        }
-        if (err === 'INVALID_TOOL_INPUT' && (tool === 'train' || tool === 'tune')) {
-          return 'Check adapter body, space name, and required fields against the schema.';
-        }
-        if (err === 'INVALID_TOOL_INPUT' && tool === 'reward') {
-          return 'Use the layer URI from forward, outcome, and any required fields.';
-        }
-        if (obj.isError === true) {
-          return 'Retry the last step; expand Technical details if you need the raw payload.';
-        }
-        if (typeof obj.next_action === 'string' && obj.next_action.trim()) {
-          return 'Follow next_action from this response when you retry.';
-        }
-        return 'Read the last successful tool result for next_action, or run activate with a clear description of what you want to do.';
-      }
-
-      function agentInstructionText(obj) {
-        if (obj == null || typeof obj !== 'object') {
-          return suggestNextStep(obj);
-        }
-        var na = typeof obj.next_action === 'string' ? obj.next_action.trim() : '';
-        if (na) return na;
-        return suggestNextStep(obj);
+        if (obj.isError === true || obj.error_code != null) return 'Something went wrong.';
+        return '';
       }
 
       function showRawJson(obj) {
@@ -279,56 +221,40 @@ export const ACTIVATE_WIDGET_INLINE_SCRIPT = `
         if (el) {
           var pre = document.createElement('pre');
           pre.className = 'raw';
-          try { pre.textContent = JSON.stringify(obj, null, 2); } catch (e) { pre.textContent = String(obj); }
+          pre.textContent = stringifyJson(obj);
           el.replaceChildren(pre);
         }
         notifySize();
       }
 
-      function renderHumanError(obj) {
+      function showJson(obj) {
+        var summary = summaryLineFromPayload(obj);
+        if (!summary) {
+          showRawJson(obj);
+          return;
+        }
         clearTopMatch();
         if (headerTitle) headerTitle.innerHTML = headerHtmlIdle();
-        document.title = 'Error — KAIROS';
+        document.title = 'Activate — KAIROS';
         if (!el) return;
         var wrap = document.createElement('div');
-        wrap.className = 'widget-error';
-        wrap.setAttribute('role', 'alert');
         var msgEl = document.createElement('p');
-        msgEl.className = 'widget-error-msg';
-        msgEl.textContent = shortHumanErrorMessage(obj);
+        msgEl.className = 'sub activate-json-summary';
+        msgEl.textContent = summary;
         wrap.appendChild(msgEl);
-        var nextEl = document.createElement('p');
-        nextEl.className = 'widget-error-next';
-        var nextLbl = document.createElement('span');
-        nextLbl.className = 'widget-error-next-label';
-        nextLbl.textContent = 'Your AI agent was asked to: ';
-        nextEl.appendChild(nextLbl);
-        nextEl.appendChild(document.createTextNode(agentInstructionText(obj)));
-        wrap.appendChild(nextEl);
         var det = document.createElement('details');
-        det.className = 'widget-error-details';
+        det.className = 'activate-json-details';
         var sum = document.createElement('summary');
         sum.textContent = 'Technical details';
         det.appendChild(sum);
         var pre = document.createElement('pre');
-        pre.className = 'raw widget-error-raw';
-        try {
-          pre.textContent = typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2);
-        } catch (e) {
-          pre.textContent = String(obj);
-        }
+        pre.className = 'raw activate-json-raw';
+        pre.textContent = stringifyJson(obj);
         det.appendChild(pre);
         wrap.appendChild(det);
         el.replaceChildren(wrap);
+        det.addEventListener('toggle', notifySize);
         notifySize();
-      }
-
-      function showJson(obj) {
-        if (isErrorLike(obj)) {
-          renderHumanError(obj);
-          return;
-        }
-        showRawJson(obj);
       }
 
       function isActivateStructured(sc) {
@@ -342,7 +268,6 @@ export const ACTIVATE_WIDGET_INLINE_SCRIPT = `
         return 'match';
       }
 
-      /** Same tier breakpoints as header "Top match" (green → amber). */
       function tierFromScore(score) {
         if (score == null || typeof score !== 'number' || isNaN(score)) return null;
         return score >= 0.8 ? '4' : score >= 0.65 ? '3' : score >= 0.5 ? '2' : '1';
@@ -504,7 +429,7 @@ export const ACTIVATE_WIDGET_INLINE_SCRIPT = `
           if (headerTitle) headerTitle.innerHTML = headerHtmlIdle();
           if (el) {
             var msg = (err && err.message) ? err.message : String(err);
-            renderHumanError({
+            showJson({
               isError: true,
               message: 'This panel could not finish starting (' + msg + '). The same data may still appear as normal text in the chat.',
               error: 'WIDGET_BOOT',
@@ -516,4 +441,4 @@ export const ACTIVATE_WIDGET_INLINE_SCRIPT = `
 
       boot();
     })();
-`.trim();
+`);

--- a/src/mcp-apps/forward-widget-html.ts
+++ b/src/mcp-apps/forward-widget-html.ts
@@ -1,6 +1,7 @@
 import { KAIROS_LOGO_SVG } from './kairos-logo-embedded.js';
 import { FORWARD_WIDGET_INLINE_CSS } from './forward-widget-inline-css.js';
 import { FORWARD_WIDGET_INLINE_SCRIPT } from './forward-widget-inline-script.js';
+import { minifyInlineWidgetHtml } from './widget-inline-minify.js';
 import { substituteWidgetPresentationToken } from './mcp-widget-presentation-inject.js';
 
 /**
@@ -9,7 +10,7 @@ import { substituteWidgetPresentationToken } from './mcp-widget-presentation-inj
  */
 export function buildForwardWidgetHtml(): string {
   const logo = KAIROS_LOGO_SVG.replaceAll('`', '&#96;');
-  return `<div id="kairos-forward-root">
+  return minifyInlineWidgetHtml(`<div id="kairos-forward-root">
   <div class="brand">
     ${logo}
     <h1 id="header-title" class="header-title"><span class="ht-brand">KAIROS</span><span class="ht-sep"> • </span><span class="ht-protocol-label">Protocol:</span></h1>
@@ -29,5 +30,5 @@ ${FORWARD_WIDGET_INLINE_CSS}
 </style>
 <script>
 ${substituteWidgetPresentationToken(FORWARD_WIDGET_INLINE_SCRIPT)}
-</script>`;
+</script>`);
 }

--- a/src/mcp-apps/forward-widget-inline-css.ts
+++ b/src/mcp-apps/forward-widget-inline-css.ts
@@ -1,5 +1,6 @@
 /** Forward-only styles; shared chrome in {@link ./mcp-widget-chrome-inline-css.ts}. */
 import { MCP_WIDGET_CHROME_INLINE_CSS } from './mcp-widget-chrome-inline-css.js';
+import { minifyInlineWidgetCss } from './widget-inline-minify.js';
 
 const FORWARD_WIDGET_SPECIFIC_INLINE_CSS = `
     #out.step-panel {
@@ -88,7 +89,6 @@ const FORWARD_WIDGET_SPECIFIC_INLINE_CSS = `
       background: color-mix(in srgb, var(--color-text-muted) 18%, var(--color-surface-elevated));
     }
     .seg-done { background: var(--color-success); border-color: color-mix(in srgb, var(--color-success) 55%, var(--color-border)); }
-    /* Current step: amber (warning), distinct from green completed segments. */
     .seg-current:not(.seg-issue) {
       background: color-mix(in srgb, var(--color-warning) 72%, var(--color-surface-elevated));
       border-color: color-mix(in srgb, var(--color-warning) 58%, var(--color-border));
@@ -98,7 +98,6 @@ const FORWARD_WIDGET_SPECIFIC_INLINE_CSS = `
       background: color-mix(in srgb, var(--color-warning) 55%, transparent);
       border-color: color-mix(in srgb, var(--color-warning) 48%, var(--color-border));
     }
-    /* Retry / error on this layer: blend warning with error tint. */
     .seg-current.seg-issue {
       background: color-mix(in srgb, var(--color-error) 42%, var(--color-warning) 58%);
       border-color: color-mix(in srgb, var(--color-error) 55%, var(--color-border));
@@ -115,16 +114,22 @@ const FORWARD_WIDGET_SPECIFIC_INLINE_CSS = `
     .widget-error {
       margin: 0;
       padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .widget-error .step-running {
+      margin: 0;
     }
     .widget-error-msg {
-      margin: 0 0 6px 0;
+      margin: 0;
       font-size: var(--font-size-sm);
       line-height: 1.45;
       font-weight: 600;
       color: var(--color-error);
     }
     .widget-error-next {
-      margin: 0 0 8px 0;
+      margin: 0;
       font-size: var(--font-size-sm);
       line-height: 1.45;
       color: var(--color-text-muted);
@@ -154,4 +159,5 @@ const FORWARD_WIDGET_SPECIFIC_INLINE_CSS = `
     }
 `.trim();
 
-export const FORWARD_WIDGET_INLINE_CSS = `${MCP_WIDGET_CHROME_INLINE_CSS}\n${FORWARD_WIDGET_SPECIFIC_INLINE_CSS}`;
+export const FORWARD_WIDGET_INLINE_CSS =
+  minifyInlineWidgetCss(MCP_WIDGET_CHROME_INLINE_CSS) + minifyInlineWidgetCss(FORWARD_WIDGET_SPECIFIC_INLINE_CSS);

--- a/src/mcp-apps/forward-widget-inline-script.ts
+++ b/src/mcp-apps/forward-widget-inline-script.ts
@@ -1,16 +1,12 @@
 /** Inline boot script for {@link ./forward-widget-html.ts} (MCP Apps HTML bundle). */
-export const FORWARD_WIDGET_INLINE_SCRIPT = `
+import { minifyInlineWidgetScript } from './widget-inline-minify.js';
+
+export const FORWARD_WIDGET_INLINE_SCRIPT = minifyInlineWidgetScript(`
     (function () {
-      var el = document.getElementById('out');
-      var headerTitle = document.getElementById('header-title');
-      var runFooter = document.getElementById('run-footer');
-      var stepText = document.getElementById('step-text');
-      var segHost = document.getElementById('progress-segments');
-      var PROTO = '2026-01-26';
-      var nextId = 1;
-      var pending = {};
-      var hostCtxState = {};
-      var PRESENTATION_ONLY = __KAIROS_WIDGET_PRESENTATION_ONLY__;
+      var el = document.getElementById('out'), headerTitle = document.getElementById('header-title');
+      var runFooter = document.getElementById('run-footer'), stepText = document.getElementById('step-text');
+      var segHost = document.getElementById('progress-segments'), PROTO = '2026-01-26';
+      var nextId = 1, pending = {}, hostCtxState = {}, PRESENTATION_ONLY = __KAIROS_WIDGET_PRESENTATION_ONLY__;
 
       window.addEventListener('message', function (ev) {
         var d = ev.data;
@@ -171,7 +167,6 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
         return false;
       }
 
-      /** Short line for humans; full server text stays in Technical details JSON only. */
       function shortHumanErrorMessage(obj) {
         if (obj == null) return 'Something went wrong.';
         if (typeof obj === 'string') {
@@ -203,7 +198,6 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
         return 'Something went wrong.';
       }
 
-      /** Prefer server next_action; else compact fallback. Keep in sync with activate-widget-inline-script. */
       function suggestNextStep(obj) {
         if (obj == null || typeof obj !== 'object') {
           return 'Read the last tool response for next_action, or run activate again with a short description of your goal.';
@@ -240,6 +234,52 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
         return suggestNextStep(obj);
       }
 
+      function errorStepLabel(obj) {
+        if (obj && typeof obj === 'object') {
+          var label = obj.current_layer_label != null && String(obj.current_layer_label).trim()
+            ? String(obj.current_layer_label).trim() : '';
+          if (label) return label;
+          if (obj.error === 'INVALID_TOOL_INPUT') return 'Fix tool input and retry';
+          if (obj.error === 'WIDGET_BOOT') return 'Restart the widget';
+          if (obj.error_code != null && String(obj.error_code).trim()) {
+            return String(obj.error_code).trim().replace(/_/g, ' ');
+          }
+        }
+        return 'Review this forward error and retry';
+      }
+
+      function normalizeForwardErrorState(obj) {
+        var idx = 1;
+        var cnt = 1;
+        var adapter = 'Forward run';
+        if (obj && typeof obj === 'object') {
+          if (obj.context_adapter_name != null && String(obj.context_adapter_name).trim()) {
+            adapter = String(obj.context_adapter_name).trim();
+          }
+          if (typeof obj.adapter_layer_index === 'number' && obj.adapter_layer_index > 0) {
+            idx = Math.floor(obj.adapter_layer_index);
+          }
+          if (typeof obj.adapter_layer_count === 'number' && obj.adapter_layer_count > 0) {
+            cnt = Math.floor(obj.adapter_layer_count);
+          } else {
+            cnt = idx;
+          }
+        }
+        return {
+          context_adapter_name: adapter,
+          current_layer_label: errorStepLabel(obj),
+          adapter_layer_index: idx,
+          adapter_layer_count: cnt,
+          error_code: obj && typeof obj === 'object' && obj.error_code != null
+            ? String(obj.error_code)
+            : (obj && typeof obj === 'object' && typeof obj.error === 'string' ? obj.error : 'FORWARD_ERROR'),
+          retry_count: obj && typeof obj === 'object' && typeof obj.retry_count === 'number'
+            ? obj.retry_count
+            : 1,
+          next_action: agentInstructionText(obj),
+        };
+      }
+
       function showRawJson(obj) {
         resetChrome();
         if (el) {
@@ -253,19 +293,24 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
         notifySize();
       }
 
-      function renderHumanError(obj) {
-        resetChrome();
+      function renderForwardError(sc, rawObj) {
+        var adapterRaw = sc.context_adapter_name != null && String(sc.context_adapter_name).trim()
+          ? String(sc.context_adapter_name).trim() : '';
+        if (headerTitle) {
+          headerTitle.innerHTML = headerHtmlWithProtocol(adapterRaw || 'Forward run');
+        }
+        document.title = (adapterRaw || 'Forward') + ' — KAIROS';
         if (el) {
           el.classList.add('step-panel');
           el.classList.add('step-panel-error');
         }
-        document.title = 'Error — KAIROS';
         var wrap = document.createElement('div');
         wrap.className = 'widget-error';
         wrap.setAttribute('role', 'alert');
+        wrap.innerHTML = formatStepTitle(sc, false, true);
         var msgEl = document.createElement('p');
         msgEl.className = 'widget-error-msg';
-        msgEl.textContent = shortHumanErrorMessage(obj);
+        msgEl.textContent = shortHumanErrorMessage(rawObj);
         wrap.appendChild(msgEl);
         var nextEl = document.createElement('p');
         nextEl.className = 'widget-error-next';
@@ -273,7 +318,7 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
         nextLbl.className = 'widget-error-next-label';
         nextLbl.textContent = 'Your AI agent was asked to: ';
         nextEl.appendChild(nextLbl);
-        nextEl.appendChild(document.createTextNode(agentInstructionText(obj)));
+        nextEl.appendChild(document.createTextNode(agentInstructionText(rawObj)));
         wrap.appendChild(nextEl);
         var det = document.createElement('details');
         det.className = 'widget-error-details';
@@ -283,14 +328,20 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
         var pre = document.createElement('pre');
         pre.className = 'raw widget-error-raw';
         try {
-          pre.textContent = typeof obj === 'string' ? obj : JSON.stringify(obj, null, 2);
+          pre.textContent = typeof rawObj === 'string' ? rawObj : JSON.stringify(rawObj, null, 2);
         } catch (e) {
-          pre.textContent = String(obj);
+          pre.textContent = String(rawObj);
         }
         det.appendChild(pre);
         wrap.appendChild(det);
         el.replaceChildren(wrap);
+        renderProgress(sc.adapter_layer_index, sc.adapter_layer_count, true, false);
         notifySize();
+      }
+
+      function renderHumanError(obj) {
+        resetChrome();
+        renderForwardError(normalizeForwardErrorState(obj), obj);
       }
 
       function showJson(obj) {
@@ -381,6 +432,10 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
           el.classList.remove('step-panel-error');
         }
         var hasIssue = !!(sc.error_code || (typeof sc.retry_count === 'number' && sc.retry_count > 0));
+        if (hasIssue) {
+          renderForwardError(sc, sc);
+          return;
+        }
         var rewardReady = isRewardNext(sc) && !hasIssue;
         el.innerHTML = formatStepTitle(sc, rewardReady, hasIssue);
         renderProgress(sc.adapter_layer_index, sc.adapter_layer_count, hasIssue, rewardReady);
@@ -460,4 +515,4 @@ export const FORWARD_WIDGET_INLINE_SCRIPT = `
 
       boot();
     })();
-`.trim();
+`);

--- a/src/mcp-apps/widget-inline-minify.ts
+++ b/src/mcp-apps/widget-inline-minify.ts
@@ -1,0 +1,20 @@
+const trimTemplateLines = (source: string): string =>
+  source
+    .trim()
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('');
+
+export const minifyInlineWidgetScript = (source: string): string => trimTemplateLines(source);
+
+export const minifyInlineWidgetCss = (source: string): string =>
+  source
+    .trim()
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([{}:;,])\s*/g, '$1')
+    .replace(/;}/g, '}')
+    .trim();
+
+export const minifyInlineWidgetHtml = (source: string): string => source.trim().replace(/>\s+</g, '><');

--- a/tests/unit/activate-widget-html.test.ts
+++ b/tests/unit/activate-widget-html.test.ts
@@ -27,10 +27,15 @@ describe('buildActivateWidgetHtml', () => {
     expect(html).toContain('choice-row-top');
     expect(html).toContain('choice-space');
     expect(html).toContain('#kairos-activate-root #out');
-    expect(html).toContain('renderHumanError');
-    expect(html).toContain('shortHumanErrorMessage');
-    expect(html).toContain('Your AI agent was asked to: ');
+    expect(html).toContain('summaryLineFromPayload');
+    expect(html).toContain('activate-json-details');
     expect(html).toContain('Technical details');
+    expect(html).toContain("showJson({ isError: true, content: p.content, message: p.message });");
+    expect(html).toContain("error: 'WIDGET_BOOT'");
+    expect(html).not.toContain('renderHumanError');
+    expect(html).not.toContain('shortHumanErrorMessage');
+    expect(html).not.toContain('Your AI agent was asked to: ');
+    expect(html).not.toContain('widget-error');
     expect(html).not.toContain('<!DOCTYPE html>');
   });
 });

--- a/tests/unit/forward-widget-html.test.ts
+++ b/tests/unit/forward-widget-html.test.ts
@@ -30,7 +30,10 @@ describe('buildForwardWidgetHtml', () => {
     expect(html).toContain('seg-issue');
     expect(html).toContain('--color-warning');
     expect(html).toContain('kairos-forward-root');
+    expect(html).toContain('normalizeForwardErrorState');
+    expect(html).toContain('renderForwardError');
     expect(html).toContain('renderHumanError');
+    expect(html).toContain('Fix tool input and retry');
     expect(html).toContain('shortHumanErrorMessage');
     expect(html).toContain('Your AI agent was asked to: ');
     expect(html).toContain('Technical details');


### PR DESCRIPTION
## Summary

This PR tightens MCP App widget bundles and adjusts activate/forward presentation.

### Widget output
- Add `widget-inline-minify.ts` helpers to compact emitted HTML (inter-tag whitespace), CSS (comments + whitespace), and inline script (line/indent stripping) for smaller fragments.

### Activate widget
- Remove the dedicated `widget-error` shell for activate-shaped errors.
- Show a short summary plus expandable **Technical details** within the normal chrome.

### Forward widget
- Use one consistent step-style layout for errors and retries (progress segments, step title, shared details block).

### Repo hygiene (included in this branch)
- `.gitignore`: ignore `.kairos-work/`.
- `.cursor/mcp.json`: Cursor MCP entry `DEVELOPMENT_KAIROS` → `http://localhost:3300/mcp` (adjust or revert if this should stay local-only).

### Tests
- Unit tests updated for new strings/helpers.
- Full `npm test` (`dev:deploy` + `dev:test`) was run successfully before push.

## Review notes
If `.cursor/mcp.json` should not ship to `main`, say so and we can drop it in a follow-up commit.