### PR TITLE
fix: enforce deterministic same-slug precedence across spaces

### DIFF
--- a/src/services/qdrant/memory-retrieval.ts
+++ b/src/services/qdrant/memory-retrieval.ts
@@ -194,11 +194,19 @@ export interface SlugResolveOutcome {
   disambiguation_note?: string;
 }
 
+function getSlugSpacePrecedence(spaceId: string): number {
+  if (spaceId.startsWith('user:')) return 0;
+  if (spaceId.startsWith('group:')) return 1;
+  if (spaceId === KAIROS_APP_SPACE_ID || spaceId.startsWith('app:')) return 2;
+  return 2;
+}
+
 /**
  * Find the first adapter layer UUID for a protocol slug (exact match), scoped to searchable spaces.
  * Paginates scroll so matches are not truncated at a small limit.
- * If the slug maps to more than one adapter, picks deterministically: default write space first, then
- * lowest point id; logs and returns a disambiguation_note instead of failing the request.
+ * If the slug maps to more than one adapter, picks deterministically by fixed precedence:
+ * personal > group > app/system, then lowest point id; logs and returns a disambiguation_note
+ * instead of failing the request.
  */
 export async function findFirstStepMemoryUuidBySlug(
   conn: QdrantConnection,
@@ -247,12 +255,11 @@ export async function findFirstStepMemoryUuidBySlug(
       return { layerUuid: String(unique[0]!.id) };
     }
 
-    const defaultWrite = getSpaceContext().defaultWriteSpaceId;
     const spaceOf = (p: any) => String(p.payload?.space_id ?? KAIROS_APP_SPACE_ID);
     const sorted = [...unique].sort((a: any, b: any) => {
-      const aDef = spaceOf(a) === defaultWrite ? 0 : 1;
-      const bDef = spaceOf(b) === defaultWrite ? 0 : 1;
-      if (aDef !== bDef) return aDef - bDef;
+      const aPriority = getSlugSpacePrecedence(spaceOf(a));
+      const bPriority = getSlugSpacePrecedence(spaceOf(b));
+      if (aPriority !== bPriority) return aPriority - bPriority;
       return String(a.id).localeCompare(String(b.id));
     });
     const winner = sorted[0]!;
@@ -261,7 +268,16 @@ export async function findFirstStepMemoryUuidBySlug(
       typeof winner.payload?.adapter?.id === 'string'
         ? winner.payload.adapter.id
         : chosenId;
-    const note = `Slug "${normalized}" matched ${unique.length} adapters; selected one deterministically (default write space preferred, then stable id). Prefer an explicit adapter URI such as kairos://adapter/${adapterHint} to avoid ambiguity.`;
+    const winnerSpaceId = spaceOf(winner);
+    const contenderSummary = sorted
+      .map((point: any) => {
+        const pointId = String(point.id);
+        const adapterId = typeof point.payload?.adapter?.id === 'string' ? point.payload.adapter.id : pointId;
+        const pointSpaceId = spaceOf(point);
+        return `${adapterId}@${pointSpaceId}`;
+      })
+      .join(', ');
+    const note = `Slug "${normalized}" matched ${unique.length} adapters; selected "${adapterHint}" from "${winnerSpaceId}" by precedence (personal > group > app/system, then stable id). Candidates: ${contenderSummary}. Prefer an explicit adapter URI such as kairos://adapter/${adapterHint} to avoid ambiguity.`;
     structuredLogger.warn(`[slug-resolve] ${note}`);
     return { layerUuid: chosenId, disambiguation_note: note };
   });

