### PR TITLE
Fix train --space handling; add CLI spaces command

### DIFF
--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -20,6 +20,16 @@ import type { DeleteOutput } from '../tools/delete_schema.js';
 
 const PROACTIVE_REFRESH_SKEW_SEC = 60;
 
+type SpacesOutput = {
+    spaces: Array<{
+        name: string;
+        space_id: string;
+        type: 'personal' | 'group' | 'app' | 'other';
+        adapter_count: number;
+        adapters?: Array<{ adapter_id: string; title: string; layer_count: number }>;
+    }>;
+};
+
 export class ApiClient {
     private baseUrl: string;
     private openInBrowser: boolean;
@@ -139,8 +149,22 @@ export class ApiClient {
         });
 
         if (!response.ok) {
-            const errorData = data as { message?: string; error?: string; login_url?: string };
-            const msg = errorData.message || errorData.error || `HTTP ${response.status}: ${response.statusText}`;
+            const errorData = data as {
+                message?: string;
+                error?: string;
+                login_url?: string;
+                available_spaces?: unknown;
+            };
+            let msg = errorData.message || errorData.error || `HTTP ${response.status}: ${response.statusText}`;
+            if (
+                (errorData.error === 'SPACE_NOT_FOUND' || errorData.error === 'SPACE_READ_ONLY') &&
+                Array.isArray(errorData.available_spaces)
+            ) {
+                const availableSpaces = errorData.available_spaces.filter((entry): entry is string => typeof entry === 'string');
+                if (availableSpaces.length > 0) {
+                    msg += `\nAvailable writable spaces: ${availableSpaces.join(', ')}`;
+                }
+            }
             if (response.status === 401) {
                 const cfg401 = await readConfig(this.baseUrl);
                 if (!isRetryAfterRefresh && cfg401.refreshToken) {
@@ -196,7 +220,7 @@ export class ApiClient {
 
     async train(
         markdown: SafeMarkdownUpload,
-        options?: { llmModelId?: string; force?: boolean },
+        options?: { llmModelId?: string; force?: boolean; space?: string },
         isRetryAfterLogin = false
     ): Promise<TrainOutput> {
         const headers: Record<string, string> = {
@@ -209,6 +233,10 @@ export class ApiClient {
 
         if (options?.force) {
             headers['x-force-update'] = 'true';
+        }
+
+        if (typeof options?.space === 'string' && options.space.trim().length > 0) {
+            headers['x-space'] = options.space.trim();
         }
 
         return this.request<TrainOutput>(
@@ -263,6 +291,17 @@ export class ApiClient {
         return this.request<DeleteOutput>('/api/delete', {
             method: 'POST',
             body: JSON.stringify({ uris }),
+        });
+    }
+
+    async spaces(options?: { include_adapter_titles?: boolean }): Promise<SpacesOutput> {
+        const body: Record<string, unknown> = {};
+        if (options?.include_adapter_titles === true) {
+            body['include_adapter_titles'] = true;
+        }
+        return this.request<SpacesOutput>('/api/spaces', {
+            method: 'POST',
+            body: JSON.stringify(body),
         });
     }
 

--- a/src/cli/commands/cli-train.ts
+++ b/src/cli/commands/cli-train.ts
@@ -109,9 +109,12 @@ export function trainCliCommand(program: Command): void {
             process.exit(1);
           }
 
-          const trainOptions: { llmModelId?: string; force?: boolean } = {};
+          const trainOptions: { llmModelId?: string; force?: boolean; space?: string } = {};
           if (options.model) trainOptions.llmModelId = options.model;
           if (options.force) trainOptions.force = options.force;
+          if (typeof options.space === 'string' && options.space.trim().length > 0) {
+            trainOptions.space = options.space.trim();
+          }
 
           if (st.isDirectory()) {
             const files = listMarkdownFiles(abs, Boolean(options.recursive));

--- a/src/cli/commands/spaces.ts
+++ b/src/cli/commands/spaces.ts
@@ -1,0 +1,29 @@
+import { Command } from 'commander';
+import { ApiClient } from '../api-client.js';
+import { handleApiError, isBrowserDisabled } from '../auth-error.js';
+import { writeJson } from '../output.js';
+import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
+
+/**
+ * spaces command
+ */
+export function spacesCommand(program: Command): void {
+  program
+    .command('spaces')
+    .description('List available spaces and adapter counts')
+    .option(
+      '--include-adapter-titles',
+      'Include per-space adapter titles and layer counts'
+    )
+    .action(async (options: { includeAdapterTitles?: boolean }) => {
+      try {
+        const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+        const response = await client.spaces({
+          include_adapter_titles: Boolean(options.includeAdapterTitles)
+        });
+        writeJson(response);
+      } catch (error) {
+        handleApiError(error, !isBrowserDisabled());
+      }
+    });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'module';
 import { activateCommand } from './commands/search.js';
 import { forwardCommand } from './commands/begin.js';
 import { trainCliCommand } from './commands/cli-train.js';
+import { spacesCommand } from './commands/spaces.js';
 import { updateCommand } from './commands/update.js';
 import { deleteCommand } from './commands/delete.js';
 import { rewardCommand } from './commands/attest.js';
@@ -48,6 +49,7 @@ export function createProgram(): Command {
   activateCommand(program); // activate
   forwardCommand(program); // forward
   trainCliCommand(program);
+  spacesCommand(program);
   updateCommand(program); // tune
   deleteCommand(program); // delete
   rewardCommand(program); // reward

--- a/src/http/http-api-train-json.ts
+++ b/src/http/http-api-train-json.ts
@@ -10,7 +10,7 @@ import { buildAdapterUri } from '../tools/kairos-uri.js';
 import { CREATION_PROTOCOL_URI } from '../services/memory/validate-protocol-structure.js';
 import { KairosError } from '../types/index.js';
 import { getSpaceContext, runWithSpaceContextAsync } from '../utils/tenant-context.js';
-import { resolveSpaceParamForContext } from '../utils/resolve-space-param.js';
+import { listWritableSpaceDisplayNames, resolveSpaceParamForContext } from '../utils/resolve-space-param.js';
 
 const SAFE_TRAIN_DETAIL_KEYS = new Set([
   'missing',
@@ -76,7 +76,11 @@ export function setupTrainJsonRoute(
         const r = resolveSpaceParamForContext(ctx, rawSpace);
         if (!r.ok) {
           const errKey = r.code === 'SPACE_READ_ONLY' ? 'SPACE_READ_ONLY' : 'SPACE_NOT_FOUND';
-          res.status(400).json({ error: errKey, message: r.message });
+          res.status(400).json({
+            error: errKey,
+            message: r.message,
+            available_spaces: listWritableSpaceDisplayNames(ctx)
+          });
           return;
         }
         resolvedSpaceId = r.spaceId;

--- a/src/http/http-api-train-raw.ts
+++ b/src/http/http-api-train-raw.ts
@@ -11,6 +11,8 @@ import { HTTP_TRAIN_RAW_BODY_LIMIT } from '../config.js';
 import { buildAdapterUri } from '../tools/kairos-uri.js';
 import { CREATION_PROTOCOL_URI } from '../services/memory/validate-protocol-structure.js';
 import { KairosError } from '../types/index.js';
+import { getSpaceContext, runWithSpaceContextAsync } from '../utils/tenant-context.js';
+import { listWritableSpaceDisplayNames, resolveSpaceParamForContext } from '../utils/resolve-space-param.js';
 
 const SAFE_TRAIN_RAW_DETAIL_KEYS = new Set([
   'missing',
@@ -71,8 +73,18 @@ export function setupTrainRawRoute(
       const force_update =
         req.query['force'] === 'true' || req.headers['x-force-update'] === 'true';
       const protocol_version = (req.query['protocol_version'] as string) || (req.headers['x-protocol-version'] as string) || undefined;
+      const space =
+        (req.query['space'] as string) ||
+        (req.headers['x-space'] as string) ||
+        undefined;
 
-      const bodyInput = { markdown_doc: markdown, llm_model_id, force_update, ...(protocol_version && { protocol_version }) };
+      const bodyInput = {
+        markdown_doc: markdown,
+        llm_model_id,
+        force_update,
+        ...(protocol_version && { protocol_version }),
+        ...(space ? { space } : {})
+      };
       const parsed = trainInputSchema.safeParse(bodyInput);
       if (!parsed.success) {
         const first = parsed.error.flatten().fieldErrors;
@@ -86,7 +98,36 @@ export function setupTrainRawRoute(
       }
 
       structuredLogger.info(`→ POST /api/train/raw (${markdown.length} bytes, model: ${parsed.data.llm_model_id}, force: ${parsed.data.force_update})`);
-      const result = await executeTrain(memoryStore, parsed.data, (fn) => fn(), qdrantService);
+      const ctx = getSpaceContext(req as express.Request & { spaceContext?: unknown });
+      const rawSpace = typeof parsed.data.space === 'string' ? parsed.data.space.trim() : '';
+      const spaceParam = rawSpace.toLowerCase();
+      let resolvedSpaceId: string;
+      if (parsed.data.space === undefined || rawSpace === '' || spaceParam === 'personal') {
+        resolvedSpaceId = ctx.defaultWriteSpaceId || ctx.allowedSpaceIds[0] || '';
+      } else {
+        const r = resolveSpaceParamForContext(ctx, rawSpace);
+        if (!r.ok) {
+          const errKey = r.code === 'SPACE_READ_ONLY' ? 'SPACE_READ_ONLY' : 'SPACE_NOT_FOUND';
+          res.status(400).json({
+            error: errKey,
+            message: r.message,
+            available_spaces: listWritableSpaceDisplayNames(ctx)
+          });
+          return;
+        }
+        resolvedSpaceId = r.spaceId;
+      }
+      const narrowedContext = {
+        ...ctx,
+        allowedSpaceIds: [resolvedSpaceId],
+        defaultWriteSpaceId: resolvedSpaceId
+      };
+      const result = await executeTrain(
+        memoryStore,
+        parsed.data,
+        (fn) => runWithSpaceContextAsync(narrowedContext, fn),
+        qdrantService
+      );
       res.status(200).json(result);
     } catch (error) {
       const err = error as { code?: string; details?: Record<string, unknown>; message?: string; status?: number; statusCode?: number; type?: string };

--- a/src/utils/resolve-space-param.ts
+++ b/src/utils/resolve-space-param.ts
@@ -97,3 +97,16 @@ export function resolveSpaceParamForContext(
   }
   return { ok: true, spaceId: match };
 }
+
+/** Writable display names for spaces available in the current context. */
+export function listWritableSpaceDisplayNames(ctx: SpaceContext): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const spaceId of ctx.allowedSpaceIds) {
+    const name = spaceIdToDisplayName(spaceId, ctx.spaceNamesById);
+    if (seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
+}

--- a/tests/integration/cli-commands-basic.test.ts
+++ b/tests/integration/cli-commands-basic.test.ts
@@ -161,6 +161,35 @@ describe('CLI Commands Basic --url Tests', () => {
       const result = JSON.parse(stdout);
       expect(result).toHaveProperty('status');
     }, 30000);
+
+    test('train with invalid --space fails and lists writable spaces', async () => {
+      requireMcpServerAndCliLogin(serverAvailable, cliLoggedIn);
+
+      await expect(
+        execAsync(
+          `node ${CLI_PATH} train --url ${BASE_URL} --force --space "/nonexistent-space" "${TEST_FILE}"`
+        )
+      ).rejects.toMatchObject({
+        stderr: expect.stringContaining('Available writable spaces:')
+      });
+    }, 30000);
+  });
+
+  describe('spaces command', () => {
+    test('spaces uses --url parameter', async () => {
+      requireMcpServerAndCliLogin(serverAvailable, cliLoggedIn);
+
+      const { stdout, stderr } = await execAsync(
+        `node ${CLI_PATH} spaces --url ${BASE_URL}`
+      );
+
+      expect(stderr).toBe('');
+      const result = JSON.parse(stdout);
+      expect(Array.isArray(result.spaces)).toBe(true);
+      expect(result.spaces.length).toBeGreaterThan(0);
+      expect(result.spaces[0]).toHaveProperty('name');
+      expect(result.spaces[0]).toHaveProperty('space_id');
+    }, 30000);
   });
 
   describe('token command', () => {

--- a/tests/integration/http-api-endpoints.test.ts
+++ b/tests/integration/http-api-endpoints.test.ts
@@ -107,42 +107,6 @@ Done.`;
       expect(data.status).toBe('stored');
     }, 30000);
 
-    test('rejects invalid space with available writable spaces listed', async () => {
-      expect.hasAssertions();
-      const markdown = `# Invalid Space ${Date.now()}
-
-## Activation Patterns
-Run for invalid space checks.
-
-## Step 1
-Verify train space validation.
-
-\`\`\`json
-{"contract": {"type": "comment", "description": "Minimal"}}
-\`\`\`
-
-## Reward Signal
-Done.`;
-      const response = await apiFetch(`${API_BASE}/train/raw?force=true`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'text/markdown',
-          'X-LLM-Model-ID': 'test-model',
-          'X-Space': '/nonexistent-space'
-        },
-        body: markdown
-      });
-
-      expect(response.status).toBe(400);
-      const data = await response.json() as {
-        error?: string;
-        available_spaces?: unknown;
-      };
-      expect(data.error === 'SPACE_NOT_FOUND' || data.error === 'SPACE_READ_ONLY').toBe(true);
-      expect(Array.isArray(data.available_spaces)).toBe(true);
-      expect((data.available_spaces as unknown[]).every((entry) => typeof entry === 'string')).toBe(true);
-      expect((data.available_spaces as unknown[]).length).toBeGreaterThan(0);
-    }, 30000);
   });
 
   describe('POST /api/snapshot', () => {

--- a/tests/integration/http-api-endpoints.test.ts
+++ b/tests/integration/http-api-endpoints.test.ts
@@ -106,6 +106,43 @@ Done.`;
       const data = await response.json();
       expect(data.status).toBe('stored');
     }, 30000);
+
+    test('rejects invalid space with available writable spaces listed', async () => {
+      expect.hasAssertions();
+      const markdown = `# Invalid Space ${Date.now()}
+
+## Activation Patterns
+Run for invalid space checks.
+
+## Step 1
+Verify train space validation.
+
+\`\`\`json
+{"contract": {"type": "comment", "description": "Minimal"}}
+\`\`\`
+
+## Reward Signal
+Done.`;
+      const response = await apiFetch(`${API_BASE}/train/raw?force=true`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/markdown',
+          'X-LLM-Model-ID': 'test-model',
+          'X-Space': '/nonexistent-space'
+        },
+        body: markdown
+      });
+
+      expect(response.status).toBe(400);
+      const data = await response.json() as {
+        error?: string;
+        available_spaces?: unknown;
+      };
+      expect(data.error === 'SPACE_NOT_FOUND' || data.error === 'SPACE_READ_ONLY').toBe(true);
+      expect(Array.isArray(data.available_spaces)).toBe(true);
+      expect((data.available_spaces as unknown[]).every((entry) => typeof entry === 'string')).toBe(true);
+      expect((data.available_spaces as unknown[]).length).toBeGreaterThan(0);
+    }, 30000);
   });
 
   describe('POST /api/snapshot', () => {

--- a/tests/integration/http-api-train-space-errors.test.ts
+++ b/tests/integration/http-api-train-space-errors.test.ts
@@ -1,0 +1,60 @@
+import { waitForHealthCheck } from '../utils/health-check.js';
+import { getAuthHeaders, getTestAuthBaseUrl } from '../utils/auth-headers.js';
+
+const BASE_URL = getTestAuthBaseUrl();
+const API_BASE = `${BASE_URL}/api`;
+
+function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...(init.headers as Record<string, string>) }
+  });
+}
+
+describe('HTTP train space validation', () => {
+  beforeAll(async () => {
+    await waitForHealthCheck({
+      url: `${BASE_URL}/health`,
+      timeoutMs: 60000,
+      intervalMs: 500
+    });
+  }, 60000);
+
+  test('POST /api/train/raw rejects invalid space and lists writable spaces', async () => {
+    expect.hasAssertions();
+    const markdown = `# Invalid Space ${Date.now()}
+
+## Activation Patterns
+Run for invalid space checks.
+
+## Step 1
+Verify train space validation.
+
+\`\`\`json
+{"contract": {"type": "comment", "description": "Minimal"}}
+\`\`\`
+
+## Reward Signal
+Done.`;
+
+    const response = await apiFetch('/train/raw?force=true', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/markdown',
+        'X-LLM-Model-ID': 'test-model',
+        'X-Space': '/nonexistent-space'
+      },
+      body: markdown
+    });
+
+    expect(response.status).toBe(400);
+    const data = await response.json() as {
+      error?: string;
+      available_spaces?: unknown;
+    };
+    expect(data.error === 'SPACE_NOT_FOUND' || data.error === 'SPACE_READ_ONLY').toBe(true);
+    expect(Array.isArray(data.available_spaces)).toBe(true);
+    expect((data.available_spaces as unknown[]).every((entry) => typeof entry === 'string')).toBe(true);
+    expect((data.available_spaces as unknown[]).length).toBeGreaterThan(0);
+  }, 30000);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix `kairos train <path>` to forward `--space` through the raw-train path (CLI -> `/api/train/raw` -> train execution context)
- add new `kairos spaces` CLI command backed by `POST /api/spaces`
- improve invalid space UX by returning `available_spaces` from train routes and surfacing them in CLI error output
- split new train-space API regression into a dedicated integration test file to satisfy max-lines lint guard

## Changes
- `src/cli/commands/cli-train.ts`
  - include `space` in options for markdown/file/directory train flow
- `src/cli/api-client.ts`
  - extend `train()` to accept `space` and send it via `x-space`
  - add `spaces()` API client method for `/api/spaces`
  - append available writable spaces to SPACE_NOT_FOUND/SPACE_READ_ONLY errors when provided by API
- `src/cli/commands/spaces.ts` (new)
  - add `kairos spaces [--include-adapter-titles]`
- `src/cli/program.ts`
  - register `spaces` command
- `src/http/http-api-train-raw.ts`
  - parse `space` from query/header
  - resolve/narrow write space context like `/api/train`
  - include `available_spaces` on invalid writable-space errors
- `src/http/http-api-train-json.ts`
  - include `available_spaces` on invalid writable-space errors
- `src/utils/resolve-space-param.ts`
  - add helper to list writable display names for current context

## Regression coverage added
- `tests/integration/http-api-train-space-errors.test.ts`
  - invalid space on `/api/train/raw` returns `SPACE_NOT_FOUND`/`SPACE_READ_ONLY` plus non-empty `available_spaces`
- `tests/integration/cli-commands-basic.test.ts`
  - invalid `kairos train --space` prints `Available writable spaces:`
  - `kairos spaces --url ...` returns a spaces payload

## Verification run in this environment
- ✅ `npm run lint`
- ⚠️ `npm run dev:deploy` fails due to missing runtime dependencies in this runner (`docker` unavailable; app cannot start without Qdrant)
- ⚠️ `npm run dev:test -- tests/integration/http-api-endpoints.test.ts tests/integration/cli-commands-basic.test.ts` fails without running dev server/auth stack

## Issue
- Closes #321
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56bc7cdd-c643-4cba-8d5b-aef8c10f517d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56bc7cdd-c643-4cba-8d5b-aef8c10f517d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

