### PR TITLE
release: 4.2.1-rc.2

### DIFF
--- a/.cursor/skills/version-bump-release/SKILL.md
+++ b/.cursor/skills/version-bump-release/SKILL.md
@@ -92,6 +92,14 @@ gh pr create --base main --head "release/$VERSION" \
   --body "Version bump to $VERSION."
 ```
 
+GitHub PR checks note:
+
+- Required checks are controlled by repository settings (branch protection /
+  rulesets), not by workflow YAML alone.
+- If you intentionally use skip tokens such as `[skip ci]`, remember they only
+  affect workflows triggered by `push` and `pull_request`, and PR behavior is
+  based on the HEAD commit message.
+
 ### 3.4 Show clickable PR URL
 
 After `gh pr create`, the CLI prints the PR URL. Present that URL clearly to the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,6 +46,22 @@ flowchart LR
 
 **PR/MR tooling:** This repo uses the GitHub CLI (**gh**) for PRs. For GitLab MRs use **glab**. KAIROS protocols: *GitHub PR with gh* (create/track PRs with `gh`), *GitLab MR with glab* (create/track MRs with `glab`).
 
+### GitHub PR protocol notes: skip CI and required checks
+
+For the GitHub PR flow, treat these as hard rules:
+
+- Required checks are configured in GitHub repository settings (branch
+  protection or rulesets), not in workflow YAML.
+- Workflow files define jobs and check names, but they do not decide which
+  checks block merge.
+- Current `main` required checks are:
+  - `Integration workflow passed`
+  - `Integration simple workflow passed`
+- `[skip ci]` style tokens only apply to workflows triggered by `push` and
+  `pull_request`, and PR behavior depends on the HEAD commit message.
+- If skip instructions are used but checks still run, verify the latest commit
+  message first, then verify required checks in branch protection settings.
+
 **Dependabot:** Auto-merge is enabled at repository level (Settings → General → Pull Requests → Allow auto-merge). On each Dependabot PR, use **Enable auto-merge**; the PR will merge when required status checks pass. No workflow is used for this.
 
 **Manual-only:** Publish npm and Publish Container are for ad-hoc republish/debug; they use `package.json` version when not run from a tag.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,68 +11,10 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE25: true
-    permissions:
-      contents: read
-      id-token: write  # Required for npm Trusted Publishing (OIDC)
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "25"
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Sync version from tag (tag push) or use package.json (manual)
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            npm version ${GITHUB_REF_NAME#v} --no-git-tag-version --allow-same-version
-          else
-            echo "Manual run: using version from package.json"
-          fi
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Set up Python (skills-ref)
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install skills-ref and validate skills
-        run: |
-          python -m pip install --upgrade pip
-          pip install "skills-ref @ git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref"
-          npm run lint:skills
-
-      - name: Knip
-        run: npm run knip
-
-      - name: Prepare publish (build tgz + test install)
-        run: npm run prepare:publish
-
-      - name: Set npm dist-tag (beta for prerelease)
-        id: npm_tag
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if echo "$VERSION" | grep -q '-'; then echo "tag=beta" >> "$GITHUB_OUTPUT"; else echo "tag=latest" >> "$GITHUB_OUTPUT"; fi
-
-      - name: Publish
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          TGZ="./dist/debian777-kairos-mcp-${VERSION}.tgz"
-          if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
-            npm publish "$TGZ" --access public --tag ${{ steps.npm_tag.outputs.tag }} --force
-          else
-            npm publish "$TGZ" --access public --tag ${{ steps.npm_tag.outputs.tag }}
-          fi
-        # No NPM_TOKEN needed when using Trusted Publishers (OIDC)
+    uses: ./.github/workflows/reusable-publish-npm.yml
+    with:
+      sync-version-from-ref: false
+      allow-existing-version: false
+      force-publish: ${{ github.event.inputs.force == 'true' }}
+      upload-sbom: false
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,93 +19,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish-npm:
-    name: Publish npm
+  trivyignore-expiry:
+    name: Trivy ignore expiry guard
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE25: true
-    # If you set an "Environment" in npm Trusted Publisher, set it here too (e.g. environment: production)
     permissions:
       contents: read
-      id-token: write
-
+    env:
+      TRIVYIGNORE_EXPIRY_WARNING_DAYS: "45"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "25"
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Set version and npm tag from ref
-        id: version
+      - name: Validate .trivyignore expiry dates
         run: |
-          ref="${{ github.event.inputs.ref }}"
-          if [ -n "$ref" ]; then
-            v="${ref#v}"
-          else
-            v="${GITHUB_REF#refs/tags/v}"
-          fi
-          echo "version=$v" >> "$GITHUB_OUTPUT"
-          if echo "$v" | grep -q '-'; then
-            echo "npm_tag=beta" >> "$GITHUB_OUTPUT"
-          else
-            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
-          fi
+          python3 scripts/ci-check-trivyignore-expiry.py \
+            --file .trivyignore \
+            --warning-days "$TRIVYIGNORE_EXPIRY_WARNING_DAYS"
 
-      - name: Sync version from tag
-        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Set up Python (skills-ref)
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install skills-ref and validate skills
-        run: |
-          python -m pip install --upgrade pip
-          pip install "skills-ref @ git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref"
-          npm run lint:skills
-
-      - name: Knip
-        run: npm run knip
-
-      - name: Prepare publish (build tgz + test install)
-        run: npm run prepare:publish
-
-      - name: Publish to npm
-        run: |
-          set +e
-          out=$(npm publish ./dist/debian777-kairos-mcp-${{ steps.version.outputs.version }}.tgz --access public --tag ${{ steps.version.outputs.npm_tag }} 2>&1)
-          code=$?
-          echo "$out"
-          if [ $code -eq 0 ]; then exit 0; fi
-          if echo "$out" | grep -q "You cannot publish over the previously published versions"; then
-            echo "Version already on npm; continuing to Docker and GitHub Release"
-            exit 0
-          fi
-          exit 1
-
-      - name: Generate npm CycloneDX SBOM
-        run: npx @cyclonedx/cyclonedx-npm@latest --output-file kairos-mcp-${{ steps.version.outputs.version }}-npm-sbom.cdx.json --output-format json
-
-      - name: Upload npm SBOM
-        uses: actions/upload-artifact@v4
-        with:
-          name: npm-sbom
-          path: kairos-mcp-${{ steps.version.outputs.version }}-npm-sbom.cdx.json
-          if-no-files-found: error
+  publish-npm:
+    name: Publish npm
+    needs: trivyignore-expiry
+    uses: ./.github/workflows/reusable-publish-npm.yml
+    with:
+      ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
+      sync-version-from-ref: true
+      allow-existing-version: true
+      force-publish: false
+      upload-sbom: true
+    secrets: inherit
 
   publish-docker:
     name: Publish Docker image
@@ -125,13 +67,7 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: |
-          ref="${{ github.event.inputs.ref }}"
-          if [ -n "$ref" ]; then
-            echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "version=${{ needs.publish-npm.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -1,0 +1,137 @@
+name: Reusable publish npm
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ""
+      sync-version-from-ref:
+        required: false
+        type: boolean
+        default: false
+      allow-existing-version:
+        required: false
+        type: boolean
+        default: false
+      force-publish:
+        required: false
+        type: boolean
+        default: false
+      upload-sbom:
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      version:
+        description: "Package version used for publish"
+        value: ${{ jobs.publish.outputs.version }}
+      npm-tag:
+        description: "npm dist-tag used for publish"
+        value: ${{ jobs.publish.outputs.npm-tag }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE25: true
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      npm-tag: ${{ steps.version.outputs.npm_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "25"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set version and npm tag
+        id: version
+        shell: bash
+        run: |
+          if [[ "${{ inputs.sync-version-from-ref }}" == "true" ]]; then
+            ref="${{ inputs.ref != '' && inputs.ref || github.ref }}"
+            if [[ "$ref" == refs/tags/* ]]; then
+              v="${ref#refs/tags/v}"
+            else
+              v="${ref#v}"
+            fi
+            npm version "$v" --no-git-tag-version --allow-same-version
+          else
+            v="$(node -p "require('./package.json').version")"
+          fi
+
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          if echo "$v" | grep -q '-'; then
+            echo "npm_tag=beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Set up Python (skills-ref)
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install skills-ref and validate skills
+        run: |
+          python -m pip install --upgrade pip
+          pip install "skills-ref @ git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref"
+          npm run lint:skills
+
+      - name: Knip
+        run: npm run knip
+
+      - name: Prepare publish (build tgz + test install)
+        run: npm run prepare:publish
+
+      - name: Publish to npm (allow existing)
+        if: inputs.allow-existing-version
+        shell: bash
+        run: |
+          set +e
+          out=$(npm publish ./dist/debian777-kairos-mcp-${{ steps.version.outputs.version }}.tgz --access public --tag ${{ steps.version.outputs.npm_tag }} 2>&1)
+          code=$?
+          echo "$out"
+          if [ $code -eq 0 ]; then exit 0; fi
+          if echo "$out" | grep -q "You cannot publish over the previously published versions"; then
+            echo "Version already on npm; continuing"
+            exit 0
+          fi
+          exit 1
+
+      - name: Publish to npm (strict)
+        if: ${{ !inputs.allow-existing-version && !inputs.force-publish }}
+        run: npm publish ./dist/debian777-kairos-mcp-${{ steps.version.outputs.version }}.tgz --access public --tag ${{ steps.version.outputs.npm_tag }}
+
+      - name: Publish to npm (force)
+        if: inputs.force-publish
+        run: npm publish ./dist/debian777-kairos-mcp-${{ steps.version.outputs.version }}.tgz --access public --tag ${{ steps.version.outputs.npm_tag }} --force
+
+      - name: Generate npm CycloneDX SBOM
+        if: inputs.upload-sbom
+        run: npx @cyclonedx/cyclonedx-npm@latest --output-file kairos-mcp-${{ steps.version.outputs.version }}-npm-sbom.cdx.json --output-format json
+
+      - name: Upload npm SBOM
+        if: inputs.upload-sbom
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-sbom
+          path: kairos-mcp-${{ steps.version.outputs.version }}-npm-sbom.cdx.json
+          if-no-files-found: error

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,22 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE25: true
 
 jobs:
+  trivyignore-expiry:
+    name: Trivy ignore expiry guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TRIVYIGNORE_EXPIRY_WARNING_DAYS: "45"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate .trivyignore expiry dates
+        run: |
+          python3 scripts/ci-check-trivyignore-expiry.py \
+            --file .trivyignore \
+            --warning-days "$TRIVYIGNORE_EXPIRY_WARNING_DAYS"
+
   dependency-review:
     name: Dependency review
     if: github.event_name == 'pull_request'

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,7 @@
 # CVE-2026-33671 (picomatch ReDoS): bundled under global npm CLI
 # (usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch).
-# npm@11.12.0 and npm@latest still ship picomatch@4.0.3; fixed upstream in 4.0.4+.
-# Runtime image does not use the npm CLI on untrusted glob patterns. Revisit when npm updates its bundle.
-CVE-2026-33671 exp:2026-06-30
+# Revalidated 2026-04-17: npm@11.12.1 (latest) still bundles tinyglobby@0.2.15
+# with picomatch@4.0.3 (fixed upstream in 4.0.4+).
+# Runtime image does not use npm CLI on untrusted glob patterns.
+# Revisit as soon as npm ships picomatch 4.0.4+ in its bundled tree.
+CVE-2026-33671 exp:2026-12-31

--- a/compose.yaml
+++ b/compose.yaml
@@ -137,7 +137,7 @@ services:
     restart: unless-stopped
 
   app-prod:
-    image: debian777/kairos-mcp:v4.2.0
+    image: debian777/kairos-mcp:v4.2.1-rc.2
     #pull_policy: always
     labels:
       - "environment=prod"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.2.1-rc.1",
+  "version": "4.2.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "4.2.1-rc.1",
+      "version": "4.2.1-rc.2",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.2.1-rc.1",
+  "version": "4.2.1-rc.2",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/ci-check-trivyignore-expiry.py
+++ b/scripts/ci-check-trivyignore-expiry.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Fail CI when .trivyignore contains expired or invalid exp:YYYY-MM-DD entries.
+Warn for entries expiring soon.
+"""
+
+from datetime import date
+from pathlib import Path
+import argparse
+import re
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--file",
+        default=".trivyignore",
+        help="Path to .trivyignore-like file",
+    )
+    parser.add_argument(
+        "--warning-days",
+        type=int,
+        default=45,
+        help="Warn when expiry is within this many days",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    path = Path(args.file)
+    if not path.exists():
+        print(f"::error::{args.file} not found")
+        return 1
+
+    today = date.today()
+    lines = path.read_text(encoding="utf-8").splitlines()
+    exp_re = re.compile(r"^\s*([A-Za-z0-9._-]+)\s+exp:(\d{4}-\d{2}-\d{2})\s*$")
+
+    found = 0
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    for idx, line in enumerate(lines, start=1):
+        match = exp_re.match(line)
+        if not match:
+            continue
+        found += 1
+        cve, exp_raw = match.groups()
+        try:
+            exp_date = date.fromisoformat(exp_raw)
+        except ValueError:
+            failures.append(f"line {idx}: {cve} has invalid date: {exp_raw}")
+            continue
+
+        days_left = (exp_date - today).days
+        if days_left < 0:
+            failures.append(f"line {idx}: {cve} expired {abs(days_left)} day(s) ago on {exp_raw}")
+        elif days_left <= args.warning_days:
+            warnings.append(f"line {idx}: {cve} expires in {days_left} day(s) on {exp_raw}")
+
+    if found == 0:
+        print(f"::warning::No exp:YYYY-MM-DD entries found in {args.file}")
+        return 0
+
+    for msg in warnings:
+        print(f"::warning::{msg}")
+
+    if failures:
+        for msg in failures:
+            print(f"::error::{msg}")
+        print(f"::error::{args.file} contains {len(failures)} expired or invalid ignore entry(ies)")
+        return 1
+
+    if warnings:
+        print(
+            f"::warning::{args.file} has {len(warnings)} entry(ies) expiring within {args.warning_days} day(s)"
+        )
+
+    print(f"Validated {args.file} expiry metadata successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,6 +1,6 @@
 ---
 slug: create-new-protocol
-version: "4.2.1-rc.1"
+version: "4.2.1-rc.2"
 title: Create / Review / Refactor KAIROS Protocol
 ---
 

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "4.2.1-rc.1"
+version: "4.2.1-rc.2"
 slug: refine-search
 title: Get help refining your search
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
@@ -1,5 +1,5 @@
 ---
-version: "4.2.1-rc.1"
+version: "4.2.1-rc.2"
 slug: create-new-protocol-review
 title: Review and Publish New KAIROS Protocol
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
@@ -1,5 +1,5 @@
 ---
-version: "4.2.1-rc.1"
+version: "4.2.1-rc.2"
 slug: challenge-type-guide
 title: Challenge Type Selection Guide
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
@@ -1,5 +1,5 @@
 ---
-version: "4.2.1-rc.1"
+version: "4.2.1-rc.2"
 slug: phase-critic
 title: Phase Critic
 ---


### PR DESCRIPTION
## Summary
- bump package version to `4.2.1-rc.2`
- sync embedded mem docs and compose image tag to the RC version
- include release workflow/docs updates already present on this release branch

## Test plan
- [x] run `npm run release:rc`
- [x] pre-commit checks passed (`version:check-skills`, `lint`, `lint:skills`)