### PR TITLE
fix compose simple profile interpolation for fullstack-only secrets

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,9 +14,9 @@ services:
     image: redis:7-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
     pull_policy: missing
     environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
     command: >
-      sh -c 'exec redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru --save 60 1000 --appendonly yes --requirepass "$$REDIS_PASSWORD"'
+      sh -c 'if [ -z "$$REDIS_PASSWORD" ]; then echo "REDIS_PASSWORD must be set when fullstack profile enables redis" >&2; exit 1; fi; exec redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru --save 60 1000 --appendonly yes --requirepass "$$REDIS_PASSWORD"'
     ports:
       - "6379:6379"
     volumes:
@@ -89,7 +89,7 @@ services:
       - .env
     environment:
       POSTGRES_USER: keycloak
-      POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
+      POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD:-}
       POSTGRES_DB: keycloak
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -120,11 +120,11 @@ services:
       - start-dev
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-}
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
       KC_DB_USERNAME: keycloak
-      KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
+      KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD:-}
       KC_HOSTNAME_STRICT: "false"
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"

--- a/tests/unit/compose-simple-profile-interpolation.test.ts
+++ b/tests/unit/compose-simple-profile-interpolation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('compose simple profile interpolation', () => {
+  it('resolves config without fullstack-only secret variables', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'kairos-compose-simple-'));
+
+    try {
+      copyFileSync(join(process.cwd(), 'compose.yaml'), join(tempDir, 'compose.yaml'));
+      writeFileSync(
+        join(tempDir, '.env'),
+        ['OPENAI_API_KEY=test-openai-key', 'QDRANT_API_KEY=test-qdrant-key', 'AUTH_ENABLED=false'].join('\n')
+      );
+
+      const result = spawnSync('docker', ['compose', '-p', 'kairos-mcp-test', 'config'], {
+        cwd: tempDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          REDIS_PASSWORD: '',
+          KEYCLOAK_DB_PASSWORD: '',
+          KEYCLOAK_ADMIN_PASSWORD: '',
+        },
+      });
+
+      if (result.error) {
+        throw result.error;
+      }
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain('REDIS_PASSWORD must be set');
+      expect(result.stderr).not.toContain('KEYCLOAK_DB_PASSWORD');
+      expect(result.stderr).not.toContain('KEYCLOAK_ADMIN_PASSWORD');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- prevent fullstack-only secret interpolation from failing the default Compose profile by using non-required defaults for Redis/Keycloak env substitutions
- keep Redis safety by validating `REDIS_PASSWORD` at Redis container startup when the `fullstack` profile actually enables Redis
- add a regression test that runs `docker compose config` with a simple-stack `.env` and asserts no fullstack-secret interpolation failures

Closes #260.

## Test plan
- [x] `npx jest tests/unit/compose-simple-profile-interpolation.test.ts --runInBand`
- [x] `docker compose config` path is exercised in test with `REDIS_PASSWORD`, `KEYCLOAK_DB_PASSWORD`, and `KEYCLOAK_ADMIN_PASSWORD` intentionally unset/empty