### PR TITLE
fix(forward): stable PoW nonce on repeat layer preview

### DIFF
--- a/src/tools/forward-view.ts
+++ b/src/tools/forward-view.ts
@@ -7,6 +7,7 @@ import { getSpaceContextFromStorage } from '../utils/tenant-context.js';
 import { extractMemoryBody } from '../utils/memory-body.js';
 import { buildChallenge, type ProofOfWorkSubmission } from './next-pow-helpers.js';
 import { forwardRuntimeStore } from '../services/forward-runtime-store.js';
+import { proofOfWorkStore } from '../services/proof-of-work-store.js';
 import type { ForwardOutput, ForwardSolution } from './forward_schema.js';
 import { buildLayerUri, parseKairosUri } from './kairos-uri.js';
 
@@ -144,6 +145,13 @@ export async function loadMemoryForParsedUri(
   return { memory };
 }
 
+/** Reuse an in-store nonce for the same layer so repeat forward-without-solution calls do not rotate the challenge. */
+async function challengeReuseOptions(memory: Memory): Promise<{ existingNonce: string } | undefined> {
+  if (!memory.memory_uuid) return undefined;
+  const existing = await proofOfWorkStore.getNonce(memory.memory_uuid);
+  return existing != null ? { existingNonce: existing } : undefined;
+}
+
 async function buildContractResponse(
   memory: Memory,
   executionId: string,
@@ -151,7 +159,8 @@ async function buildContractResponse(
 ): Promise<{ contract: ForwardOutput['contract']; tensorIn?: Record<string, unknown> }> {
   const storedContract = normalizeContract(memory);
   if (!storedContract) {
-    const fallback = await buildChallenge(memory, undefined);
+    const reuse = await challengeReuseOptions(memory);
+    const fallback = await buildChallenge(memory, undefined, reuse);
     if (proofHash) {
       fallback.proof_hash = proofHash;
     }
@@ -174,7 +183,8 @@ async function buildContractResponse(
     };
   }
 
-  const challenge = await buildChallenge(memory, storedContract);
+  const reuse = await challengeReuseOptions(memory);
+  const challenge = await buildChallenge(memory, storedContract, reuse);
   if (proofHash) {
     challenge.proof_hash = proofHash;
   }

--- a/src/tools/next-pow-helpers.ts
+++ b/src/tools/next-pow-helpers.ts
@@ -77,6 +77,8 @@ export async function buildChallenge(
   if (memory?.memory_uuid) {
     if (options?.existingNonce != null) {
       base.nonce = options.existingNonce;
+      // Refresh TTL so repeated forward previews (no solution) do not expire the active challenge.
+      await proofOfWorkStore.setNonce(memory.memory_uuid, options.existingNonce);
     } else {
       const nonce = crypto.randomBytes(16).toString('hex');
       await proofOfWorkStore.setNonce(memory.memory_uuid, nonce);

--- a/tests/unit/forward-nonce-stability.test.ts
+++ b/tests/unit/forward-nonce-stability.test.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeAll, describe, expect, jest, test } from '@jest/globals';
+import type { Memory } from '../../src/types/memory.js';
+
+const nonceByUuid = new Map<string, string>();
+
+jest.unstable_mockModule('../../src/services/proof-of-work-store.js', () => ({
+  MAX_RETRIES: 3,
+  proofOfWorkStore: {
+    getNonce: async (uuid: string) => nonceByUuid.get(uuid) ?? null,
+    setNonce: async (uuid: string, nonce: string) => {
+      nonceByUuid.set(uuid, nonce);
+    },
+    getResult: async () => null,
+    saveResult: async () => {},
+    setProofHash: async () => {},
+    getProofHash: async () => null,
+    incrementRetry: async () => 1,
+    resetRetry: async () => {}
+  }
+}));
+
+jest.unstable_mockModule('../../src/services/forward-runtime-store.js', () => ({
+  forwardRuntimeStore: {
+    getExecution: async () => null,
+    startExecution: async () => {},
+    setTensor: async () => {},
+    getTensor: async () => null,
+    getTensorInputs: async () => ({}),
+    requireTensorInputs: async () => ({}),
+    deleteExecution: async () => {}
+  }
+}));
+
+function makeCommentLayerMemory(memoryUuid: string): Memory {
+  return {
+    memory_uuid: memoryUuid,
+    label: 'Test layer',
+    tags: [],
+    text: '# Step\n\nDo the thing.',
+    llm_model_id: 'test',
+    created_at: new Date().toISOString(),
+    adapter: { id: 'adapter-head-uuid', name: 'Test adapter', layer_index: 5, layer_count: 5 },
+    inference_contract: {
+      type: 'comment',
+      required: true,
+      comment: { min_length: 10 }
+    }
+  };
+}
+
+describe('buildForwardView nonce stability', () => {
+  let buildForwardView: typeof import('../../src/tools/forward-view.js').buildForwardView;
+
+  beforeAll(async () => {
+    const mod = await import('../../src/tools/forward-view.js');
+    buildForwardView = mod.buildForwardView;
+  });
+
+  afterEach(() => {
+    nonceByUuid.clear();
+  });
+
+  test('repeat forward preview for the same layer reuses the same nonce', async () => {
+    const memoryUuid = randomUUID();
+    const memory = makeCommentLayerMemory(memoryUuid);
+    const executionId = randomUUID();
+
+    const first = await buildForwardView(memory, executionId);
+    const second = await buildForwardView(memory, executionId);
+
+    expect(first.contract).toBeDefined();
+    expect(second.contract).toBeDefined();
+    if (
+      typeof first.contract !== 'object' ||
+      first.contract === null ||
+      !('nonce' in first.contract) ||
+      typeof first.contract.nonce !== 'string'
+    ) {
+      throw new Error('expected comment contract with nonce');
+    }
+    expect(second.contract).toMatchObject({ nonce: first.contract.nonce });
+    expect(nonceByUuid.get(memoryUuid)).toBe(first.contract.nonce);
+  });
+});


### PR DESCRIPTION
## Problem
`forward` without a `solution` always called `buildChallenge`, which generated a **new** nonce and overwrote Redis on every preview. Any second fetch (widget refresh, host re-query, duplicate tool call) left the client holding an **old** nonce while the store held a **new** one, producing `NONCE_MISMATCH` on submit—often visible on the last layer after more UI activity.

## Change
- `buildContractResponse` reuses an existing in-store nonce for the same layer memory UUID (via `buildChallenge(..., { existingNonce })`).
- When echoing `existingNonce`, `buildChallenge` now calls `setNonce` again to **refresh TTL** (1h) so long reads do not expire the challenge silently.

## Test
- `tests/unit/forward-nonce-stability.test.ts`: two `buildForwardView` calls for the same layer yield the same `contract.nonce` (mocked PoW + runtime stores).

## Verification
`npm test` (dev:deploy + full Jest integration suite) passed locally.

Fixes behavior described in `reports/mcp-bug-development_kairos-forward-nonce-mismatch-layer5-2026-03-27.md` (client echoed prior contract; server store had rotated nonce).