### PR TITLE
fix(auth): resolve group spaces for bearer sessions

### DIFF
--- a/src/http/bearer-validate.ts
+++ b/src/http/bearer-validate.ts
@@ -113,7 +113,19 @@ export async function validateBearerToken(
   const iss = typeof payload["iss"] === "string" ? payload["iss"] : "";
   if (!iss) return null;
   const realm = realmFromIssuer(iss);
-  const groups = applyOidcGroupsAllowlist(extractGroupsFromPayload(payload), OIDC_GROUPS_ALLOWLIST);
+  const groupsFromAccess = extractGroupsFromPayload(payload);
+  let groups = groupsFromAccess;
+  if (groupsFromAccess.length === 0) {
+    const nestedIdToken = payload["id_token"];
+    if (typeof nestedIdToken === "string" && nestedIdToken.length > 0) {
+      try {
+        groups = extractGroupsFromPayload(decodePayload(nestedIdToken));
+      } catch {
+        // Ignore malformed nested id_token and keep empty groups.
+      }
+    }
+  }
+  groups = applyOidcGroupsAllowlist(groups, OIDC_GROUPS_ALLOWLIST);
   const enrich = enrichAuthPayloadFromVerifiedJwt(payload);
   const result: AuthPayload = {
     sub,

--- a/tests/unit/bearer-validate-group-fallback.test.ts
+++ b/tests/unit/bearer-validate-group-fallback.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeAll, describe, expect, jest, test } from '@jest/globals';
+import { createHash } from 'node:crypto';
+
+const payloadByToken = new Map<string, Record<string, unknown>>();
+
+function tokenFor(payload: Record<string, unknown>): string {
+  const key = createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+  const token = `token-${key}`;
+  payloadByToken.set(token, payload);
+  return token;
+}
+
+jest.unstable_mockModule('jose/jwt/decode', () => ({
+  decodeJwt: (token: string) => payloadByToken.get(token) ?? {}
+}));
+
+jest.unstable_mockModule('jose', () => ({
+  createRemoteJWKSet: () => async () => ({}) as never,
+  jwtVerify: async (token: string) => ({ payload: payloadByToken.get(token) ?? {} })
+}));
+
+jest.unstable_mockModule('../../src/http/oidc-profile-claims.js', () => ({
+  applyOidcGroupsAllowlist: (groups: string[]) => groups,
+  enrichAuthPayloadFromVerifiedJwt: () => ({ account_kind: 'local', account_label: 'Local' }),
+  extractGroupsFromPayload: (payload: Record<string, unknown>) =>
+    Array.isArray(payload.groups) ? payload.groups.filter((x): x is string => typeof x === 'string') : [],
+  realmFromIssuer: (iss: string) => {
+    const match = /\/realms\/([^/]+)/.exec(iss);
+    return match?.[1] ?? 'default';
+  }
+}));
+
+describe('validateBearerToken group extraction', () => {
+  let validateBearerToken: typeof import('../../src/http/bearer-validate.js').validateBearerToken;
+
+  beforeAll(async () => {
+    ({ validateBearerToken } = await import('../../src/http/bearer-validate.js'));
+  });
+
+  afterEach(() => {
+    payloadByToken.clear();
+  });
+
+  test('uses id_token groups when access token has no groups', async () => {
+    const issuer = 'https://kc.example/realms/kairos-dev';
+    const token = tokenFor({
+      iss: issuer,
+      sub: 'user-1',
+      aud: ['kairos-mcp'],
+      id_token: tokenFor({
+        groups: ['/SHARED/PE-TEAM']
+      })
+    });
+
+    const auth = await validateBearerToken(token, [issuer], ['kairos-mcp']);
+    expect(auth).not.toBeNull();
+    expect(auth?.groups).toEqual(['/SHARED/PE-TEAM']);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix Bearer auth group extraction by falling back to nested `id_token` groups when the access token has no `groups` claim
- preserve current behavior when access token already includes groups, and keep allowlist filtering in place
- add a regression unit test covering the nested `id_token` fallback path

## Root cause
Some OIDC clients return `groups` only in ID token context. MCP calls using Bearer auth were reading only access-token claims, which made group memberships invisible in `SpaceContext` and caused:
- `spaces` tool to omit group spaces
- `train` with group target to fail with `SPACE_NOT_FOUND`

## Validation
- `NODE_OPTIONS='--experimental-vm-modules' npx jest tests/unit/bearer-validate-group-fallback.test.ts --runInBand` ✅
- `npx eslint src/http/bearer-validate.ts tests/unit/bearer-validate-group-fallback.test.ts` ✅
- `npm run dev:deploy` ❌ blocked in this environment: missing repo `.env`/`QDRANT_URL` (server cannot start)

## Risk notes
- change is isolated to Bearer auth claim extraction and only applies when access token groups are empty
- malformed nested `id_token` is handled defensively (ignored, no throw)
- no change to space-id derivation or write-scope checks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f66a3e07-7100-4f06-9fcd-29da34df674b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f66a3e07-7100-4f06-9fcd-29da34df674b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

