### PR TITLE
fix(auth): restore Keycloak issuer and DCR for MCP streamable HTTP

### DIFF
--- a/src/http/http-well-known.ts
+++ b/src/http/http-well-known.ts
@@ -2,24 +2,17 @@
  * OAuth 2.0 well-known metadata endpoints for MCP authorization discovery.
  *
  * Protected Resource Metadata (RFC 9728):
- *   GET /.well-known/oauth-protected-resource       (root — fallback)
- *   GET /.well-known/oauth-protected-resource/mcp   (path-specific — tried first by spec-compliant clients)
+ *   GET /.well-known/oauth-protected-resource       (root - fallback)
+ *   GET /.well-known/oauth-protected-resource/mcp   (path-specific - tried first by spec-compliant clients)
  *
  * Authorization Server Metadata (RFC 8414 proxy):
  *   GET /.well-known/oauth-authorization-server
  *
- *   Proxies Keycloak's authorization server metadata with two critical overrides:
- *   1. Strips `registration_endpoint` — prevents MCP clients from using Dynamic Client
- *      Registration (RFC 7591), which creates a new Keycloak client per session and causes
- *      unbounded client sprawl (100+ orphaned clients observed in production).
- *   2. Adds `client_id_metadata_document_supported: true` — signals MCP clients (spec 2025-11-25)
- *      to use Client ID Metadata Documents instead of DCR.
- *
- *   MCP client fallback priority (spec 2025-11-25):
- *     1. Pre-registered client info (kairos-cli exposed via kairos_cli_client_id)
- *     2. Client ID Metadata Documents (when client_id_metadata_document_supported is true)
- *     3. DCR (only when registration_endpoint is present — we strip it)
- *     4. User prompt
+ *   Proxies Keycloak's realm OpenID configuration. registration_endpoint is preserved so
+ *   MCP hosts that require Dynamic Client Registration (e.g. Cursor streamable HTTP) work.
+ *   Adds client_id_metadata_document_supported: true (MCP spec 2025-11-25) so clients that
+ *   support Client ID Metadata Documents can prefer them over DCR when applicable.
+ *   Operators should constrain DCR in Keycloak realm settings if client sprawl is a concern.
  *
  * See: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
  */
@@ -27,35 +20,25 @@ import type { Express, Request, Response } from 'express';
 import { AUTH_CALLBACK_BASE_URL, KEYCLOAK_URL, KEYCLOAK_INTERNAL_URL, KEYCLOAK_REALM, KEYCLOAK_CLI_CLIENT_ID } from '../config.js';
 import { structuredLogger } from '../utils/structured-logger.js';
 
-function buildProtectedResourceMetadata(): Record<string, unknown> {
+export function buildProtectedResourceMetadata(): Record<string, unknown> {
   const base = AUTH_CALLBACK_BASE_URL.replace(/\/$/, '');
   const resource = `${base}/mcp`;
   const issuer = KEYCLOAK_URL
     ? `${KEYCLOAK_URL.replace(/\/$/, '')}/realms/${KEYCLOAK_REALM}`
     : '';
 
-  // Point authorization_servers to KAIROS itself (not Keycloak directly).
-  // KAIROS serves /.well-known/oauth-authorization-server as a filtered proxy of Keycloak's
-  // metadata — stripping registration_endpoint to prevent DCR client sprawl.
-  // MCP clients discover auth capabilities from KAIROS, but auth/token endpoints in the
-  // proxied metadata still point to Keycloak for the actual OAuth flows.
   const metadata: Record<string, unknown> = {
     resource,
-    authorization_servers: base ? [base] : issuer ? [issuer] : [],
+    authorization_servers: issuer ? [issuer] : [],
     scopes_supported: ['openid', 'profile', 'email', 'kairos-groups'],
     bearer_methods_supported: ['header'],
     resource_name: 'KAIROS MCP'
   };
-  // Optional: expose endpoints so CLI and other clients can build auth URLs without 401 or hardcoded paths.
   if (issuer) {
     metadata['authorization_endpoint'] = `${issuer}/protocol/openid-connect/auth`;
     metadata['token_endpoint'] = `${issuer}/protocol/openid-connect/token`;
   }
-  // RFC 9728 allows additional parameters. MCP clients that support it should add these
-  // to the authorization request (e.g. prompt=login) to avoid already_logged_in when
-  // the user is logged in elsewhere, without disabling SSO for normal browser use.
   metadata['authorization_request_parameters'] = { prompt: 'login' };
-  // KAIROS-specific extension: expose the public client_id for PKCE flows (CLI and MCP hosts)
   if (KEYCLOAK_CLI_CLIENT_ID) {
     metadata['kairos_cli_client_id'] = KEYCLOAK_CLI_CLIENT_ID;
   }
@@ -76,16 +59,12 @@ export function setupWellKnown(app: Express): void {
   app.get('/.well-known/oauth-protected-resource', handler);
   app.get('/.well-known/oauth-protected-resource/mcp', handler);
 
-  // Authorization Server Metadata — proxy from Keycloak with DCR stripped.
   setupAuthorizationServerMetadata(app);
 }
 
 // ---------------------------------------------------------------------------
 // Authorization Server Metadata proxy (RFC 8414)
 // ---------------------------------------------------------------------------
-
-/** Fields stripped from Keycloak metadata to prevent MCP clients from using DCR. */
-const STRIPPED_FIELDS = ['registration_endpoint'] as const;
 
 /** Cache upstream metadata to avoid per-request round-trips. */
 let authServerMetadataCache: { data: Record<string, unknown>; expiresAt: number } | null = null;
@@ -133,26 +112,14 @@ async function fetchUpstreamAuthServerMetadata(): Promise<Record<string, unknown
   }
 }
 
