### PR TITLE
fix: preserve Reward Signal in markdown export

### DIFF
--- a/src/services/memory/activation-pattern-payload.ts
+++ b/src/services/memory/activation-pattern-payload.ts
@@ -42,7 +42,14 @@ function buildCanonicalAdapterPayload(
       ? adapter['protocol_version']
       : undefined;
 
+  const passthroughEntries = Object.entries(adapter).filter(
+    ([key]) =>
+      !['id', 'name', 'layer_index', 'layer_count', 'protocol_version', 'activation_patterns'].includes(key)
+  );
+  const passthroughAdapterFields = Object.fromEntries(passthroughEntries);
+
   return {
+    ...passthroughAdapterFields,
     id,
     name,
     layer_index: layerIndex,

--- a/src/services/memory/adapter-builder.ts
+++ b/src/services/memory/adapter-builder.ts
@@ -60,6 +60,14 @@ function startsWithRewardSection(sectionText: string): boolean {
   return /^##\s+(Reward Signal|Completion Rule)\s*(?:\r?\n|$)/i.test(trimmed);
 }
 
+function extractRewardSection(sectionText: string): string | null {
+  const trimmed = sectionText.trim();
+  if (!trimmed || !startsWithRewardSection(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
 /**
  * Process a single H1 section into an adapter of layer memories. Layer
  * boundaries are defined by fenced contract blocks. H2 headings are used only
@@ -151,7 +159,8 @@ function processH1Section(
   }
 
   const trailing = h1Content.slice(prevEnd).trim();
-  if (trailing.length > 0 && !startsWithRewardSection(trailing)) {
+  const rewardSection = extractRewardSection(trailing);
+  if (trailing.length > 0 && !rewardSection) {
     const codeResult = codeBlockProcessor.processMarkdown(trailing);
     const baseTags = generateTags(trailing);
     const codeTags = codeResult.allIdentifiers.slice(0, 5);
@@ -187,6 +196,14 @@ function processH1Section(
   } else {
     memories.forEach(m => {
       if (m.adapter) m.adapter.layer_count = memories.length;
+    });
+  }
+
+  if (rewardSection) {
+    memories.forEach((memory) => {
+      if (memory.adapter) {
+        memory.adapter.reward_signal = rewardSection;
+      }
     });
   }
 

--- a/src/services/memory/qdrant-point-to-memory.ts
+++ b/src/services/memory/qdrant-point-to-memory.ts
@@ -56,6 +56,9 @@ export function pointToMemory(point: QdrantPointLike): Memory {
       ...(Array.isArray(payloadAdapter.activation_patterns) && {
         activation_patterns: payloadAdapter.activation_patterns,
       }),
+      ...(typeof payloadAdapter.reward_signal === 'string' && {
+        reward_signal: payloadAdapter.reward_signal,
+      }),
     };
   }
 

--- a/src/services/memory/store-adapter-default-handler.ts
+++ b/src/services/memory/store-adapter-default-handler.ts
@@ -197,7 +197,8 @@ export async function storeDefaultAdapter(
           layer_index: adapter.layer_index,
           layer_count: adapter.layer_count,
           ...(adapter.protocol_version && { protocol_version: adapter.protocol_version }),
-          ...(adapter.activation_patterns && { activation_patterns: adapter.activation_patterns })
+          ...(adapter.activation_patterns && { activation_patterns: adapter.activation_patterns }),
+          ...(typeof adapter.reward_signal === 'string' && { reward_signal: adapter.reward_signal })
         }
       }
     });

--- a/src/services/memory/store-adapter-header-handler.ts
+++ b/src/services/memory/store-adapter-header-handler.ts
@@ -144,7 +144,8 @@ export async function storeHeaderBasedAdapter(
           layer_index: i + 1,
           layer_count: layerCount,
           ...(adapter.protocol_version && { protocol_version: adapter.protocol_version }),
-          ...(adapter.activation_patterns && { activation_patterns: adapter.activation_patterns })
+          ...(adapter.activation_patterns && { activation_patterns: adapter.activation_patterns }),
+          ...(typeof adapter.reward_signal === 'string' && { reward_signal: adapter.reward_signal })
         },
         slug: protocolSlug
       }

--- a/src/services/qdrant/memory-retrieval.ts
+++ b/src/services/qdrant/memory-retrieval.ts
@@ -127,6 +127,9 @@ export async function getMemoryByUUID(conn: QdrantConnection, uuid: string): Pro
         }),
         ...(Array.isArray(payload.adapter.activation_patterns) && {
           activation_patterns: payload.adapter.activation_patterns
+        }),
+        ...(typeof payload.adapter.reward_signal === 'string' && {
+          reward_signal: payload.adapter.reward_signal
         })
       } : undefined,
       inference_contract: payload.inference_contract,

--- a/src/tools/dump.ts
+++ b/src/tools/dump.ts
@@ -38,6 +38,20 @@ function buildMarkdownDocSingle(memory: Memory): string {
   return body + challengeBlock(getInferenceContract(memory));
 }
 
+function includesRewardHeading(markdown: string): boolean {
+  return /^##\s+(Reward Signal|Completion Rule)\s*(?:\r?\n|$)/im.test(markdown);
+}
+
+function resolveStoredRewardSection(memories: Memory[]): string | null {
+  for (const memory of memories) {
+    const rewardSignal = memory.adapter?.reward_signal;
+    if (typeof rewardSignal === 'string' && rewardSignal.trim().length > 0) {
+      return rewardSignal.trim();
+    }
+  }
+  return null;
+}
+
 function buildMarkdownDocProtocol(memories: Memory[]): string {
   if (memories.length === 0) return '';
   const adapterName = memories[0]!.adapter?.name ?? memories[0]!.label ?? 'Protocol';
@@ -46,6 +60,13 @@ function buildMarkdownDocProtocol(memories: Memory[]): string {
     const body = extractMemoryBody(memory.text);
     const bodyStripped = stripRedundantStepH2(body, memory.label);
     parts.push(`## ${memory.label}\n\n${bodyStripped}${challengeBlock(getInferenceContract(memory))}`);
+  }
+  const rewardSection = resolveStoredRewardSection(memories);
+  if (rewardSection) {
+    const rewardAlreadyPresent = memories.some((memory) => includesRewardHeading(extractMemoryBody(memory.text)));
+    if (!rewardAlreadyPresent) {
+      parts.push(rewardSection);
+    }
   }
   return parts.join('\n\n');
 }

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -5,6 +5,7 @@ export interface AdapterInfo {
   layer_count: number; // Total number of layers in the adapter
   protocol_version?: string; // Optional semver carried from frontmatter/train input
   activation_patterns?: string[];
+  reward_signal?: string; // Optional trailing Reward Signal/Completion Rule markdown section
 }
 
 export interface TensorOutputSpec {

--- a/tests/integration/kairos-dump.test.ts
+++ b/tests/integration/kairos-dump.test.ts
@@ -69,7 +69,10 @@ Only after all steps.`;
     expect(out).toHaveProperty('uri', uri);
     expect(out).toHaveProperty('format', 'markdown');
     expect(out).toHaveProperty('content_type');
-    expect((out.content as string).toLowerCase()).toContain('body for export single');
+    const content = out.content as string;
+    expect(content.toLowerCase()).toContain('body for export single');
+    expect(content).toContain('## Reward Signal');
+    expect(content).toContain('Only after all steps.');
   }, 25000);
 
   test('export with adapter URI returns full adapter markdown', async () => {
@@ -123,6 +126,8 @@ Only after all steps.`;
     expect(content).toContain('Export Protocol');
     expect(content).toContain('First');
     expect(content).toContain('Second');
+    expect(content).toContain('## Reward Signal');
+    expect(content).toContain('Only after all steps.');
   }, 25000);
 
   test('export with non-existent URI returns error', async () => {

--- a/tests/unit/adapter-builder.test.ts
+++ b/tests/unit/adapter-builder.test.ts
@@ -20,5 +20,7 @@ describe('buildHeaderMemoryAdapter', () => {
     expect(memories[1]?.label).toBe('Step Two');
     expect(memories[memories.length - 1]?.text).toContain('Second body.');
     expect(memories[memories.length - 1]?.text).not.toContain('## Reward Signal');
+    expect(memories[0]?.adapter?.reward_signal).toContain('## Reward Signal');
+    expect(memories[0]?.adapter?.reward_signal).toContain('Only after all steps.');
   });
 });


### PR DESCRIPTION
## Summary
- preserve trailing `## Reward Signal` / `## Completion Rule` content as adapter metadata during train parsing instead of dropping it
- restore persisted reward section in protocol markdown export while keeping Reward Signal non-executable
- add regression coverage in adapter-builder unit tests and export integration tests for markdown round-trip behavior

## Test plan
- [x] `npm run dev:test -- tests/unit/adapter-builder.test.ts tests/integration/kairos-dump.test.ts`
- [x] `npm test`
- [x] `npm run build`