### PR TITLE
release: 4.0.0

### DIFF
--- a/eslint/flat-config.cjs
+++ b/eslint/flat-config.cjs
@@ -35,6 +35,7 @@ function createFlatConfig(rootDir) {
         '.cache/**',
         'helm/**',
         '.ai/**',
+        '.kairos-work/**',
         '.local/**',
         '.git',
         '.git/**',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.0.0-rc.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "4.0.0-rc.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.0.0-rc.0",
+  "version": "4.0.0",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/kairos/SKILL.md
+++ b/skills/kairos/SKILL.md
@@ -16,7 +16,7 @@ description: >-
   reward → respond. No other path allowed.
 
 metadata:
-  version: "4.0.0-rc.0"
+  version: "4.0.0"
   author: kairos-mcp
 allowed-tools: activate forward reward train tune export delete spaces
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,6 +1,6 @@
 ---
 slug: create-new-protocol
-version: "4.0.0-rc.0"
+version: "4.0.0"
 ---
 
 # Create New KAIROS Protocol

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "4.0.0-rc.0"
+version: "4.0.0"
 slug: refine-search
 title: Get help refining your search
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
@@ -1,5 +1,5 @@
 ---
-version: "4.0.0-rc.0"
+version: "4.0.0"
 slug: create-new-protocol-review
 title: Review and Publish New KAIROS Protocol
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
@@ -1,5 +1,5 @@
 ---
-version: "4.0.0-rc.0"
+version: "4.0.0"
 slug: challenge-type-guide
 title: Challenge Type Selection Guide
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
@@ -1,5 +1,5 @@
 ---
-version: "4.0.0-rc.0"
+version: "4.0.0"
 slug: phase-critic
 title: Phase Critic
 ---


### PR DESCRIPTION
Stable release **4.0.0** (promoted from 4.0.0-rc.0).

Also adds **.kairos-work/** to ESLint global ignores so local worktree scratch files under that directory do not fail pre-commit (matches `.gitignore`).