### PR TITLE
fix: persist tune adapter markdown updates

### DIFF
--- a/src/tools/tune-execute.ts
+++ b/src/tools/tune-execute.ts
@@ -1,0 +1,314 @@
+import type { QdrantService } from '../services/qdrant/service.js';
+import { getSpaceContextFromStorage } from '../utils/tenant-context.js';
+import { resolveSpaceParamForContext } from '../utils/resolve-space-param.js';
+import { CodeBlockProcessor } from '../services/code-block-processor.js';
+import { IDGenerator } from '../services/id-generator.js';
+import { buildHeaderMemoryAdapter } from '../services/memory/adapter-builder.js';
+import { parseFrontmatter } from '../utils/frontmatter.js';
+import { executeUpdate } from './update.js';
+import { type TuneInput, type TuneOutput } from './tune_schema.js';
+import { parseKairosUri, buildLayerUri } from './kairos-uri.js';
+import { buildTuneResultMessage } from './tune-messages.js';
+
+type AdapterLayerPoint = { uuid: string; payload: any };
+
+function sortByLayerIndex(layers: AdapterLayerPoint[]): AdapterLayerPoint[] {
+  return [...layers].sort((left, right) => {
+    const li =
+      typeof left.payload?.adapter?.layer_index === 'number'
+        ? left.payload.adapter.layer_index
+        : Number.MAX_SAFE_INTEGER;
+    const ri =
+      typeof right.payload?.adapter?.layer_index === 'number'
+        ? right.payload.adapter.layer_index
+        : Number.MAX_SAFE_INTEGER;
+    return li - ri;
+  });
+}
+
+function selectAdapterLayerSet(layers: AdapterLayerPoint[], preferredSpaceId?: string): AdapterLayerPoint[] {
+  if (layers.length <= 1) {
+    return sortByLayerIndex(layers);
+  }
+
+  const groupedBySpace = new Map<string, AdapterLayerPoint[]>();
+  for (const layer of layers) {
+    const sid = typeof layer.payload?.space_id === 'string' ? layer.payload.space_id.trim() : '';
+    const key = sid.length > 0 ? sid : '__unknown__';
+    groupedBySpace.set(key, [...(groupedBySpace.get(key) ?? []), layer]);
+  }
+
+  if (groupedBySpace.size <= 1) {
+    return sortByLayerIndex(layers);
+  }
+
+  const ctx = getSpaceContextFromStorage();
+  const candidateSpaceIds = [preferredSpaceId, ctx.defaultWriteSpaceId].filter(
+    (value): value is string => typeof value === 'string' && value.trim().length > 0
+  );
+  for (const candidate of candidateSpaceIds) {
+    const selected = groupedBySpace.get(candidate.trim());
+    if (selected && selected.length > 0) {
+      return sortByLayerIndex(selected);
+    }
+  }
+
+  const fallbackSpaceId = [...groupedBySpace.keys()].sort((a, b) => a.localeCompare(b))[0];
+  return sortByLayerIndex(groupedBySpace.get(fallbackSpaceId!) ?? layers);
+}
+
+async function normalizeTuneUri(qdrantService: QdrantService, uri: string, preferredSpaceId?: string): Promise<string> {
+  const parsed = parseKairosUri(uri);
+  if (parsed.kind === 'layer') {
+    return `kairos://mem/${parsed.id}`;
+  }
+
+  const layers = selectAdapterLayerSet(await qdrantService.getAdapterLayers(parsed.id), preferredSpaceId);
+  const head = layers[0]?.uuid ?? parsed.id;
+  return `kairos://mem/${head}`;
+}
+
+async function collectLayerMemoryUuidsForTune(
+  qdrantService: QdrantService,
+  uri: string,
+  preferredSpaceId?: string
+): Promise<string[]> {
+  const parsed = parseKairosUri(uri);
+  if (parsed.kind === 'layer') {
+    return [parsed.id];
+  }
+  const layers = selectAdapterLayerSet(await qdrantService.getAdapterLayers(parsed.id), preferredSpaceId);
+  return layers.map((l) => l.uuid);
+}
+
+async function reassignAdapterLayersToSpace(
+  qdrantService: QdrantService,
+  originalUri: string,
+  targetSpaceId: string
+): Promise<void> {
+  const layerUuids = await collectLayerMemoryUuidsForTune(qdrantService, originalUri);
+  for (const uuid of layerUuids) {
+    await qdrantService.updateMemory(uuid, { space_id: targetSpaceId });
+  }
+}
+
+async function tuneAdapterMarkdownInPlace(
+  qdrantService: QdrantService,
+  adapterUri: string,
+  markdownDoc: string
+): Promise<string> {
+  const parsed = parseKairosUri(adapterUri);
+  if (parsed.kind !== 'adapter') {
+    throw new Error('tuneAdapterMarkdownInPlace requires an adapter URI');
+  }
+
+  const existingLayers = selectAdapterLayerSet(await qdrantService.getAdapterLayers(parsed.id));
+  if (existingLayers.length === 0) {
+    throw new Error(`Adapter not found: ${adapterUri}`);
+  }
+
+  const currentModel = existingLayers[0]?.payload?.llm_model_id;
+  const llmModelId =
+    typeof currentModel === 'string' && currentModel.trim().length > 0 ? currentModel.trim() : 'tune-in-place';
+
+  const parsedDoc = parseFrontmatter(markdownDoc);
+  const adapterMarkdown = parsedDoc.body.length > 0 ? parsedDoc.body : markdownDoc;
+  const codeBlockProcessor = new CodeBlockProcessor();
+  const nextLayers = buildHeaderMemoryAdapter(adapterMarkdown, llmModelId, new Date(), codeBlockProcessor);
+  if (nextLayers.length === 0) {
+    throw new Error('Invalid adapter markdown: expected H1 with at least one layer');
+  }
+
+  const nextAdapterName = nextLayers[0]?.adapter?.name?.trim() ?? '';
+  if (!nextAdapterName) {
+    throw new Error('Invalid adapter markdown: missing adapter title (H1)');
+  }
+  const expectedAdapterId = IDGenerator.generateAdapterUUIDv5(nextAdapterName);
+  if (expectedAdapterId !== parsed.id) {
+    throw new Error(
+      `Adapter title "${nextAdapterName}" resolves to ${expectedAdapterId}, but tune target is ${parsed.id}. Keep the H1 unchanged when tuning by adapter URI.`
+    );
+  }
+
+  if (nextLayers.length !== existingLayers.length) {
+    throw new Error(
+      `Layer count mismatch: adapter has ${existingLayers.length} layers, markdown has ${nextLayers.length}. Use train(force_update=true) for structural adapter changes.`
+    );
+  }
+
+  const frontmatterVersion =
+    typeof parsedDoc.version === 'string' && parsedDoc.version.trim().length > 0 ? parsedDoc.version.trim() : undefined;
+  if (frontmatterVersion) {
+    for (const memory of nextLayers) {
+      if (memory.adapter) {
+        memory.adapter.protocol_version = frontmatterVersion;
+      }
+    }
+  }
+
+  for (let i = 0; i < existingLayers.length; i++) {
+    const existing = existingLayers[i]!;
+    const next = nextLayers[i]!;
+    const existingAdapter =
+      existing.payload?.adapter && typeof existing.payload.adapter === 'object'
+        ? (existing.payload.adapter as Record<string, unknown>)
+        : {};
+    const nextAdapter = next.adapter;
+
+    const adapterUpdate: Record<string, unknown> = {
+      ...existingAdapter,
+      id: parsed.id,
+      name: nextAdapter?.name ?? existingAdapter['name'],
+      layer_index: i + 1,
+      layer_count: nextLayers.length,
+      activation_patterns: Array.isArray(nextAdapter?.activation_patterns) ? nextAdapter.activation_patterns : [],
+      reward_signal: typeof nextAdapter?.reward_signal === 'string' ? nextAdapter.reward_signal : ''
+    };
+    if (typeof nextAdapter?.protocol_version === 'string' && nextAdapter.protocol_version.trim().length > 0) {
+      adapterUpdate['protocol_version'] = nextAdapter.protocol_version.trim();
+    }
+
+    await qdrantService.updateMemory(existing.uuid, {
+      label: next.label,
+      text: next.text,
+      tags: next.tags,
+      adapter: adapterUpdate,
+      inference_contract: next.inference_contract ?? null
+    });
+  }
+
+  return buildLayerUri(existingLayers[0]!.uuid);
+}
+
+export async function executeTune(qdrantService: QdrantService, input: TuneInput): Promise<TuneOutput> {
+  const ctx = getSpaceContextFromStorage();
+  const rawSpace = typeof input.space === 'string' ? input.space.trim() : '';
+  let targetSpaceId: string | undefined;
+  if (rawSpace.length > 0) {
+    const r = resolveSpaceParamForContext(ctx, rawSpace);
+    if (!r.ok) {
+      throw new Error(r.message);
+    }
+    targetSpaceId = r.spaceId;
+    if (!ctx.allowedSpaceIds.includes(targetSpaceId)) {
+      throw new Error('Target space is not in your allowed spaces');
+    }
+  }
+
+  const hasMarkdown =
+    Array.isArray(input.markdown_doc) &&
+    input.markdown_doc.some((s) => typeof s === 'string' && s.trim().length > 0);
+  const hasUpdates = input.updates && Object.keys(input.updates).length > 0;
+  const hasContent = Boolean(hasMarkdown || hasUpdates);
+
+  if (!hasContent && !targetSpaceId) {
+    throw new Error('Provide markdown_doc, updates, or space');
+  }
+
+  if (!hasContent && targetSpaceId) {
+    const results: TuneOutput['results'] = [];
+    let total_updated = 0;
+    let total_failed = 0;
+    for (const originalUri of input.uris) {
+      try {
+        const layerUuids = await collectLayerMemoryUuidsForTune(qdrantService, originalUri);
+        for (const uuid of layerUuids) {
+          await qdrantService.updateMemory(uuid, { space_id: targetSpaceId });
+        }
+        const head = layerUuids[0];
+        results.push({
+          uri: head ? buildLayerUri(head) : originalUri,
+          status: 'updated',
+          message: 'Adapter layers reassigned to target space'
+        });
+        total_updated++;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        results.push({
+          uri: originalUri,
+          status: 'error',
+          message: `Space move failed: ${errorMessage}`
+        });
+        total_failed++;
+      }
+    }
+    return { results, total_updated, total_failed };
+  }
+
+  const results: TuneOutput['results'] = [];
+  let total_updated = 0;
+  let total_failed = 0;
+
+  for (let i = 0; i < input.uris.length; i++) {
+    const originalUri = input.uris[i]!;
+    const markdownAtIndex = Array.isArray(input.markdown_doc) ? input.markdown_doc[i] : undefined;
+    const parsedUri = parseKairosUri(originalUri);
+    try {
+      if (parsedUri.kind === 'adapter' && typeof markdownAtIndex === 'string' && markdownAtIndex.trim().length > 0) {
+        const layerUri = await tuneAdapterMarkdownInPlace(qdrantService, originalUri, markdownAtIndex);
+        results.push({
+          uri: layerUri,
+          status: 'updated',
+          message: `Adapter layer ${layerUri} updated successfully`
+        });
+        total_updated++;
+        continue;
+      }
+
+      const normalizedUri = await normalizeTuneUri(qdrantService, originalUri);
+      const perUriUpdate = await executeUpdate(qdrantService, {
+        uris: [normalizedUri] as any,
+        markdown_doc: typeof markdownAtIndex === 'string' ? [markdownAtIndex] : undefined,
+        updates: input.updates
+      });
+      const entry = perUriUpdate.results[0];
+      const layerUri = buildLayerUri((entry?.uri ?? normalizedUri).split('/').pop() ?? '');
+      const row = {
+        uri: layerUri,
+        status: entry?.status ?? 'error',
+        message: buildTuneResultMessage(
+          entry ?? { status: 'error', message: 'Failed to update memory: Unknown update failure' },
+          layerUri
+        )
+      } as TuneOutput['results'][number];
+      results.push(row);
+      if (row.status === 'updated') total_updated++;
+      else total_failed++;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      results.push({
+        uri: originalUri,
+        status: 'error',
+        message: `Failed to update adapter layer: ${errorMessage}`
+      });
+      total_failed++;
+    }
+  }
+
+  if (targetSpaceId) {
+    for (let i = 0; i < input.uris.length; i++) {
+      const originalUri = input.uris[i]!;
+      const row = results[i];
+      if (!row || row.status !== 'updated') continue;
+      try {
+        await reassignAdapterLayersToSpace(qdrantService, originalUri, targetSpaceId);
+        row.message = `${row.message} Reassigned to target space.`;
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        results[i] = {
+          uri: row.uri,
+          status: 'error',
+          message: `Content updated but space reassignment failed: ${errorMessage}`
+        };
+        total_failed++;
+        total_updated--;
+      }
+    }
+  }
+
+  return {
+    results,
+    total_updated,
+    total_failed
+  };
+}

