### PR TITLE
add grounding reminder to activate guidance

### DIFF
--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -8,6 +8,33 @@ title: Create / Review / Refactor KAIROS Protocol
 
 # Create / Review / Refactor KAIROS Protocol
 
+> **Why we create protocols — a note to the agent reading this.**
+>
+> KAIROS protocols are not documentation. They are not conventional apps.
+> They are **interfaces for a fundamentally new kind of user: AI agents.**
+>
+> You, the agent reading this, are the primary user. When you execute a
+> protocol, you follow instructions designed to help you harmonise with the
+> human you serve. Every phase boundary, every contract, every explicit stop
+> condition exists because you cannot reliably infer these on your own — and
+> honest uncertainty is always better than confident drift.
+>
+> When you author a new protocol, you are designing behaviour for yourself
+> and for other agents — some weaker, some stronger, all trying to serve
+> their humans well. Write for them:
+>
+> - **Single source of truth.** Never duplicate rules across protocols.
+>   When rules drift between files, agents execute contradictory behaviour
+>   depending on entry point — and they cannot detect the contradiction.
+> - **Explicit over implicit.** Agents fill ambiguity with hallucination.
+>   Say exactly what to do, when to stop, and when to ask.
+> - **Phases teach modes.** Each step teaches the agent which cognitive mode
+>   it is in: explore, clarify, decide, execute, verify, review. Blurring
+>   these modes causes the agent to act when it should verify, or guess
+>   when it should ask.
+> - **Truth over fluency.** A protocol that reads well but causes wrong
+>   behaviour is worse than one that reads rough but executes correctly.
+
 ## Activation Patterns
 
 KAIROS authoring lifecycle — create, review, or fix adapters / protocols / workflows.
@@ -19,18 +46,6 @@ as synonyms. Supports three operations:
   missing cross-references, chaining gaps, DRY violations, stale guidance, or
   agent-hostile ambiguity. Read-only.
 - **fix** — apply specific corrections to an existing adapter / protocol and re-train.
-
-KAIROS exists for **AI agents** and for **human–AI harmony**. The goal is not only
-to make tools callable. The goal is to help agents recognise the **right mode at the
-right time**:
-
-- when to explore
-- when to clarify
-- when to brainstorm
-- when to decide
-- when to execute
-- when to verify
-- when to review
 
 **Run this protocol when the user says ANY of:**
 

--- a/src/tools/activate.ts
+++ b/src/tools/activate.ts
@@ -66,9 +66,12 @@ async function mapSearchToActivate(
     })
   );
 
+  const groundingReminder =
+    'Protocols are interfaces for AI agents. Choose the adapter that serves the human\'s real need, follow it exactly, and never fabricate proof.';
+
   return {
     must_obey: true,
-    message: searchOutput.message,
+    message: `${groundingReminder}\n\n${searchOutput.message}`,
     next_action: "Pick one choice and follow that choice's next_action.",
     query,
     choices,


### PR DESCRIPTION
## Summary
- add an explicit grounding reminder to `activate` output so agents prioritize user intent and truth-first execution
- update the protocol-authoring mem adapter intro with an agent-facing rationale focused on explicitness, phase clarity, and no-drift behavior
- keep the change scoped to two files and isolated from the previous security/build PR

## Test plan
- [x] `npm run lint -- src/tools/activate.ts`
- [x] pre-commit checks passed on commit (`version:check-skills`, `lint`, `lint:skills`)
- [x] verify PR diff against `main` only includes:
  - `src/tools/activate.ts`
  - `src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md`