--- a/tests/unit/slug-resolve-precedence.test.ts
+++ b/tests/unit/slug-resolve-precedence.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from '@jest/globals';
+import { KAIROS_APP_SPACE_ID } from '../../src/config.js';
+import { findFirstStepMemoryUuidBySlug } from '../../src/services/qdrant/memory-retrieval.js';
+import { runWithSpaceContextAsync } from '../../src/utils/tenant-context.js';
+
+type ScrollPoint = {
+  id: string;
+  payload: {
+    space_id?: string;
+    adapter?: { id?: string; layer_index?: number };
+  };
+};
+
+function makeConn(points: ScrollPoint[]) {
+  return {
+    executeWithReconnect: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+    client: {
+      scroll: async () => ({ points, next_page_offset: null })
+    },
+    collectionName: 'test'
+  } as const;
+}
+
+describe('findFirstStepMemoryUuidBySlug precedence', () => {
+  test('prefers personal over group and app/system regardless of default write space', async () => {
+    const conn = makeConn([
+      { id: '30000000-0000-4000-8000-000000000000', payload: { space_id: KAIROS_APP_SPACE_ID, adapter: { id: 'app-adapter' } } },
+      { id: '20000000-0000-4000-8000-000000000000', payload: { space_id: 'group:realm:team', adapter: { id: 'group-adapter' } } },
+      { id: '10000000-0000-4000-8000-000000000000', payload: { space_id: 'user:realm:user-1', adapter: { id: 'personal-adapter' } } }
+    ]);
+
+    const outcome = await runWithSpaceContextAsync(
+      {
+        userId: 'u',
+        groupIds: [],
+        allowedSpaceIds: ['user:realm:user-1', 'group:realm:team', KAIROS_APP_SPACE_ID],
+        defaultWriteSpaceId: 'group:realm:team'
+      },
+      () => findFirstStepMemoryUuidBySlug(conn as never, 'demo-slug')
+    );
+
+    expect(outcome.layerUuid).toBe('10000000-0000-4000-8000-000000000000');
+  });
+
+  test('prefers group over app when personal is absent', async () => {
+    const conn = makeConn([
+      { id: '30000000-0000-4000-8000-000000000000', payload: { space_id: KAIROS_APP_SPACE_ID, adapter: { id: 'app-adapter' } } },
+      { id: '20000000-0000-4000-8000-000000000000', payload: { space_id: 'group:realm:team', adapter: { id: 'group-adapter' } } }
+    ]);
+
+    const outcome = await runWithSpaceContextAsync(
+      {
+        userId: 'u',
+        groupIds: [],
+        allowedSpaceIds: ['group:realm:team', KAIROS_APP_SPACE_ID],
+        defaultWriteSpaceId: KAIROS_APP_SPACE_ID
+      },
+      () => findFirstStepMemoryUuidBySlug(conn as never, 'demo-slug')
+    );
+
+    expect(outcome.layerUuid).toBe('20000000-0000-4000-8000-000000000000');
+  });
+
+  test('keeps provenance details in disambiguation note', async () => {
+    const conn = makeConn([
+      { id: '20000000-0000-4000-8000-000000000000', payload: { space_id: 'group:realm:team', adapter: { id: 'group-adapter' } } },
+      { id: '10000000-0000-4000-8000-000000000000', payload: { space_id: 'user:realm:user-1', adapter: { id: 'personal-adapter' } } }
+    ]);
+
+    const outcome = await runWithSpaceContextAsync(
+      {
+        userId: 'u',
+        groupIds: [],
+        allowedSpaceIds: ['user:realm:user-1', 'group:realm:team'],
+        defaultWriteSpaceId: 'group:realm:team'
+      },
+      () => findFirstStepMemoryUuidBySlug(conn as never, 'demo-slug')
+    );
+
+    expect(outcome.disambiguation_note).toContain('personal > group > app/system');
+    expect(outcome.disambiguation_note).toContain('Candidates: personal-adapter@user:realm:user-1, group-adapter@group:realm:team');
+  });
+});


### PR DESCRIPTION
## Summary
- enforce deterministic same-slug resolution precedence as personal > group > app/system
- preserve deterministic fallback by stable id when precedence is equal
- include richer disambiguation provenance with candidate adapter-to-space mapping
- add unit coverage for precedence and disambiguation-note provenance details

## Test plan
- [x] `npm run dev:test -- tests/unit/slug-resolve-precedence.test.ts`
- [x] `npm run dev:deploy`
- [x] `npm run dev:test` *(fails in this environment with shared baseline failures: Redis `NOAUTH`, and `v4-kairos-forward-continue` proof-hash/next_action expectations)*