### PR TITLE
docs(mem): add protocol-linking-guide and DRY-up 2001

### DIFF
--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -142,21 +142,11 @@ For `fix`: ask which adapter to fix and what the issue is.
 - Which parts stay in the router, and which belong only in extensions?
 
 **4. If Chain pattern:**
-- Each adapter in the chain is self-contained with its own Activation Patterns
-  and Reward Signal.
-- The Reward Signal layer of adapter N uses an `mcp` contract with
-  `forward` + slug URI to link to adapter N+1.
-- Each adapter handles one cohesive concern (e.g. prepare, plan, code, deliver).
-- The chain entry point is what `activate` resolves to. Subsequent links use
-  `forward` + slug directly — no `activate` needed mid-chain.
-- Every mid-chain adapter must include `chain_root: <entry-slug>` in its
-  frontmatter. This causes `activate` to collapse any direct match for a
-  mid-chain adapter to the chain root's URI, preventing out-of-order execution.
-- Every mid-chain adapter should include a **Prerequisites** paragraph in its
-  Activation Patterns listing the inputs required from earlier phases and
-  directing the agent to start from the chain root if those inputs are missing.
-- Use `activate` mid-chain only when the target genuinely depends on runtime
-  classification that the current adapter cannot resolve.
+
+Load `protocol-linking-guide` for full chain structuring rules
+(`forward` with `kairos://adapter/protocol-linking-guide`).
+
+Collect:
 - What are the chain links and their concerns?
 - What is the minimum number of links that helps weaker models?
 - Which link is the chain entry point (matched by `activate`)?
@@ -266,13 +256,8 @@ Every protocol gets a short, unique, lowercase-hyphenated `slug`.
 
 **Challenge types:**
 
-| Type | Use for | Engine validates |
-|---|---|---|
-| `comment` | Analysis, drafting, structured summaries | `min_length` |
-| `user_input` | Human confirmation or choice | Non-empty response |
-| `mcp` | Required tool call | Tool called successfully |
-| `mcp` + `arguments` | Chain link to another adapter via `forward` | Tool called with matching arguments |
-| `shell` | Command execution or state verification | Exit code 0 |
+Load `challenge-type-guide` for decision rules, JSON formats, and interpreter
+selection (`forward` with `kairos://adapter/challenge-type-guide`).
 
 **If Router pattern:** draft the router and each extension as separate files.
 

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
@@ -179,6 +179,5 @@ The agent can now:
 1. pick the correct challenge type for each protocol step
 2. match challenge type to the step's mode
 3. choose the right interpreter
