### PR TITLE
fix train title similarity guard

### DIFF
--- a/src/services/memory/store-adapter-helpers.ts
+++ b/src/services/memory/store-adapter-helpers.ts
@@ -101,7 +101,7 @@ export async function checkSimilarAdapterByTitle(
 
   const label = buildAdapterSimilaritySearchQuery(adapterTitle);
 
-  const { memories, scores } = await methods.searchMemories(label, 10, false);
+  const { memories, scores } = await methods.searchAdapterTitlesBySimilarity(label, 10);
 
   if (memories.length === 0 || scores.length === 0) {
     return;

--- a/src/services/memory/store-methods.ts
+++ b/src/services/memory/store-methods.ts
@@ -15,6 +15,7 @@ import {
   memoryIsBuiltinSearchFooterProtocol
 } from '../../constants/builtin-search-meta.js';
 import { pointToMemory as mapQdrantPointToMemory } from './qdrant-point-to-memory.js';
+import { searchAdapterTitlesBySimilarity as searchAdapterTitlesBySimilarityImpl } from './store-title-similarity-search.js';
 import {
   getActivationPatternVectorName,
   getAdapterTitleVectorName,
@@ -105,6 +106,16 @@ export class MemoryQdrantStoreMethods {
     const vectorResult = await this.vectorSearch(queryKey, limit);
     await redisCacheService.setSearchResult(queryKey, limit, vectorResult, { collapse });
     return vectorResult;
+  }
+
+  async searchAdapterTitlesBySimilarity(query: string, limit: number): Promise<{ memories: Memory[], scores: number[] }> {
+    return searchAdapterTitlesBySimilarityImpl({
+      client: this.client,
+      collection: this.collection,
+      query,
+      limit,
+      mapPointToMemory: (point) => this.pointToMemory(point)
+    });
   }
 
   /**

--- a/src/services/memory/store-title-similarity-search.ts
+++ b/src/services/memory/store-title-similarity-search.ts
@@ -1,0 +1,59 @@
+import type { QdrantClient } from '@qdrant/js-client-rest';
+import type { Memory } from '../../types/memory.js';
+import { embeddingService } from '../embedding/service.js';
+import { KAIROS_CREATION_PROTOCOL_UUID, KAIROS_REFINING_PROTOCOL_UUID, memoryIsBuiltinSearchFooterProtocol } from '../../constants/builtin-search-meta.js';
+import { buildSpaceFilter } from '../../utils/space-filter.js';
+import { getSearchSpaceIds } from '../../utils/tenant-context.js';
+import { getAdapterTitleVectorName } from '../../utils/qdrant-vector-types.js';
+
+export async function searchAdapterTitlesBySimilarity(params: {
+  client: QdrantClient;
+  collection: string;
+  query: string;
+  limit: number;
+  mapPointToMemory: (point: { id: string; payload: Record<string, unknown> }) => Memory;
+}): Promise<{ memories: Memory[]; scores: number[] }> {
+  const queryKey = (params.query || '').trim();
+
+  if (!queryKey) {
+    return { memories: [], scores: [] };
+  }
+
+  const queryEmbeddingResult = await embeddingService.generateEmbedding(queryKey);
+  const queryVector = queryEmbeddingResult.embedding;
+  const titleVectorName = getAdapterTitleVectorName(queryVector.length);
+  const searchSpaceIds = getSearchSpaceIds();
+  const baseFilter = buildSpaceFilter(searchSpaceIds, {
+    must: [{ key: 'adapter.layer_index', match: { value: 1 } }]
+  });
+  const filter = {
+    ...baseFilter,
+    must_not: [{ has_id: [KAIROS_REFINING_PROTOCOL_UUID, KAIROS_CREATION_PROTOCOL_UUID] }]
+  };
+  const points = await params.client.search(params.collection, {
+    vector: { name: titleVectorName, vector: queryVector },
+    limit: params.limit,
+    filter,
+    params: { quantization: { rescore: true } },
+    with_payload: true,
+    with_vector: false
+  });
+
+  const filtered = (points ?? [])
+    .map((point: any) => {
+      const memory = params.mapPointToMemory({ id: String(point.id), payload: point.payload || {} });
+      const score = typeof point.score === 'number' ? point.score : 0;
+      return { memory, score };
+    })
+    .filter(entry => entry.score > 0 && !memoryIsBuiltinSearchFooterProtocol(entry.memory))
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return (a.memory.memory_uuid ?? '').localeCompare(b.memory.memory_uuid ?? '');
+    })
+    .slice(0, params.limit);
+
+  return {
+    memories: filtered.map(entry => entry.memory),
+    scores: filtered.map(entry => entry.score)
+  };
+}

--- a/tests/integration/http-api-train-similarity-guard.test.ts
+++ b/tests/integration/http-api-train-similarity-guard.test.ts
@@ -1,0 +1,67 @@
+import { waitForHealthCheck } from '../utils/health-check.js';
+import { getAuthHeaders, getTestAuthBaseUrl } from '../utils/auth-headers.js';
+
+const BASE_URL = getTestAuthBaseUrl();
+const API_BASE = `${BASE_URL}/api`;
+
+function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...(init.headers as Record<string, string>) }
+  });
+}
+
+function buildMarkdown(title: string): string {
+  return `# ${title}
+
+## Activation Patterns
+Run this adapter when the user wants to manage notes in an Obsidian vault via MCP.
+
+## Discover Notes
+List relevant notes in the vault and identify the best candidate for the user's request.
+
+\`\`\`json
+{"contract":{"type":"comment","comment":{"min_length":20},"required":true}}
+\`\`\`
+
+## Read Or Update Note
+Read the chosen note, summarize relevant content, and apply the requested change if needed.
+
+\`\`\`json
+{"contract":{"type":"comment","comment":{"min_length":20},"required":true}}
+\`\`\`
+
+## Reward Signal
+Success means the intended vault note was found and the requested read or edit outcome was completed accurately.`;
+}
+
+describe('HTTP train similarity guard regression', () => {
+  beforeAll(async () => {
+    await waitForHealthCheck({
+      url: `${BASE_URL}/health`,
+      timeoutMs: 60000,
+      intervalMs: 500
+    });
+  }, 60000);
+
+  test('POST /api/train/raw accepts unrelated adapter titles without impossible similarity rejection', async () => {
+    expect.hasAssertions();
+    const title = `Obsidian Vault - Find, Read, Edit, Create Notes via MCP ${Date.now()}`;
+    const response = await apiFetch('/train/raw', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/markdown',
+        'X-LLM-Model-ID': 'test-model',
+        'X-Space': 'personal'
+      },
+      body: buildMarkdown(title)
+    });
+
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toHaveProperty('status', 'stored');
+    expect(Array.isArray(data.items)).toBe(true);
+    expect(data.items.length).toBeGreaterThan(0);
+  }, 30000);
+});

--- a/tests/unit/train-similarity-guard.test.ts
+++ b/tests/unit/train-similarity-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { checkSimilarAdapterByTitle } from '../../src/services/memory/store-adapter-helpers.js';
+import type { Memory } from '../../src/types/memory.js';
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    memory_uuid: '11111111-1111-4111-8111-111111111111',
+    label: 'Activation Patterns',
+    tags: [],
+    text: 'Existing adapter body',
+    llm_model_id: 'test-model',
+    created_at: new Date().toISOString(),
+    adapter: {
+      id: '22222222-2222-4222-8222-222222222222',
+      name: 'Existing Adapter',
+      layer_index: 1,
+      layer_count: 2
+    },
+    ...overrides
+  };
+}
+
+describe('checkSimilarAdapterByTitle', () => {
+  test('uses dedicated title similarity search instead of hybrid ranking scores', async () => {
+    const searchMemories = jest.fn(async () => ({
+      memories: [makeMemory()],
+      scores: [1.18]
+    }));
+    const searchAdapterTitlesBySimilarity = jest.fn(async () => ({
+      memories: [makeMemory()],
+      scores: [0.41]
+    }));
+
+    await expect(
+      checkSimilarAdapterByTitle(
+        {
+          searchMemories,
+          searchAdapterTitlesBySimilarity
+        } as any,
+        'Obsidian Vault - Find, Read, Edit, Create Notes via MCP',
+        false
+      )
+    ).resolves.toBeUndefined();
+
+    expect(searchAdapterTitlesBySimilarity).toHaveBeenCalledTimes(1);
+    expect(searchMemories).not.toHaveBeenCalled();
+  });
+
+  test('throws SIMILAR_MEMORY_FOUND when title cosine similarity crosses threshold', async () => {
+    const searchAdapterTitlesBySimilarity = jest.fn(async () => ({
+      memories: [makeMemory()],
+      scores: [0.95]
+    }));
+
+    await expect(
+      checkSimilarAdapterByTitle(
+        { searchAdapterTitlesBySimilarity } as any,
+        'Existing Adapter',
+        false
+      )
+    ).rejects.toMatchObject({
+      code: 'SIMILAR_MEMORY_FOUND',
+      details: expect.objectContaining({
+        similarity_score: 0.95,
+        existing_memory: expect.objectContaining({
+          adapter_name: 'Existing Adapter'
+        })
+      })
+    });
+  });
+
+  test('preserves force_update bypass', async () => {
+    const searchAdapterTitlesBySimilarity = jest.fn();
+
+    await expect(
+      checkSimilarAdapterByTitle(
+        { searchAdapterTitlesBySimilarity } as any,
+        'Force Updated Adapter',
+        true
+      )
+    ).resolves.toBeUndefined();
+
+    expect(searchAdapterTitlesBySimilarity).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- switch the train duplicate-title guard to a dedicated adapter-title cosine similarity search instead of reusing hybrid ranking scores
- add a focused unit regression for `SIMILAR_MEMORY_FOUND` handling and a focused HTTP regression covering successful train of a new adapter title
- preserve the existing duplicate guard behavior while preventing impossible `similarity_score > 1.0` reports

Closes #336.

## Test plan
- [x] `npx jest --runInBand tests/unit/train-similarity-guard.test.ts --config '{"preset":"ts-jest/presets/default-esm","testEnvironment":"node","extensionsToTreatAsEsm":[".ts"],"transform":{"^.+\\.tsx?$": ["ts-jest", {"useESM":true,"tsconfig":{"target":"ES2022","module":"ES2022","moduleResolution":"NodeNext","isolatedModules":true}}]},"moduleNameMapper":{"^(\\.{1,2}/.*)\\.js$":"$1","^uuid$":"<rootDir>/tests/mocks/uuid-stub.cjs"},"setupFiles":["<rootDir>/tests/env-loader.ts","dotenv/config"],"setupFilesAfterEnv":["<rootDir>/tests/setup.ts"],"testTimeout":10000}'`
- [x] `PORT=3300 AUTH_ENABLED=false npx jest --runInBand tests/integration/http-api-train-similarity-guard.test.ts`
- [x] `KAIROS_API_URL=http://localhost:4300 node dist/cli/index.js train --model gpt-5.4 --space personal var/issue-336-pr-check.md`