### PR TITLE
fix: protect app/system adapters from overwrite in update and tune flows

### DIFF
--- a/src/services/memory/store-adapter-helpers.ts
+++ b/src/services/memory/store-adapter-helpers.ts
@@ -4,6 +4,7 @@ import { KairosError } from '../../types/index.js';
 import { SIMILAR_MEMORY_THRESHOLD } from '../../config.js';
 import { getSpaceContext } from '../../utils/tenant-context.js';
 import { buildSpaceFilter } from '../../utils/space-filter.js';
+import { isProtectedWriteSpace, protectedWriteErrorMessage } from '../../utils/protected-space-write-guard.js';
 import type { MemoryQdrantStoreMethods } from './store-methods.js';
 import { buildAdapterUri, buildLayerUri } from '../../tools/kairos-uri.js';
 import { MAX_AUTO_SUFFIX_ATTEMPTS, nextAutoSlugCandidate } from '../../utils/protocol-slug.js';
@@ -63,6 +64,24 @@ export async function handleDuplicateAdapter(
         uri: `kairos://mem/${String(p.id)}`
       }));
       throw new KairosError('Duplicate adapter', 'DUPLICATE_ADAPTER', 409, { adapter_id: adapterUuid, items });
+    }
+    const protectedEntries = (dup.points || []).filter((p: any) =>
+      isProtectedWriteSpace(typeof p?.payload?.space_id === 'string' ? p.payload.space_id : '')
+    );
+    if (protectedEntries.length > 0) {
+      const items = protectedEntries.map((p: any) => ({
+        label: (p.payload?.label as string) || 'Memory',
+        uri: `kairos://mem/${String(p.id)}`,
+        space_id: typeof p?.payload?.space_id === 'string' ? p.payload.space_id : undefined
+      }));
+      const firstSpaceId =
+        typeof protectedEntries[0]?.payload?.space_id === 'string' ? protectedEntries[0].payload.space_id : undefined;
+      throw new KairosError(
+        protectedWriteErrorMessage(firstSpaceId),
+        'PROTECTED_SPACE_WRITE_FORBIDDEN',
+        403,
+        { adapter_id: adapterUuid, items }
+      );
     }
     const filter = buildSpaceFilter(getSpaceContext().allowedSpaceIds, {
       must: [{ key: 'adapter.id', match: { value: adapterUuid } }]

--- a/src/tools/tune-execute.ts
+++ b/src/tools/tune-execute.ts
@@ -9,6 +9,7 @@ import { executeUpdate } from './update.js';
 import { type TuneInput, type TuneOutput } from './tune_schema.js';
 import { parseKairosUri, buildLayerUri } from './kairos-uri.js';
 import { buildTuneResultMessage } from './tune-messages.js';
+import { isProtectedWriteSpace, protectedWriteErrorMessage } from '../utils/protected-space-write-guard.js';
 
 type AdapterLayerPoint = { uuid: string; payload: any };
 
@@ -57,6 +58,15 @@ function selectAdapterLayerSet(layers: AdapterLayerPoint[], preferredSpaceId?: s
   return sortByLayerIndex(groupedBySpace.get(fallbackSpaceId!) ?? layers);
 }
 
+function assertWritableTuneLayers(layers: AdapterLayerPoint[]): void {
+  for (const layer of layers) {
+    const spaceId = typeof layer.payload?.space_id === 'string' ? layer.payload.space_id : '';
+    if (isProtectedWriteSpace(spaceId)) {
+      throw new Error(protectedWriteErrorMessage(spaceId));
+    }
+  }
+}
+
 async function normalizeTuneUri(qdrantService: QdrantService, uri: string, preferredSpaceId?: string): Promise<string> {
   const parsed = parseKairosUri(uri);
   if (parsed.kind === 'layer') {
@@ -64,6 +74,7 @@ async function normalizeTuneUri(qdrantService: QdrantService, uri: string, prefe
   }
 
   const layers = selectAdapterLayerSet(await qdrantService.getAdapterLayers(parsed.id), preferredSpaceId);
+  assertWritableTuneLayers(layers);
   const head = layers[0]?.uuid ?? parsed.id;
   return `kairos://mem/${head}`;
 }
@@ -78,6 +89,7 @@ async function collectLayerMemoryUuidsForTune(
     return [parsed.id];
   }
   const layers = selectAdapterLayerSet(await qdrantService.getAdapterLayers(parsed.id), preferredSpaceId);
+  assertWritableTuneLayers(layers);
   return layers.map((l) => l.uuid);
 }
 
@@ -103,6 +115,7 @@ async function tuneAdapterMarkdownInPlace(
   }
 
   const existingLayers = selectAdapterLayerSet(await qdrantService.getAdapterLayers(parsed.id));
+  assertWritableTuneLayers(existingLayers);
   if (existingLayers.length === 0) {
     throw new Error(`Adapter not found: ${adapterUri}`);
   }

--- a/src/utils/protected-space-write-guard.ts
+++ b/src/utils/protected-space-write-guard.ts
@@ -1,0 +1,16 @@
+import { KAIROS_APP_SPACE_ID } from '../config.js';
+
+const SYSTEM_SPACE_IDS = new Set(['space:system', 'space:kairos-system']);
+
+export function isProtectedWriteSpace(spaceId: string | undefined | null): boolean {
+  const normalized = typeof spaceId === 'string' ? spaceId.trim().toLowerCase() : '';
+  if (!normalized) {
+    return true;
+  }
+  return normalized === KAIROS_APP_SPACE_ID.toLowerCase() || SYSTEM_SPACE_IDS.has(normalized);
+}
+
+export function protectedWriteErrorMessage(spaceId?: string): string {
+  const suffix = typeof spaceId === 'string' && spaceId.trim().length > 0 ? ` (${spaceId.trim()})` : '';
+  return `Cannot overwrite adapters in protected app/system spaces${suffix}. Fork to a personal or group space instead.`;
+}

--- a/tests/unit/store-adapter-helpers.test.ts
+++ b/tests/unit/store-adapter-helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import { handleDuplicateAdapter } from '../../src/services/memory/store-adapter-helpers.js';
+import { runWithSpaceContextAsync } from '../../src/utils/tenant-context.js';
+
+describe('handleDuplicateAdapter protected-space guard', () => {
+  test('blocks force update when duplicate is in protected app space', async () => {
+    const client = {
+      scroll: jest.fn(async () => ({
+        points: [{
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          payload: { label: 'Built-in adapter', space_id: 'space:kairos-app' }
+        }]
+      })),
+      delete: jest.fn(async () => ({}))
+    };
+
+    await expect(
+      runWithSpaceContextAsync(
+        {
+          userId: 'u1',
+          groupIds: [],
+          allowedSpaceIds: ['space:personal', 'space:kairos-app'],
+          defaultWriteSpaceId: 'space:personal'
+        },
+        async () => handleDuplicateAdapter(client as any, 'kairos', 'adapter-uuid', true)
+      )
+    ).rejects.toMatchObject({ code: 'PROTECTED_SPACE_WRITE_FORBIDDEN' });
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
+  test('allows force update for personal/group duplicates', async () => {
+    const client = {
+      scroll: jest.fn(async () => ({
+        points: [{
+          id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          payload: { label: 'Personal override', space_id: 'user:realm:uuid' }
+        }]
+      })),
+      delete: jest.fn(async () => ({}))
+    };
+
+    await runWithSpaceContextAsync(
+      {
+        userId: 'u1',
+        groupIds: [],
+        allowedSpaceIds: ['user:realm:uuid', 'group:realm:group-uuid'],
+        defaultWriteSpaceId: 'user:realm:uuid'
+      },
+      async () => handleDuplicateAdapter(client as any, 'kairos', 'adapter-uuid', true)
+    );
+
+    expect(client.delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/tune-execute.test.ts
+++ b/tests/unit/tune-execute.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import { executeTune } from '../../src/tools/tune-execute.js';
 import { IDGenerator } from '../../src/services/id-generator.js';
+import { runWithSpaceContextAsync } from '../../src/utils/tenant-context.js';
 
 type LayerPayload = {
   space_id: string;
@@ -193,5 +194,73 @@ New reward text after tune.
     expect(output.results[0]?.status).toBe('error');
     expect(output.results[0]?.message).toContain('Failed to update adapter layer');
     expect(fakeQdrant.updateCalls).toHaveLength(0);
+  });
+
+  test('blocks tune updates for app/system-backed adapters', async () => {
+    const adapterName = 'Tune Protected Adapter';
+    const adapterId = IDGenerator.generateAdapterUUIDv5(adapterName);
+    const appOnlyLayers = buildInitialLayers(adapterId, adapterName).map((layer) => ({
+      ...layer,
+      payload: {
+        ...layer.payload,
+        space_id: 'space:kairos-app'
+      }
+    }));
+    const fakeQdrant = new FakeQdrantService(appOnlyLayers);
+
+    const output = await executeTune(fakeQdrant as any, {
+      uris: [`kairos://adapter/${adapterId}`],
+      updates: { tags: ['blocked'] }
+    });
+
+    expect(output.total_updated).toBe(0);
+    expect(output.total_failed).toBe(1);
+    expect(output.results[0]?.status).toBe('error');
+    expect(output.results[0]?.message).toContain('protected app/system spaces');
+    expect(fakeQdrant.updateCalls).toHaveLength(0);
+  });
+
+  test('still updates writable personal override when app and personal layers share adapter id', async () => {
+    const adapterName = 'Tune Mixed Space Adapter';
+    const adapterId = IDGenerator.generateAdapterUUIDv5(adapterName);
+    const personalLayers = buildInitialLayers(adapterId, adapterName).map((layer) => ({
+      ...layer,
+      payload: {
+        ...layer.payload,
+        space_id: 'user:test-space'
+      }
+    }));
+    const appLayerUuids = [
+      '33333333-3333-4333-8333-333333333333',
+      '44444444-4444-4444-8444-444444444444'
+    ];
+    const appLayers = buildInitialLayers(adapterId, adapterName).map((layer, index) => ({
+      ...layer,
+      uuid: appLayerUuids[index]!,
+      payload: {
+        ...layer.payload,
+        space_id: 'space:kairos-app'
+      }
+    }));
+    const fakeQdrant = new FakeQdrantService([...personalLayers, ...appLayers]);
+
+    const output = await runWithSpaceContextAsync(
+      {
+        userId: 'u1',
+        groupIds: [],
+        allowedSpaceIds: ['user:test-space'],
+        defaultWriteSpaceId: 'user:test-space'
+      },
+      async () =>
+        executeTune(fakeQdrant as any, {
+          uris: [`kairos://adapter/${adapterId}`],
+          updates: { tags: ['personal-update'] }
+        })
+    );
+
+    expect(output.total_updated).toBe(1);
+    expect(output.total_failed).toBe(0);
+    expect(fakeQdrant.updateCalls).toHaveLength(1);
+    expect(fakeQdrant.updateCalls[0]?.id).toBe('11111111-1111-4111-8111-111111111111');
   });
 });


### PR DESCRIPTION
## Summary
- add a protected-space write guard utility for app/system adapter ownership
- block force-overwrite duplicate path when duplicate entries resolve to protected spaces
- block tune mutations for protected-space adapter layers while preserving writable personal/group override behavior
- add unit tests for blocked protected writes and allowed personal/group updates

## Test plan
- [x] `npm run dev:test -- tests/unit/store-adapter-helpers.test.ts tests/unit/tune-execute.test.ts`
- [x] `npm run dev:deploy`
- [x] `npm run dev:test` *(fails in this environment with shared baseline failures: Redis `NOAUTH`, and `v4-kairos-forward-continue` proof-hash/next_action expectations)*