### PR TITLE
Replace inline protocol-synonym lint allow with ESLint file exception

### DIFF
--- a/eslint/flat-config.cjs
+++ b/eslint/flat-config.cjs
@@ -314,6 +314,12 @@ function createFlatConfig(rootDir) {
         'kairos-forbidden-text/review-protocol-wording': 'off',
       },
     },
+    {
+      files: ['skills/kairos/SKILL.md'],
+      rules: {
+        'kairos-forbidden-text/review-protocol-wording': 'off',
+      },
+    },
 
     // -------------------------------------------------------------------------
     // 3da. All shell scripts (stub parser; no code rules)

--- a/skills/kairos/SKILL.md
+++ b/skills/kairos/SKILL.md
@@ -21,9 +21,6 @@ metadata:
 allowed-tools: activate forward reward train tune export delete spaces
 ---
 
-<!-- kairos-lint-allow-protocol-synonyms -->
-<!-- Intentional: this skill documents KAIROS MCP execution chains and uses "protocol" for the activate→forward→reward flow alongside adapters. -->
-
 # KAIROS — ZERO DRIFT PROTOCOL
 
 **CRITICAL DIRECTIVE (non-negotiable):**  


### PR DESCRIPTION
## Summary
- move the `review-protocol-wording` exception for `skills/kairos/SKILL.md` into ESLint flat config
- remove the inline protocol-synonym allow marker and explanatory comment from `skills/kairos/SKILL.md`
- keep the rule behavior unchanged for the rest of the repository while centralizing this suppression

Closes #334.

## Test plan
- `NODE_PATH=/Users/jakub.plichcinski/local/git/github.com/debian777/kairos-mcp/node_modules PATH=/Users/jakub.plichcinski/local/git/github.com/debian777/kairos-mcp/node_modules/.bin:$PATH eslint skills/kairos/SKILL.md eslint/flat-config.cjs`