### PR TITLE
release: 4.1.1-rc.2

### DIFF
--- a/.cursor/skills/version-bump-release/SKILL.md
+++ b/.cursor/skills/version-bump-release/SKILL.md
@@ -3,12 +3,16 @@ name: version-bump-release
 description: "Deterministic version bump and release workflow. Use when the user says: bump version, cut a release, create a release, version-bump PR, or similar release-related requests."
 ---
 
-# Version Bump & Release
+# Version bump and release
 
 Releases work **with or without this skill**.
 
-- **Without skill:** Run `npm version <type> --no-git-tag-version` (or use the repo’s `npm run release:<type>` targets), then `npm run version:sync-skills`, then do branch/commit/push/PR yourself.
-- **With skill:** The skill helps (1) choose the next version type, (2) get your confirmation, and (3) automate the rest.
+- **Without skill:** Run `npm version <type> --no-git-tag-version` (or use the
+  repo `npm run release:<type>` targets), then `npm run version:sync-skills`
+  when you did not use a `release:*` script, then branch, commit, push, and
+  open the PR yourself.
+- **With skill:** The skill helps (1) choose the next version type, (2) get your
+  confirmation, and (3) automate the rest.
 
 ---
 
@@ -29,14 +33,15 @@ Recommend a type from conventional commits:
 | `fix:` / `docs:` / `chore:` / `refactor:` / `ci:` / `test:` | **patch** | `release:patch` / `release:bug` |
 | User wants prerelease | **rc** / **beta** / **pre** | `release:rc` / `release:beta` / `release:pre` |
 
-If confidence < 95%, ask the user.
+If confidence is below 95%, ask the user.
 
 ---
 
 ## 2. User confirmation
 
-**Before any version change, ask the user to confirm the version type (and value if helpful).**  
-After confirmation, run the full automation below without further questions.
+**Before any version change, ask the user to confirm the version type (and value
+if helpful).** After confirmation, run the full automation below without further
+questions.
 
 ---
 
@@ -44,7 +49,7 @@ After confirmation, run the full automation below without further questions.
 
 Run from **repo root**, in order.
 
-**3.1 Ensure latest main**
+### 3.1 Ensure latest main
 
 ```bash
 git fetch origin main
@@ -52,16 +57,19 @@ git checkout main
 git pull origin main
 ```
 
-**3.2 Create release branch and run release target**
+### 3.2 Create release branch and run release target
 
-Create a temporary branch, run the chosen npm target (it runs `npm version ... --no-git-tag-version` and `version:sync-skills`), then rename the branch to `release/<version>`:
+Create a temporary branch, run the chosen npm target (it runs
+`npm version ... --no-git-tag-version` and `npm run version:sync-skills`), then
+rename the branch to `release/<version>`:
 
 ```bash
 git checkout -b release/next
 npm run release:<type>
 ```
 
-Replace `<type>` with one of: `major`, `minor`, `patch`, `bug`, `rc`, `pre`, `beta`.
+Replace `<type>` with one of: `major`, `minor`, `patch`, `bug`, `rc`, `pre`,
+`beta`.
 
 Then rename the branch to the actual version:
 
@@ -70,7 +78,10 @@ VERSION=$(node -p "require('./package.json').version")
 git branch -m release/next "release/$VERSION"
 ```
 
-**3.3 Commit, push, open PR**
+### 3.3 Commit, push, open PR
+
+Stage everything the sync step can change (see **What `version:sync-skills`
+does** below). Prefer a quick `git status` if anything looks unexpected.
 
 ```bash
 git add package.json package-lock.json src/embed-docs/mem/ skills/