-4. avoid anti-patterns
-5. apply working-directory and security rules
-6. use stronger verification patterns instead of weak narrative checks
+4. apply working-directory and security rules
+5. use stronger verification patterns instead of weak narrative checks

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002006.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002006.md
@@ -1,0 +1,176 @@
+---
+version: "4.2.1"
+slug: protocol-linking-guide
+title: Protocol Linking Guide
+---
+
+
+
+# Protocol Linking Guide
+
+Decision rules for structuring adapter relationships: layers vs chains,
+`activate` vs `forward` + slug, chain-root collapsing, and MCP argument
+validation for deterministic cross-protocol linking.
+
+## Activation Patterns
+
+**Typically invoked by:** `create-new-protocol` and
+`create-new-protocol-review`.
+
+**Can be invoked directly when agent needs:**
+- "layers vs chains" / "when to split into multiple adapters"
+- "how to link adapters" / "cross-protocol linking"
+- "activate vs forward" / "when to use forward with slug"
+- "chain-root collapsing" / "how chain_root works"
+
+**Trigger pattern:** **layers** / **chains** / **linking** / **forward** +
+(slug | adapter | protocol).
+
+**Must Never:**
+- Be used as an execution protocol.
+- Recommend chaining when layers suffice.
+
+**Must Always:**
+- Be consulted before splitting a protocol into multiple adapters.
+- Be consulted before adding `forward` calls or `chain_root` frontmatter.
+
+**Good trigger examples:**
+- "my protocol is 400 lines, should I split?" → load this
+- "how do I link adapter A to adapter B?" → load this
+- "what is chain_root?" → load this
+
+**Bad trigger examples:**
+- "which challenge type for this step?" → use `challenge-type-guide`
+- "create a new protocol" → use `create-new-protocol`
+
+## Layers vs Chains
+
+**Layers** (H2 steps within one adapter) are the preferred unit of work. Use
+layers when all steps fit in one adapter under 350 lines and serve a single
+cohesive concern.
+
+**Chain via `forward` + slug** — use only when:
+- the adapter exceeds 350 lines
+- weaker models cannot follow the full adapter in one pass
+- runtime routing to different adapters is needed (Router pattern)
+- a step is reusable across multiple parent adapters (e.g. `phase-critic`)
+
+Chaining is NOT a replacement for layers. A 6-step protocol that fits in 350
+lines should stay as one adapter with 6 H2 layers.
+
+```json
+{"contract":{"type":"comment","comment":{"min_length":30},"required":true}}
+```
+
+## `activate` vs `forward` + slug
+
+| Situation | Use |
+|---|---|
+| Initial user-intent resolution | `activate` |
+| Target adapter is known at authoring time | `forward` + slug |
+| Target depends on runtime classification the current adapter cannot resolve | `activate` |
+| Linking to the next adapter in a chain | `forward` + slug |
+| Reusable sub-protocol invoked by multiple parents | `forward` + slug |
+
+Never call `activate` just to get a slug you already know — it wastes a
+round-trip and introduces non-determinism.
+
+```json
+{"contract":{"type":"comment","comment":{"min_length":30},"required":true}}
+```
+
+## System adapters vs user adapters
+
+System adapters chain using static UUIDs in `next_action`:
+
+```text
+call forward with kairos://adapter/00000000-0000-0000-0000-000000002005 ...
+```
+
+User-authored adapters use the slug instead:
+
+```text
+call forward with kairos://adapter/implement-terraform ...
+```
+
+Slugs are globally unique (enforced by `train`), so resolution is
+deterministic — no scoring, no ambiguity.
+
+```json
+{"contract":{"type":"comment","comment":{"min_length":30},"required":true}}
+```
+
+## MCP argument validation for chain links
+
+A bare `mcp` contract checks only the tool name:
+
+```json
+{"contract":{"type":"mcp","mcp":{"tool_name":"forward"},"required":true}}
+```
+
+An `mcp` contract **with `arguments`** verifies the exact target:
+
+```json
+{"contract":{"type":"mcp","mcp":{"tool_name":"forward","arguments":{"uri":"kairos://adapter/code-review-policy"}},"required":true}}
+```
+
+The server validates that `solution.mcp.arguments` is a superset of the
+contract's `mcp.arguments` (subset/deep matching). This proves the agent
+called `forward` with the correct slug, not just any `forward` call.
+
+Use the `arguments` form whenever a step's purpose is to invoke a specific
+known adapter.
+
+```json
+{"contract":{"type":"comment","comment":{"min_length":30},"required":true}}
+```
+
+## Chain-root collapsing
+
+When a chain has multiple adapters, `activate` might match a mid-chain adapter
+directly. Without protection, the agent would start at the wrong step, missing
+prerequisite context gathered by earlier phases.
+
+**`chain_root` frontmatter field** solves this at the server level. Add it to
+every mid-chain adapter:
+
+```yaml
+---
+slug: implement-plan
+version: 1.0.0
+chain_root: implement
+---
+```
+
+**Server behaviour:** When `activate` returns a match that has `chain_root`,
+the server resolves the slug to the root adapter's URI and replaces the
+choice's `uri` and `next_action` to point there. Multiple mid-chain matches
+from the same chain are deduplicated to a single entry. The agent always
+starts at the chain entry point.
+
+**Defense in depth — protocol-level safeguards:** Each mid-chain adapter
+should include a **Prerequisites** paragraph in its Activation Patterns
+listing inputs required from earlier phases and directing the agent to start
+from the chain root if those inputs are missing. This catches direct `forward`
+calls that bypass `activate`.
+
+**Rules:**
+- The chain root adapter must NOT have `chain_root` in its frontmatter.
+- `chain_root` must refer to an existing slug (the chain entry point).
+- `forward` calls within a chain are unaffected — `chain_root` only changes
+  `activate` output routing.
+
+```json
+{"contract":{"type":"comment","comment":{"min_length":30},"required":true}}
+```
+
+## Reward Signal
+
+Only reachable after all prior steps are solved.
+
+The agent can now:
+1. decide when to use layers vs chains
+2. choose `activate` vs `forward` + slug correctly
+3. distinguish system-UUID linking from user-slug linking
+4. apply MCP argument validation for deterministic chain links
+5. implement `chain_root` collapsing with defense-in-depth safeguards

--- a/src/embed-docs/mem/README.md
+++ b/src/embed-docs/mem/README.md
@@ -37,6 +37,7 @@ synonyms. Prefer **adapter** in new copy when you are not mirroring user-facing 
 | UUID | Slug | Purpose |
 |------|------|---------|
 | [2004](00000000-0000-0000-0000-000000002004.md) | `challenge-type-guide` | Challenge type selection, interpreter choice, and stronger verification patterns |
+| [2006](00000000-0000-0000-0000-000000002006.md) | `protocol-linking-guide` | Layers vs chains, `activate` vs `forward` + slug, chain-root collapsing, MCP argument validation |
 
 ## Cross-Protocol Linking
 


### PR DESCRIPTION
## Summary

- **New reference document** `protocol-linking-guide` (2006): layers vs chains, `activate` vs `forward` + slug, chain-root collapsing, MCP argument validation for deterministic cross-protocol linking.
- **DRY-up 2001** (`create-new-protocol`): replaced inline chain rules (14 lines) and challenge type table (7 rows) with explicit `forward` references to `protocol-linking-guide` (2006) and `challenge-type-guide` (2004). Agents now load these reference docs during authoring instead of relying on duplicated inline content.
- **Reverted 2004** (`challenge-type-guide`): removed linking content that was incorrectly added in a prior iteration — now scoped back to challenge types only.
- **Updated README**: added 2006 to the Reference Documents table.

## Motivation

The authoring protocol (2001) contained inline chain-structuring rules and a challenge type table that duplicated content better served by dedicated reference documents. This violated the DRY principle that 2001 itself teaches. By extracting linking guidance into a standalone adapter (`protocol-linking-guide`), agents can discover it both through the authoring flow (`forward` from 2001) and independently via `activate`.

## Test plan

- [ ] `npm run lint` passes
- [ ] All three adapters train successfully (`challenge-type-guide`, `protocol-linking-guide`, `create-new-protocol`)
- [ ] Agent running `create-new-protocol` discovers both reference docs at the correct steps