### PR TITLE
fix(ci): idempotent release tag, workflow_run filter, drop v4 branch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,8 +5,8 @@
 ```mermaid
 flowchart LR
   subgraph triggers["Triggers"]
-    PR[PR → main, v4, or ci/**]
-    PUSH[Push → main, v4, or ci/**]
+    PR[PR → main or ci/**]
+    PUSH[Push → main or ci/**]
     TAG[Tag push v*.*.*]
     MANUAL[Manual dispatch]
   end
@@ -42,7 +42,7 @@ flowchart LR
 
 **Release path (normal flow):** Version-bump PR merged to main → **Release tag on version bump** runs; if `package.json` version &gt; latest tag, it pushes that tag → **Release** runs on tag push (publish npm → publish Docker → create GitHub Release).
 
-**Integration:** Runs on every PR and push to **main**, **v4**, or **`ci/**`** (integration and beta lines such as `ci/integration-on-v4`), and on tag push to re-verify the released ref. Manual run available. Without a push (or PR) trigger on those `ci/**` branches, **Release tag on version bump** never sees a successful **Integration** `workflow_run`, so beta tags are not created automatically after CI green.
+**Integration:** Runs on every PR and push to **main** or **`ci/**`** (integration and beta lines such as `ci/integration-line`), and on tag push to re-verify the released ref. Manual run available. Without a push (or PR) trigger on those `ci/**` branches, **Release tag on version bump** never sees a successful **Integration** `workflow_run`, so beta tags are not created automatically after CI green.
 
 **PR/MR tooling:** This repo uses the GitHub CLI (**gh**) for PRs. For GitLab MRs use **glab**. KAIROS protocols: *GitHub PR with gh* (create/track PRs with `gh`), *GitLab MR with glab* (create/track MRs with `glab`).
 
@@ -114,7 +114,7 @@ flowchart TB
 
 The integration workflow uses **optional secrets:** `OPENAI_API_KEY` (embedding tests), `KEYCLOAK_ADMIN_PASSWORD`, `KEYCLOAK_DB_PASSWORD`, `SESSION_SECRET`. In the workflow they are referenced as `${{ secrets.OPENAI_API_KEY }}` etc. Non-sensitive values use **repository variables** as `${{ vars.VAR_NAME }}`. If optional secrets are not set, the job uses fixed defaults for Keycloak and generates `SESSION_SECRET` so the job runs without any secrets.
 
-**Triggers:** `pull_request` / `push` to **main**, **v4**, or **`ci/**`**; `push` tags `v*.*.*`; `workflow_dispatch` (optional force input).
+**Triggers:** `pull_request` / `push` to **main** or **`ci/**`**; `push` tags `v*.*.*`; `workflow_dispatch` (optional force input).
 
 **Actions → Integration → Run workflow** (workflow_dispatch).
 
@@ -152,11 +152,12 @@ sequenceDiagram
 
 ## Release tag on version bump
 
-`release-tag-on-version-bump.yml` runs after **Integration** completes (any branch) or via **manual dispatch**.
+`release-tag-on-version-bump.yml` runs after **Integration** completes successfully on **`main`** or **`ci/**`** (`workflow_run` branch filter), or via **manual dispatch**. Human version bumps follow [.cursor/skills/version-bump-release/SKILL.md](../../.cursor/skills/version-bump-release/SKILL.md): branch **`release/<version>`** → PR to **`main`** → merge → Integration on **`main`** → this workflow creates the tag (no local tag from the skill).
 
-- **Main:** Full releases (`vX.Y.Z`) and pre-releases (`vX.Y.Z-pre.N`) — creates and pushes the tag when `package.json` version is **greater** than the latest existing stable tag. Same as before.
-- **Any other branch:** **Beta only** — creates the tag only if the version contains `-beta.` (e.g. `3.2.0-beta.0`) and that tag does not already exist. Full/pre releases are not created from non-main branches.
-- **Manual trigger (Actions → Release tag on version bump → Run workflow):** Provide **ref** (branch or SHA, e.g. `ci/integration-on-v4` or a commit SHA). Beta only: tags the commit if `package.json` version contains `-beta.` and the tag `v<version>` does not exist. Use when Integration has not run on that ref yet or you need to retry tagging. Prefer the automatic path: push to a **`ci/**`** branch (or **main** / **v4**), let **Integration** go green, then this workflow runs from **`workflow_run`** and pushes the tag and dispatches **Release**.
+- **Main:** Full releases (`vX.Y.Z`) and pre-releases (e.g. `vX.Y.Z-rc.N`) — creates and pushes the tag when `package.json` version is **greater** than the latest existing **stable** tag (`X.Y.Z` only) **and** `v<package.json version>` does not already exist (local or on `origin`). Repeat Integration runs for the same version exit cleanly instead of failing on duplicate `git tag`.
+- **`ci/**`:** **Beta only** — creates the tag only if the version contains `-beta.` (e.g. `3.2.0-beta.0`) and that tag does not already exist (local or on `origin`). Full/pre releases are not created from non-main branches.
+- **Concurrency:** One job at a time per repository (`cancel-in-progress: false`) so concurrent runs do not race on `git tag` / `git push`.
+- **Manual trigger (Actions → Release tag on version bump → Run workflow):** Provide **ref** (branch or SHA, e.g. `ci/integration-line` or a commit SHA). Beta only: tags the commit if `package.json` version contains `-beta.` and the tag `v<version>` does not exist. Use when Integration has not run on that ref yet or you need to retry tagging. Prefer the automatic path: push to **`ci/**`** or merge to **main** per the skill, let **Integration** go green on **`main`** or **`ci/**`**, then this workflow runs from **`workflow_run`** and pushes the tag and dispatches **Release**.
 
 **Flow:** When a tag is created (by this workflow), it triggers the **Release** workflow (npm → Docker → GitHub Release).
 

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -8,7 +8,7 @@ on:
       - "ct.yaml"
       - ".github/workflows/helm-chart.yml"
   push:
-    branches: [main, v4, "ci/**"]
+    branches: [main, "ci/**"]
     paths:
       - "helm/kairos-mcp/**"
       - "ct.yaml"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,12 +11,12 @@ name: Integration
 
 on:
   pull_request:
-    # Base branches: include ci/** so PRs into integration lines get the same gate as main/v4.
-    branches: [main, v4, "ci/**"]
+    # Base branches: include ci/** so PRs into integration lines get the same gate as main.
+    branches: [main, "ci/**"]
   merge_group:
   push:
     # Integration + Release tag (workflow_run) must run on beta/integration branches or beta never auto-tags.
-    branches: [main, v4, "ci/**"]
+    branches: [main, "ci/**"]
     tags:
       - 'v*.*.*'
   workflow_dispatch:

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -6,10 +6,15 @@
 # Requires branch protection to allow this workflow to push tags.
 name: Release tag on version bump
 
+concurrency:
+  group: release-tag-on-version-bump-${{ github.repository }}
+  cancel-in-progress: false
+
 on:
   workflow_run:
     workflows: [Integration]
     types: [completed]
+    branches: [main, "ci/**"]
   workflow_dispatch:
     inputs:
       ref:
@@ -33,6 +38,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -74,11 +80,20 @@ jobs:
 
           do_tag=false
           if [ "$is_main" = "true" ]; then
-            higher=$(printf '%s\n' "$latest" "$pkg" | sort -V | tail -n1)
-            if [ "$higher" = "$pkg" ] && [ "$latest" != "$pkg" ]; then do_tag=true; fi
+            if git rev-parse "$tag_name" >/dev/null 2>&1; then
+              :
+            elif git ls-remote --exit-code --tags origin "refs/tags/${tag_name}" >/dev/null 2>&1; then
+              :
+            else
+              higher=$(printf '%s\n' "$latest" "$pkg" | sort -V | tail -n1)
+              if [ "$higher" = "$pkg" ] && [ "$latest" != "$pkg" ]; then do_tag=true; fi
+            fi
           else
             if [ "$is_beta" = "true" ]; then
-              if ! git rev-parse "$tag_name" >/dev/null 2>&1; then do_tag=true; fi
+              if ! git rev-parse "$tag_name" >/dev/null 2>&1 \
+                && ! git ls-remote --exit-code --tags origin "refs/tags/${tag_name}" >/dev/null 2>&1; then
+                do_tag=true
+              fi
             fi
           fi
 
@@ -95,7 +110,12 @@ jobs:
             echo "version=" >> "$GITHUB_OUTPUT"
             if [ "$is_main" != "true" ] && [ "$is_beta" != "true" ]; then
               echo "Skipped: non-main branches only allow beta versions (version must contain -beta.)"
-            elif [ "$is_main" != "true" ] && git rev-parse "$tag_name" >/dev/null 2>&1; then
+            elif [ "$is_main" = "true" ] && { git rev-parse "$tag_name" >/dev/null 2>&1 \
+              || git ls-remote --exit-code --tags origin "refs/tags/${tag_name}" >/dev/null 2>&1; }; then
+              echo "Skipped: tag $tag_name already exists (local or origin)"
+            elif [ "$is_main" != "true" ] && [ "$is_beta" = "true" ] \
+              && { git rev-parse "$tag_name" >/dev/null 2>&1 \
+              || git ls-remote --exit-code --tags origin "refs/tags/${tag_name}" >/dev/null 2>&1; }; then
               echo "Skipped: tag $tag_name already exists"
             else
               echo "No tag needed (package version $pkg not greater than latest $latest)"

--- a/scripts/deploy-generate-dev-secrets.py
+++ b/scripts/deploy-generate-dev-secrets.py
@@ -35,7 +35,7 @@ SECRET_KEYS = [
 
 # Dev defaults applied when generating .env (merged after template; template can override).
 DEV_DEFAULTS = {
-    "MAX_CONCURRENT_MCP_REQUESTS": "10",
+    "MAX_CONCURRENT_MCP_REQUESTS": "10000",
 }
 
 PLACEHOLDER_RE = re.compile(r"^__([A-Za-z_][A-Za-z0-9_]*)__$")

--- a/scripts/deploy-run-env.sh
+++ b/scripts/deploy-run-env.sh
@@ -438,6 +438,7 @@ test() {
             if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
                 summary_reporter=(--reporters default --reporters "$PROJECT_DIR/tests/reporters/jest-github-summary-reporter.cjs")
             fi
+            # Serial tests (--runInBand): one MCP server; extra Jest workers did not improve wall time and caused queueing unless MAX_CONCURRENT_MCP_REQUESTS is high.
             # deploy - now need to run manually: npm run dev:deploy
             if [ ${#args[@]} -eq 0 ]; then
                 MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag --runInBand --detectOpenHandles --testTimeout=30000 "${summary_reporter[@]}" --testPathPatterns "tests/integration/" 2>&1  | tee -a "$REPORT_LOG_FILE"

--- a/scripts/env/.env.template
+++ b/scripts/env/.env.template
@@ -12,8 +12,8 @@ PORT=3300
 METRICS_PORT=9390
 # Optional: absolute path (or cwd-relative) to the Vite output directory (dist/ui). Use when the server serves an unexpected UI tree.
 # KAIROS_UI_DIR=
-# Concurrency limit for MCP POST /mcp; 0=auto-detect, -1=disabled. Dev default 10 for load test (npm run test:load).
-MAX_CONCURRENT_MCP_REQUESTS=10
+# Concurrency limit for MCP POST /mcp; 0=auto-detect, -1=disabled. High dev default avoids integration-test stalls; use a low value (e.g. 10) for load/concurrency tests (tests/load, npm run test:load).
+MAX_CONCURRENT_MCP_REQUESTS=10000
 # When true, MCP App chat widgets skip ui/initialize and ignore tool results (static shell for host debugging).
 # KAIROS_MCP_WIDGET_PRESENTATION_ONLY=false
 NODE_ENV=development


### PR DESCRIPTION
## Summary
- **Release tag on version bump:** idempotent tag check (local + origin), `fetch-tags` on checkout, concurrency queue, `workflow_run.branches` limited to `main` and `ci/**`.
- **Integration / Helm:** remove obsolete `v4` branch triggers; README and examples updated.
- **Dev env:** align `MAX_CONCURRENT_MCP_REQUESTS` default to 10000 in template and generator; comment on Jest staying `--runInBand` (parallel workers did not help wall time).

## Testing
- Local validation as applicable; CI Integration expected on PR.