@@ -81,21 +92,75 @@ gh pr create --base main --head "release/$VERSION" \
   --body "Version bump to $VERSION."
 ```
 
-**3.4 Show clickable PR URL**
+### 3.4 Show clickable PR URL
 
-After `gh pr create`, the CLI prints the PR URL. Present that URL clearly to the user (e.g. as a clickable link in your response). If you need to obtain it explicitly:
+After `gh pr create`, the CLI prints the PR URL. Present that URL clearly to the
+user (for example as a clickable link in your response). If you need it
+explicitly:
 
 ```bash
 gh pr view --json url -q .url
 ```
 
-**Do not create a git tag.** Tags are created when the version-bump PR is merged to `main` (`.github/workflows/release-tag-on-version-bump.yml`).
+**Do not create a git tag.** Tags are created after the version-bump PR merges
+to `main` when Integration succeeds (see
+`.github/workflows/release-tag-on-version-bump.yml`). Do not push `refs/tags/v*`
+manually; **pre-push** blocks it.
 
 ---
 
-## 4. Edge cases
+## 4. What `version:sync-skills` does
 
-- **Dirty working tree:** Stash or commit unrelated changes first. The release branch should only contain version-bump artefacts (and any changes the user explicitly includes).
+Implementation: `scripts/build-sync-skill-versions.mjs` (also run during
+`prebuild`).
+
+1. **`src/embed-docs/mem/*.md`**  
+   Frontmatter `version` is set to **`package.json` `version`** (including
+   prerelease).
+
+2. **Top-level skill trees under `skills/`**  
+   For each **immediate** subdirectory of `skills/` (for example `skills/kairos/`),
+   if `SKILL.md` contains a metadata `version:` line, that value is updated. If
+   `references/KAIROS.md` exists and has a leading frontmatter `version`, that is
+   updated too. The target version is the **greater** of `package.json` version
+   and the latest **stable** `vX.Y.Z` tag in the repo (no prerelease suffix in
+   the tag), defaulting to `1.0.0` when no stable tag exists. That way a new
+   release number is applied to skills **before** the new tag exists.
+
+**Scope limit:** Only `skills/<name>/...` where `<name>` is a direct child of
+`skills/` is processed. Deeper layouts (for example `skills/.system/foo/SKILL.md`)
+are **not** updated by this script unless the script is extended.
+
+**Verification:** `npm run version:check-skills` runs the same logic in `--check`
+mode and exits non-zero on mismatch. **Integration** runs this; **pre-commit**
+runs it when `package.json`, `skills/`, or `src/embed-docs/mem/` is staged.
+
+---
+
+## 5. Edge cases and troubleshooting
+
+- **Dirty working tree:** Stash or commit unrelated changes first. The release
+  branch should only contain version-bump artifacts (and anything the user
+  explicitly includes).
+
 - **Existing `release/*` branch:** Warn and ask whether to reuse or delete it.
-- **Pre-release → stable:** If current version is e.g. `3.3.0-rc.1` and the user wants stable, use `npm run release:patch` (strips prerelease and bumps patch).
-- **Sync failures:** If `version:sync-skills` fails, fix the issue before committing.
+
+- **Pre-release to stable:** If the current version is for example `3.3.0-rc.1`
+  and the user wants stable, `npm run release:patch` is the usual path (npm drops
+  the prerelease and advances the patch level).
+
+- **`version:check-skills` fails (pre-commit or CI):** This means embedded
+  versions are out of sync with targets, not necessarily that `sync` crashed.
+  1. Run `git fetch --tags` so “latest stable tag” is correct locally.
+  2. Run `npm run version:sync-skills`.
+  3. Re-stage: `git add skills/ src/embed-docs/mem/` (and `package.json` /
+     `package-lock.json` if you changed them).
+  4. Run `npm run version:check-skills` again before committing.
+
+- **`version:sync-skills` throws or exits non-zero:** Fix the underlying error
+  (invalid `package.json`, missing `version` field, unreadable files, and so on),
+  then re-run sync. Do not commit a broken bump.
+
+- **New skill file under `skills/<dir>/`:** Ensure `SKILL.md` has the expected
+  `version:` metadata line (two-space indent) so the script can update it; same
+  for `references/KAIROS.md` frontmatter if you use it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.1.1-rc.1",
+  "version": "4.1.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "4.1.1-rc.1",
+      "version": "4.1.1-rc.2",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.1.1-rc.1",
+  "version": "4.1.1-rc.2",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,6 +1,6 @@
 ---
 slug: create-new-protocol
-version: "4.1.1-rc.1"
+version: "4.1.1-rc.2"
 title: Create / Review / Refactor KAIROS Protocol
 ---
 

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "4.1.1-rc.1"
+version: "4.1.1-rc.2"
 slug: refine-search
 title: Get help refining your search
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
@@ -1,5 +1,5 @@
 ---
-version: "4.1.1-rc.1"
+version: "4.1.1-rc.2"
 slug: create-new-protocol-review
 title: Review and Publish New KAIROS Protocol
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
@@ -1,5 +1,5 @@
 ---
-version: "4.1.1-rc.1"
+version: "4.1.1-rc.2"
 slug: challenge-type-guide
 title: Challenge Type Selection Guide
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
@@ -1,5 +1,5 @@
 ---
-version: "4.1.1-rc.1"
+version: "4.1.1-rc.2"
 slug: phase-critic
 title: Phase Critic
 ---


### PR DESCRIPTION
Version bump to 4.1.1-rc.2.

Includes updated `.cursor/skills/version-bump-release/SKILL.md` (accurate `version:sync-skills` / `version:check-skills` behavior, troubleshooting, and skills sync scope).