### PR TITLE
fix: remove forward widget blank white area in host iframe

### DIFF
--- a/src/mcp-apps/forward-widget-inline-css.ts
+++ b/src/mcp-apps/forward-widget-inline-css.ts
@@ -3,6 +3,10 @@ import { MCP_WIDGET_CHROME_INLINE_CSS } from './mcp-widget-chrome-inline-css.js'
 import { minifyInlineWidgetCss } from './widget-inline-minify.js';
 
 const FORWARD_WIDGET_SPECIFIC_INLINE_CSS = `
+    html,
+    body {
+      background: transparent;
+    }
     #out {
       flex: 0 1 auto;
       max-height: none;

--- a/tests/integration/mcp-ui-resource-read.test.ts
+++ b/tests/integration/mcp-ui-resource-read.test.ts
@@ -65,6 +65,7 @@ describe('MCP UI resource read (spaces widget)', () => {
       expect(typeof c.text).toBe('string');
       expect(c.text).toContain('kairos-forward-view');
       expect(c.text).toContain('isForwardStructured');
+      expect(c.text).toContain('background:transparent');
     }, 'resources/read forward widget');
   });
 


### PR DESCRIPTION
## Summary
- set forward widget `html, body` background to transparent to avoid painting excess iframe height
- keep change scoped to forward widget CSS only
- add regression assertion in forward widget resource integration test

## Test plan
- [x] `npm test -- tests/integration/mcp-ui-resource-read.test.ts`
- [x] `npm run dev:deploy`
- [x] `npm run dev:test` *(fails in this environment with shared baseline failures: Redis `NOAUTH`, and `v4-kairos-forward-continue` proof-hash/next_action expectations)*