### PR TITLE
fix(auth): group spaces in MCP spaces/train (fixes #278)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -143,7 +143,8 @@ export const AUTH_ALLOWED_AUDIENCES_STRING = getEnvString('AUTH_ALLOWED_AUDIENCE
  * Comma-separated group names (or /paths) allowed in the KAIROS auth session after OIDC.
  * Only JWT `groups` entries that match any entry are kept:
  * exact name or path (slash optional), or a **prefix** entry ending with `/` (e.g. `/kairos-shares/`
- * keeps every group whose path starts with that prefix). Empty = keep no token groups (default deny).
+ * keeps every group whose path starts with that prefix). Matching is **case-insensitive** for paths.
+ * Empty = keep no token groups (default deny).
  * Keycloak still issues full membership in the JWT; this filter controls what KAIROS forwards internally.
  */
 export const OIDC_GROUPS_ALLOWLIST: readonly string[] = (() => {

--- a/src/http/bearer-validate.ts
+++ b/src/http/bearer-validate.ts
@@ -35,14 +35,56 @@ export interface AuthPayload {
 
 const JWKS_CACHE = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
-/** Resolve JWKS fetch URL: use KEYCLOAK_INTERNAL_URL when token issuer is user-facing (localhost) so Docker app can reach Keycloak. */
-function getJwksFetchUrl(issuer: string): string {
+/**
+ * Issuer URL base for server-side HTTP to Keycloak (JWKS, userinfo).
+ * When KEYCLOAK_INTERNAL_URL is set and the token issuer matches KEYCLOAK_URL, use internal host
+ * so Docker can reach Keycloak.
+ */
+function resolveOidcIssuerBaseForServerFetch(issuer: string): string {
   const base = issuer.replace(/\/$/, "");
   if (KEYCLOAK_INTERNAL_URL && KEYCLOAK_URL && base.startsWith(KEYCLOAK_URL.replace(/\/$/, ""))) {
     const internalBase = KEYCLOAK_INTERNAL_URL.replace(/\/$/, "");
-    return `${internalBase}${new URL(base).pathname}/protocol/openid-connect/certs`;
+    return `${internalBase}${new URL(base).pathname}`;
   }
-  return `${base}/protocol/openid-connect/certs`;
+  return base;
+}
+
+function getJwksFetchUrl(issuer: string): string {
+  return `${resolveOidcIssuerBaseForServerFetch(issuer)}/protocol/openid-connect/certs`;
+}
+
+function getOidcUserinfoUrl(issuer: string): string {
+  return `${resolveOidcIssuerBaseForServerFetch(issuer)}/protocol/openid-connect/userinfo`;
+}
+
+/**
+ * When the access JWT has no `groups` claim (common if Group Membership is mapped to ID token / userinfo only),
+ * fetch groups from OIDC Userinfo using the same Bearer token. Aligns MCP Bearer auth with browser sessions
+ * that merge id_token groups in the OAuth callback.
+ */
+async function fetchGroupsFromOidcUserinfo(issuer: string, accessToken: string): Promise<string[]> {
+  const url = getOidcUserinfoUrl(issuer);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json"
+      },
+      signal: AbortSignal.timeout(8000)
+    });
+    if (!res.ok) {
+      structuredLogger.debug(`[auth] userinfo groups: HTTP ${res.status} url=${url}`);
+      return [];
+    }
+    const body = (await res.json()) as Record<string, unknown>;
+    return extractGroupsFromPayload(body);
+  } catch (err) {
+    structuredLogger.debug(
+      `[auth] userinfo groups: fetch failed url=${url} err=${err instanceof Error ? err.message : String(err)}`
+    );
+    return [];
+  }
 }
 
 function getJwksForIssuer(issuer: string): ReturnType<typeof createRemoteJWKSet> {
@@ -124,6 +166,9 @@ export async function validateBearerToken(
         // Ignore malformed nested id_token and keep empty groups.
       }
     }
+  }
+  if (groups.length === 0) {
+    groups = await fetchGroupsFromOidcUserinfo(iss, token);
   }
   groups = applyOidcGroupsAllowlist(groups, OIDC_GROUPS_ALLOWLIST);
   const enrich = enrichAuthPayloadFromVerifiedJwt(payload);

