### PR TITLE
fix(skill): require full retry traces and fault attribution in bug reports

### DIFF
--- a/skills/.system/kairos-bug-report/SKILL.md
+++ b/skills/.system/kairos-bug-report/SKILL.md
@@ -26,20 +26,52 @@ with no extra top-level sections.
 5. Reproduction
 6. Checklist before saving
 
+**BEFORE WRITING:** If the KAIROS MCP server is reachable, call its
+`/health` endpoint (HTTP GET to `<KAIROS_API_URL>/health`) or equivalent
+and capture the response. This provides the server version and
+infrastructure component status needed for the Environment section.
+
 **CONTENT TYPES:**
 - **Summary:** One sentence: failure + MCP server name + tool/resource.
-- **Calls and responses:** For each call: request in fenced `json`
-  (server, tool/resource, arguments); response in fenced `json` (full
-  payload or error). Preserve order.
-- **Reasoning:** Why each call was made, how responses were interpreted,
-  and where the bug likely is (client, server, schema, docs, or
-  unclear).
-- **Environment / context:** IDE/MCP version, OS, and relevant
-  config/env names only. Never include secret values.
+- **Calls and responses:** For **every** call in the failing flow
+  (activate, each forward attempt, reward): request in fenced `json`
+  (server, tool/resource, arguments) **immediately followed by** its
+  response in fenced `json` (full payload or error). Preserve
+  chronological order.
+  - **Retry rule:** When a flow ends in `MAX_RETRIES_EXCEEDED` or
+    similar retry exhaustion, include **every** retry attempt
+    (request + response), not just the first and last. If `retry_count`
+    is N, the report must contain N request-response pairs for that
+    step. A reader must be able to see exactly what changed (or did not
+    change) between attempts.
+  - Never omit intermediate successful responses — they are essential
+    for diagnosing state drift.
+- **Reasoning:** Must include:
+  - Why each call was made and how each response was interpreted.
+  - **Fault attribution (mandatory when retries > 0):** For each failed
+    attempt, state whether the agent followed the server's
+    `next_action`, used the current `nonce`/`proof_hash`/`uri` from
+    the latest response, or deviated. Classify the root cause as one
+    of:
+    - **agent error** — agent ignored server guidance, reused stale
+      values, targeted wrong URI, or sent wrong solution type.
+    - **server error** — agent followed guidance correctly but server
+      rejected valid input or returned inconsistent state.
+    - **unclear** — insufficient evidence to determine fault.
+  - If the agent caused retries by ignoring server responses, the
+    report must say so. Do not attribute agent errors to the server.
+- **Environment / context:** Must include:
+  - **KAIROS MCP version** (from `/health` `version` field, or from
+    MCP server connect banner if available).
+  - **Infrastructure status** (Qdrant, Redis/cache, embedding) — one
+    line each: healthy / unhealthy / degraded / not configured. Source
+    this from `/health` `dependencies` object.
+  - **OS and IDE** (OS version, Cursor/IDE version if available).
+  - **Relevant config/env names** only. Never include secret values.
 - **Reproduction:** Minimal steps; expected vs. actual in one or two
   sentences.
 - **Checklist before saving:** Markdown task list (`- [ ]`) with the
-  five items below.
+  items below.
 
 **MUST:**
 - Emit all six sections in order.
@@ -54,6 +86,12 @@ with no extra top-level sections.
 - Add top-level sections not in STRUCTURE (for example Appendix, Notes,
   or Extra).
 - Omit or reorder sections.
+- Omit retry attempts. If `retry_count` is N, all N request-response
+  pairs must appear. Showing only the first and final attempt is
+  forbidden.
+- Attribute agent execution errors to the server. If the agent reused a
+  stale nonce, targeted the wrong URI, or ignored `next_action`, the
+  Reasoning section must classify this as agent error.
 - Put request/response in plain text or non-JSON code blocks.
 - Include unredacted secrets, tokens, cookies, or API keys.
 
@@ -63,10 +101,13 @@ with no extra top-level sections.
 
 - [ ] Summary states server, tool/resource, and the failure in one
   sentence.
-- [ ] All relevant MCP calls and responses are in JSON code blocks with
-  secrets redacted.
-- [ ] Reasoning explains the intent of each call and the interpretation
-  of each response.
+- [ ] Every MCP call in the flow has both request **and** response JSON
+  blocks — including **all retry attempts** (no skipped intermediate
+  responses), with secrets redacted.
+- [ ] Reasoning includes explicit fault attribution for each failed
+  attempt (agent error / server error / unclear) with evidence.
+- [ ] Environment includes KAIROS MCP version and infrastructure
+  component status (Qdrant, Redis/cache, embedding).
 - [ ] Reproduction steps are minimal and someone else could follow them.
 - [ ] File is saved in `reports/` with filename
   `mcp-bug-<server>-<short-description>-<date>.md`.


### PR DESCRIPTION
## Summary

- **Require all retry attempts in bug reports** — when a flow ends in `MAX_RETRIES_EXCEEDED`, the report must include every request-response pair, not just the first and last. This prevents agents from hiding their own execution mistakes behind a summary.
- **Add mandatory fault attribution** — for each failed attempt, the agent must classify the root cause as `agent error`, `server error`, or `unclear` with evidence. Explicitly forbids attributing agent mistakes (stale nonce, wrong URI) to the server.
- **Require infrastructure context** — reports must now call `/health` before writing and include KAIROS MCP version + dependency status (Qdrant, Redis/cache, embedding).

## Motivation

Issues #360 and #361 were filed as server bugs but the traces show the agent ignoring `next_action` and reusing stale nonces. Without full retry traces and honest fault attribution, these reports are undiagnosable.

## Test plan

- [ ] Verify updated skill renders correctly in Markdown
- [ ] Trigger a bug report on a failing flow and confirm all retry pairs appear
- [ ] Confirm fault attribution section classifies agent vs server errors

Closes #360, #361