--- a/src/tools/tune.ts
+++ b/src/tools/tune.ts
@@ -1,152 +1,16 @@
 import type { QdrantService } from '../services/qdrant/service.js';
-import { qdrantService as qdrantServiceSingleton } from '../services/qdrant/index.js';
 import { getToolDoc } from '../resources/embedded-mcp-resources.js';
-import { getTenantId, getSpaceContextFromStorage } from '../utils/tenant-context.js';
-import { resolveSpaceParamForContext } from '../utils/resolve-space-param.js';
-import { executeUpdate } from './update.js';
-import { tuneInputSchema, tuneOutputSchema, type TuneInput, type TuneOutput } from './tune_schema.js';
-import { parseKairosUri, buildLayerUri } from './kairos-uri.js';
+import { getTenantId } from '../utils/tenant-context.js';
+import { tuneInputSchema, tuneOutputSchema } from './tune_schema.js';
 import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
-import { buildTuneResultMessage } from './tune-messages.js';
 import { mcpLooseToolInput } from './mcp-loose-input-schema.js';
 import { mcpToolInputValidationErrorResult } from './mcp-tool-input-teaching.js';
+import { executeTune } from './tune-execute.js';
 
-async function normalizeTuneUri(qdrantService: QdrantService, uri: string): Promise<string> {
-  const parsed = parseKairosUri(uri);
-  if (parsed.kind === 'layer') {
-    return `kairos://mem/${parsed.id}`;
-  }
-
-  const layers = await qdrantService.getAdapterLayers(parsed.id);
-  const head = layers[0]?.uuid ?? parsed.id;
-  return `kairos://mem/${head}`;
-}
-
-async function collectLayerMemoryUuidsForTune(qdrantService: QdrantService, uri: string): Promise<string[]> {
-  const parsed = parseKairosUri(uri);
-  if (parsed.kind === 'layer') {
-    return [parsed.id];
-  }
-  const layers = await qdrantService.getAdapterLayers(parsed.id);
-  return layers.map((l) => l.uuid);
-}
-
-async function reassignAdapterLayersToSpace(
-  qdrantService: QdrantService,
-  originalUri: string,
-  targetSpaceId: string
-): Promise<void> {
-  const layerUuids = await collectLayerMemoryUuidsForTune(qdrantService, originalUri);
-  for (const uuid of layerUuids) {
-    await qdrantService.updateMemory(uuid, { space_id: targetSpaceId });
-  }
-}
-
-export async function executeTune(qdrantService: QdrantService, input: TuneInput): Promise<TuneOutput> {
-  const ctx = getSpaceContextFromStorage();
-  const rawSpace = typeof input.space === 'string' ? input.space.trim() : '';
-  let targetSpaceId: string | undefined;
-  if (rawSpace.length > 0) {
-    const r = resolveSpaceParamForContext(ctx, rawSpace);
-    if (!r.ok) {
-      throw new Error(r.message);
-    }
-    targetSpaceId = r.spaceId;
-    if (!ctx.allowedSpaceIds.includes(targetSpaceId)) {
-      throw new Error('Target space is not in your allowed spaces');
-    }
-  }
-
-  const hasMarkdown =
-    Array.isArray(input.markdown_doc) &&
-    input.markdown_doc.some((s) => typeof s === 'string' && s.trim().length > 0);
-  const hasUpdates = input.updates && Object.keys(input.updates).length > 0;
-  const hasContent = Boolean(hasMarkdown || hasUpdates);
-
-  if (!hasContent && !targetSpaceId) {
-    throw new Error('Provide markdown_doc, updates, or space');
-  }
-
-  const normalizedUris = await Promise.all(input.uris.map((uri) => normalizeTuneUri(qdrantService, uri)));
-
-  if (!hasContent && targetSpaceId) {
-    const results: TuneOutput['results'] = [];
-    let total_updated = 0;
-    let total_failed = 0;
-    for (const originalUri of input.uris) {
-      try {
-        const layerUuids = await collectLayerMemoryUuidsForTune(qdrantService, originalUri);
-        for (const uuid of layerUuids) {
-          await qdrantService.updateMemory(uuid, { space_id: targetSpaceId });
-        }
-        const head = layerUuids[0];
-        results.push({
-          uri: head ? buildLayerUri(head) : originalUri,
-          status: 'updated',
-          message: 'Adapter layers reassigned to target space'
-        });
-        total_updated++;
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        results.push({
-          uri: originalUri,
-          status: 'error',
-          message: `Space move failed: ${errorMessage}`
-        });
-        total_failed++;
-      }
-    }
-    return { results, total_updated, total_failed };
-  }
-
-  const updateResult = await executeUpdate(qdrantService, {
-    uris: normalizedUris as any,
-    markdown_doc: input.markdown_doc,
-    updates: input.updates
-  });
-
-  const results = updateResult.results.map((entry) => {
-    const layerUri = buildLayerUri(entry.uri.split('/').pop() ?? '');
-    return {
-      uri: layerUri,
-      status: entry.status,
-      message: buildTuneResultMessage(entry, layerUri)
-    };
-  });
-
-  let total_updated = updateResult.total_updated;
-  let total_failed = updateResult.total_failed;
-
-  if (targetSpaceId) {
-    for (let i = 0; i < input.uris.length; i++) {
-      const originalUri = input.uris[i]!;
-      const row = results[i];
-      if (!row || row.status !== 'updated') continue;
-      try {
-        await reassignAdapterLayersToSpace(qdrantService, originalUri, targetSpaceId);
-        row.message = `${row.message} Reassigned to target space.`;
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        results[i] = {
-          uri: row.uri,
-          status: 'error',
-          message: `Content updated but space reassignment failed: ${errorMessage}`
-        };
-        total_failed++;
-        total_updated--;
-      }
-    }
-  }
-
-  return {
-    results,
-    total_updated,
-    total_failed
-  };
-}
+export { executeTune } from './tune-execute.js';
 
 export function registerTuneTool(server: any, toolName = 'tune') {
-  const qdrantService = qdrantServiceSingleton;
+  let qdrantService: QdrantService | null = null;
   server.registerTool(
     toolName,
     {
@@ -170,6 +34,10 @@ export function registerTuneTool(server: any, toolName = 'tune') {
       const input = parsedInput.data;
 
       try {
+        if (!qdrantService) {
+          const qdrantModule = await import('../services/qdrant/index.js');
+          qdrantService = qdrantModule.qdrantService;
+        }
         const result = await executeTune(qdrantService, input);
         mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
         mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(result).length);

--- a/tests/unit/tune-execute.test.ts
+++ b/tests/unit/tune-execute.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from '@jest/globals';
+import { executeTune } from '../../src/tools/tune-execute.js';
+import { IDGenerator } from '../../src/services/id-generator.js';
+
+type LayerPayload = {
+  space_id: string;
+  label: string;
+  text: string;
+  tags: string[];
+  llm_model_id: string;
+  adapter: {
+    id: string;
+    name: string;
+    layer_index: number;
+    layer_count: number;
+    protocol_version?: string;
+    activation_patterns?: string[];
+    reward_signal?: string;
+  };
+  inference_contract?: unknown;
+};
+
+type LayerRecord = { uuid: string; payload: LayerPayload };
+
+class FakeQdrantService {
+  private readonly layerByUuid = new Map<string, LayerRecord>();
+  readonly updateCalls: Array<{ id: string; updates: Record<string, unknown> }> = [];
+
+  constructor(layers: LayerRecord[]) {
+    for (const layer of layers) {
+      this.layerByUuid.set(layer.uuid, {
+        uuid: layer.uuid,
+        payload: structuredClone(layer.payload)
+      });
+    }
+  }
+
+  async getAdapterLayers(adapterId: string): Promise<Array<{ uuid: string; payload: LayerPayload }>> {
+    const rows = [...this.layerByUuid.values()]
+      .filter((layer) => layer.payload.adapter.id === adapterId)
+      .sort((left, right) => left.payload.adapter.layer_index - right.payload.adapter.layer_index)
+      .map((layer) => ({ uuid: layer.uuid, payload: structuredClone(layer.payload) }));
+    return rows;
+  }
+
+  async updateMemory(id: string, updates: Record<string, unknown>): Promise<void> {
+    const layer = this.layerByUuid.get(id);
+    if (!layer) {
+      throw new Error(`Missing layer ${id}`);
+    }
+    const mergedPayload = {
+      ...layer.payload,
+      ...updates,
+      adapter: updates.adapter ? (updates.adapter as LayerPayload['adapter']) : layer.payload.adapter
+    } as LayerPayload;
+    this.layerByUuid.set(id, { uuid: id, payload: mergedPayload });
+    this.updateCalls.push({ id, updates });
+  }
+
+  getLayer(uuid: string): LayerRecord | undefined {
+    return this.layerByUuid.get(uuid);
+  }
+}
+
+function buildInitialLayers(adapterId: string, adapterName: string): LayerRecord[] {
+  const layer1Uuid = '11111111-1111-4111-8111-111111111111';
+  const layer2Uuid = '22222222-2222-4222-8222-222222222222';
+  return [
+    {
+      uuid: layer1Uuid,
+      payload: {
+        space_id: 'user:test-space',
+        label: 'Activation Patterns',
+        text: 'Old trigger text',
+        tags: ['old'],
+        llm_model_id: 'cursor-live-adapter-update',
+        inference_contract: { type: 'comment', comment: { min_length: 10 }, required: true },
+        adapter: {
+          id: adapterId,
+          name: adapterName,
+          layer_index: 1,
+          layer_count: 2,
+          protocol_version: '1.0.0',
+          activation_patterns: ['run old path'],
+          reward_signal: '## Reward Signal\n\nOld reward text.'
+        }
+      }
+    },
+    {
+      uuid: layer2Uuid,
+      payload: {
+        space_id: 'user:test-space',
+        label: 'Do Work',
+        text: 'Old work step',
+        tags: ['old', 'work'],
+        llm_model_id: 'cursor-live-adapter-update',
+        inference_contract: { type: 'comment', comment: { min_length: 10 }, required: true },
+        adapter: {
+          id: adapterId,
+          name: adapterName,
+          layer_index: 2,
+          layer_count: 2,
+          protocol_version: '1.0.0',
+          activation_patterns: ['run old path'],
+          reward_signal: '## Reward Signal\n\nOld reward text.'
+        }
+      }
+    }
+  ];
+}
+
+describe('executeTune adapter markdown updates', () => {
+  test('updates all adapter layers in place and refreshes adapter metadata', async () => {
+    const adapterName = 'Tune Export Regression Adapter';
+    const adapterId = IDGenerator.generateAdapterUUIDv5(adapterName);
+    const layers = buildInitialLayers(adapterId, adapterName);
+    const fakeQdrant = new FakeQdrantService(layers);
+
+    const nextMarkdown = `---
+slug: tune-export-regression-adapter
+version: 1.0.2
+---
+
+# ${adapterName}
+
+## Activation Patterns
+
+- run new path
+
+\`\`\`json
+{"contract":{"type":"comment","comment":{"min_length":8},"required":true}}
+\`\`\`
+
+## Apply Fix
+
+Fresh implementation details for the second layer.
+
+\`\`\`json
+{"contract":{"type":"comment","comment":{"min_length":12},"required":true}}
+\`\`\`
+
+## Reward Signal
+
+New reward text after tune.
+`;
+
+    const output = await executeTune(fakeQdrant as any, {
+      uris: [`kairos://adapter/${adapterId}`],
+      markdown_doc: [nextMarkdown]
+    });
+
+    expect(output.total_updated).toBe(1);
+    expect(output.total_failed).toBe(0);
+    expect(output.results[0]).toMatchObject({
+      uri: 'kairos://layer/11111111-1111-4111-8111-111111111111',
+      status: 'updated'
+    });
+    expect(fakeQdrant.updateCalls).toHaveLength(2);
+
+    const layer1 = fakeQdrant.getLayer('11111111-1111-4111-8111-111111111111');
+    const layer2 = fakeQdrant.getLayer('22222222-2222-4222-8222-222222222222');
+    expect(layer1?.payload.adapter.protocol_version).toBe('1.0.2');
+    expect(layer1?.payload.adapter.activation_patterns).toContain('run new path');
+    expect(layer1?.payload.adapter.reward_signal).toContain('New reward text after tune.');
+    expect(layer2?.payload.label).toBe('Apply Fix');
+    expect(layer2?.payload.text).toContain('Fresh implementation details for the second layer.');
+  });
+
+  test('rejects markdown that maps to a different adapter id', async () => {
+    const adapterName = 'Tune Export Regression Adapter';
+    const adapterId = IDGenerator.generateAdapterUUIDv5(adapterName);
+    const layers = buildInitialLayers(adapterId, adapterName);
+    const fakeQdrant = new FakeQdrantService(layers);
+
+    const wrongMarkdown = `# Different Adapter Title
+
+## Activation Patterns
+
+- invalid
+
+\`\`\`json
+{"contract":{"type":"comment","comment":{"min_length":5},"required":true}}
+\`\`\`
+`;
+
+    const output = await executeTune(fakeQdrant as any, {
+      uris: [`kairos://adapter/${adapterId}`],
+      markdown_doc: [wrongMarkdown]
+    });
+
+    expect(output.total_updated).toBe(0);
+    expect(output.total_failed).toBe(1);
+    expect(output.results[0]?.status).toBe('error');
+    expect(output.results[0]?.message).toContain('Failed to update adapter layer');
+    expect(fakeQdrant.updateCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `tune` adapter-URI markdown updates to rewrite all existing adapter layers in place so `export` reflects the tuned content immediately.
- Add guardrails for adapter-ID/title mismatch and layer-count mismatch, returning clear errors for structural changes that should use `train(force_update=true)`.
- Add regression tests for in-place adapter tuning behavior and extract execution logic into `tune-execute` for focused testing.

## Test plan
- [x] `npm exec jest -- tests/unit/tune-execute.test.ts tests/unit/tune.test.ts --runInBand`
- [x] `npm exec eslint src/tools/tune.ts src/tools/tune-execute.ts tests/unit/tune-execute.test.ts`
- [x] `npm run build`
- [x] `npm test`

Closes #266