--- a/src/http/oidc-profile-claims.ts
+++ b/src/http/oidc-profile-claims.ts
@@ -101,27 +101,34 @@ function groupPathForm(g: string): string {
 export function applyOidcGroupsAllowlist(groups: string[], allowlist: readonly string[]): string[] {
   if (allowlist.length === 0) return [];
   const exact = new Set<string>();
+  const exactLower = new Set<string>();
   const prefixes: string[] = [];
+  const prefixLower: string[] = [];
   for (const e of allowlist) {
     const t = e.trim();
     if (!t) continue;
     if (t.endsWith("/")) {
       const p = t.startsWith("/") ? t : `/${t}`;
       prefixes.push(p);
+      prefixLower.push(p.toLowerCase());
       continue;
     }
     for (const v of groupStringVariants(t)) {
       exact.add(v);
+      exactLower.add(v.toLowerCase());
     }
   }
   return groups.filter((g) => {
     const variants = groupStringVariants(g);
     if (variants.length === 0) return false;
-    if (variants.some((v) => exact.has(v))) return true;
+    if (variants.some((v) => exact.has(v) || exactLower.has(v.toLowerCase()))) return true;
     const pathForm = groupPathForm(g);
     if (!pathForm) return false;
-    for (const p of prefixes) {
-      if (pathForm.startsWith(p)) return true;
+    const pathLower = pathForm.toLowerCase();
+    for (let i = 0; i < prefixes.length; i++) {
+      const p = prefixes[i]!;
+      const pl = prefixLower[i]!;
+      if (pathForm.startsWith(p) || pathLower.startsWith(pl)) return true;
     }
     return false;
   });

--- a/tests/unit/bearer-validate-group-fallback.test.ts
+++ b/tests/unit/bearer-validate-group-fallback.test.ts
@@ -32,6 +32,7 @@ jest.unstable_mockModule('../../src/http/oidc-profile-claims.js', () => ({
 
 describe('validateBearerToken group extraction', () => {
   let validateBearerToken: typeof import('../../src/http/bearer-validate.js').validateBearerToken;
+  const originalFetch = globalThis.fetch;
 
   beforeAll(async () => {
     ({ validateBearerToken } = await import('../../src/http/bearer-validate.js'));
@@ -39,6 +40,7 @@ describe('validateBearerToken group extraction', () => {
 
   afterEach(() => {
     payloadByToken.clear();
+    globalThis.fetch = originalFetch;
   });
 
   test('uses id_token groups when access token has no groups', async () => {
@@ -53,6 +55,28 @@ describe('validateBearerToken group extraction', () => {
     });
 
     const auth = await validateBearerToken(token, [issuer], ['kairos-mcp']);
+    expect(auth).not.toBeNull();
+    expect(auth?.groups).toEqual(['/SHARED/PE-TEAM']);
+  });
+
+  test('uses OIDC userinfo when access token has no groups and no nested id_token', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sub: 'user-1', groups: ['/SHARED/PE-TEAM'] })
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const issuer = 'https://kc.example/realms/kairos-dev';
+    const token = tokenFor({
+      iss: issuer,
+      sub: 'user-1',
+      aud: ['kairos-mcp']
+    });
+
+    const auth = await validateBearerToken(token, [issuer], ['kairos-mcp']);
+    expect(fetchMock).toHaveBeenCalled();
+    const callUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(callUrl).toContain('/protocol/openid-connect/userinfo');
     expect(auth).not.toBeNull();
     expect(auth?.groups).toEqual(['/SHARED/PE-TEAM']);
   });

--- a/tests/unit/oidc-profile-claims.test.ts
+++ b/tests/unit/oidc-profile-claims.test.ts
@@ -126,6 +126,14 @@ describe("oidc-profile-claims", () => {
     expect(applyOidcGroupsAllowlist(["/kairos-shares"], ["/kairos-shares/"])).toEqual([]);
   });
 
+  test("applyOidcGroupsAllowlist matches group paths case-insensitively against allowlist prefix", () => {
+    expect(applyOidcGroupsAllowlist(["/SHARED/PE-TEAM"], ["/shared/"])).toEqual(["/SHARED/PE-TEAM"]);
+  });
+
+  test("applyOidcGroupsAllowlist matches exact entries case-insensitively", () => {
+    expect(applyOidcGroupsAllowlist(["/Kairos-Auditor"], ["kairos-auditor"])).toEqual(["/Kairos-Auditor"]);
+  });
+
   test("mergeCallbackTokenPayloads does not map realm_access roles into groups", () => {
     const r = mergeCallbackTokenPayloads({
       idPayload: null,


### PR DESCRIPTION
## Summary
Fixes [issue #278](https://github.com/debian777/kairos-mcp/issues/278): MCP `spaces` omitted group spaces and `train` returned `SPACE_NOT_FOUND` for group paths while the web UI showed membership.

## Root cause
- Browser sessions merge `groups` from the id token when the access token has none; Bearer MCP validation only saw the access JWT, so `auth.groups` could be empty.
- `OIDC_GROUPS_ALLOWLIST` matching was case-sensitive, so a prefix like `/shared/` did not match JWT paths such as `/SHARED/PE-TEAM`.

## Changes
- After JWT parsing (including nested `id_token`), if `groups` is still empty, call OIDC Userinfo with the same Bearer token and parse `groups` (issuer URL uses the same internal-base logic as JWKS).
- Case-insensitive exact and prefix matching in `applyOidcGroupsAllowlist`.
- Config comment update; unit tests for userinfo fallback and allowlist casing.

## Verification
- `npm test` (dev:deploy + dev:test): green (61 suites, 220 tests passed).

## Notes
- `OIDC_GROUPS_ALLOWLIST` must still be configured (non-empty) for any token groups to be kept.
- Keycloak should expose `groups` on Userinfo for the fallback to apply when the access token omits them.