-function buildAuthorizationServerMetadata(upstream: Record<string, unknown>): Record<string, unknown> {
+export function buildAuthorizationServerMetadata(upstream: Record<string, unknown>): Record<string, unknown> {
   const metadata = { ...upstream };
 
-  // Strip DCR endpoint to prevent MCP clients from registering new Keycloak clients.
-  for (const field of STRIPPED_FIELDS) {
-    delete metadata[field];
-  }
+  // Preserve registration_endpoint from Keycloak — MCP hosts (e.g. Cursor streamable HTTP)
+  // require it for Dynamic Client Registration. Stripping it causes:
+  //   "Incompatible auth server: does not support dynamic client registration"
+  // Operators should constrain DCR in Keycloak realm settings if client sprawl is a concern.
 
-  // Also strip from mtls_endpoint_aliases (Keycloak mirrors endpoints there).
-  const mtls = metadata['mtls_endpoint_aliases'];
-  if (mtls && typeof mtls === 'object') {
-    const aliases = { ...(mtls as Record<string, unknown>) };
-    for (const field of STRIPPED_FIELDS) {
-      delete aliases[field];
-    }
-    metadata['mtls_endpoint_aliases'] = aliases;
-  }
-
-  // Signal MCP clients (spec 2025-11-25) that Client ID Metadata Documents are supported.
-  // This is position 2 in the MCP client fallback priority, ahead of DCR (position 3).
   metadata['client_id_metadata_document_supported'] = true;
 
   return metadata;

--- a/tests/unit/oauth-protected-resource-contract.test.ts
+++ b/tests/unit/oauth-protected-resource-contract.test.ts
@@ -1,0 +1,85 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+let buildProtectedResourceMetadata: () => Record<string, unknown>;
+let buildAuthorizationServerMetadata: (upstream: Record<string, unknown>) => Record<string, unknown>;
+
+beforeAll(async () => {
+    process.env['AUTH_CALLBACK_BASE_URL'] = 'http://localhost:3300';
+    process.env['KEYCLOAK_URL'] = 'http://keycloak.local:8180';
+    process.env['KEYCLOAK_REALM'] = 'kairos-dev';
+    process.env['KEYCLOAK_CLI_CLIENT_ID'] = 'kairos-cli';
+
+    const mod = await import('../../src/http/http-well-known.js');
+    buildProtectedResourceMetadata = mod.buildProtectedResourceMetadata;
+    buildAuthorizationServerMetadata = mod.buildAuthorizationServerMetadata;
+});
+
+// ---------------------------------------------------------------------------
+// Bug: authorization_servers points to KAIROS app instead of Keycloak issuer.
+// MCP clients fetch /.well-known/oauth-authorization-server from that server,
+// which strips registration_endpoint → "does not support dynamic client registration".
+// ---------------------------------------------------------------------------
+
+describe('Protected Resource Metadata (buildProtectedResourceMetadata)', () => {
+    it('authorization_servers must point to Keycloak issuer, not KAIROS app base', () => {
+        const meta = buildProtectedResourceMetadata();
+        const servers = meta['authorization_servers'] as string[];
+
+        expect(servers).toHaveLength(1);
+        // Must be the Keycloak realm issuer — NOT the KAIROS app base URL.
+        expect(servers[0]).toBe('http://keycloak.local:8180/realms/kairos-dev');
+        expect(servers[0]).not.toBe('http://localhost:3300');
+    });
+
+    it('token_endpoint issuer must match authorization_servers[0]', () => {
+        const meta = buildProtectedResourceMetadata();
+        const servers = meta['authorization_servers'] as string[];
+        const tokenEndpoint = meta['token_endpoint'] as string;
+
+        const issuerFromToken = tokenEndpoint.replace(/\/protocol\/openid-connect\/token$/, '');
+        expect(servers[0]).toBe(issuerFromToken);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug: buildAuthorizationServerMetadata strips registration_endpoint from
+// Keycloak metadata. MCP hosts (e.g. Cursor streamable HTTP) require it for
+// Dynamic Client Registration. Stripping causes the connection failure.
+// ---------------------------------------------------------------------------
+
+describe('Authorization Server Metadata (buildAuthorizationServerMetadata)', () => {
+    const UPSTREAM_KEYCLOAK = {
+        issuer: 'http://keycloak.local:8180/realms/kairos-dev',
+        authorization_endpoint: 'http://keycloak.local:8180/realms/kairos-dev/protocol/openid-connect/auth',
+        token_endpoint: 'http://keycloak.local:8180/realms/kairos-dev/protocol/openid-connect/token',
+        registration_endpoint: 'http://keycloak.local:8180/realms/kairos-dev/clients-registrations/openid-connect',
+        mtls_endpoint_aliases: {
+            registration_endpoint: 'http://keycloak.local:8180/realms/kairos-dev/clients-registrations/openid-connect',
+        },
+    };
+
+    it('must preserve registration_endpoint from upstream Keycloak metadata', () => {
+        const result = buildAuthorizationServerMetadata({ ...UPSTREAM_KEYCLOAK });
+        expect(result['registration_endpoint']).toBe(UPSTREAM_KEYCLOAK.registration_endpoint);
+    });
+
+    it('must preserve registration_endpoint in mtls_endpoint_aliases', () => {
+        const result = buildAuthorizationServerMetadata({ ...UPSTREAM_KEYCLOAK });
+        const aliases = result['mtls_endpoint_aliases'] as Record<string, unknown>;
+        expect(aliases['registration_endpoint']).toBe(
+            UPSTREAM_KEYCLOAK.mtls_endpoint_aliases.registration_endpoint
+        );
+    });
+
+    it('must set client_id_metadata_document_supported', () => {
+        const result = buildAuthorizationServerMetadata({ ...UPSTREAM_KEYCLOAK });
+        expect(result['client_id_metadata_document_supported']).toBe(true);
+    });
+
+    it('must pass through all other upstream fields unchanged', () => {
+        const result = buildAuthorizationServerMetadata({ ...UPSTREAM_KEYCLOAK });
+        expect(result['issuer']).toBe(UPSTREAM_KEYCLOAK.issuer);
+        expect(result['authorization_endpoint']).toBe(UPSTREAM_KEYCLOAK.authorization_endpoint);
+        expect(result['token_endpoint']).toBe(UPSTREAM_KEYCLOAK.token_endpoint);
+    });
+});


### PR DESCRIPTION
## Problem

Cursor (and other MCP hosts using streamable HTTP) failed to connect with:

```
Incompatible auth server: does not support dynamic client registration
```

## Root cause

1. **Protected Resource Metadata** listed `authorization_servers` as the KAIROS app base while `token_endpoint` pointed at Keycloak, so discovery did not match the token issuer.
2. **`/.well-known/oauth-authorization-server`** proxied Keycloak metadata but stripped `registration_endpoint`, so clients that require Dynamic Client Registration (DCR) rejected the auth server.

## Changes

- Set `authorization_servers` to the Keycloak realm issuer (same issuer as `token_endpoint`).
- Preserve `registration_endpoint` (and `mtls_endpoint_aliases` mirrors) in the proxied authorization server document; still add `client_id_metadata_document_supported`.
- Export `buildProtectedResourceMetadata` and `buildAuthorizationServerMetadata` for tests.
- Add unit tests that assert the contract (they fail on the old behavior).

## Validation

- `npx jest tests/unit/oauth-protected-resource-contract.test.ts`
- `npm run dev:deploy` and manual curl of well-known endpoints; `registration_endpoint` present and `authorization_servers` aligned with Keycloak.

Operators who relied on stripping DCR to limit Keycloak client sprawl should tighten DCR policies in the Keycloak realm instead.