### PR TITLE
docs: clarify train vs tune update boundaries

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -199,6 +199,7 @@ Update one or more adapter or layer URIs.
 
 ```bash
 kairos tune kairos://adapter/<uuid> --file updated.md
+kairos tune kairos://adapter/<uuid> --updates '{"tags":["updated"]}'
 kairos tune kairos://layer/<a> kairos://layer/<b> --files a.md b.md
 kairos tune kairos://layer/<uuid> --updates '{"text":"new content"}'
 ```
@@ -208,6 +209,13 @@ Use one of:
 - `--file`
 - `--files` (one path per URI)
 - `--updates`
+
+Use `tune` for in-place adapter/layer edits. For structural adapter changes
+(for example, changing title identity or layer count), re-train with force:
+
+```bash
+kairos train adapter.md --model "gpt-4.1" --force
+```
 
 ### `delete`
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -59,7 +59,7 @@ docs.
 | [forward](../../src/embed-docs/tools/forward.md) | Run adapter layers; contracts and solutions. |
 | [reward](../../src/embed-docs/tools/reward.md) | Finalize a run (replaces older attest). |
 | [train](../../src/embed-docs/tools/train.md) | Store adapter markdown. |
-| [tune](../../src/embed-docs/tools/tune.md) | Edit stored layers / structure. |
+| [tune](../../src/embed-docs/tools/tune.md) | Edit stored adapter/layer content in place. |
 | [export](../../src/embed-docs/tools/export.md) | Export markdown or datasets. |
 | [delete](../../src/embed-docs/tools/delete.md) | Delete memories by URI. |
 | [spaces](../../src/embed-docs/tools/spaces.md) | List usable space names. |

--- a/docs/architecture/workflow-export.md
+++ b/docs/architecture/workflow-export.md
@@ -61,8 +61,9 @@ Training exports apply the stored reward gate:
 1. After **`activate`**, pick the adapter you need to inspect.
 2. Call **`export`** with that **`kairos://adapter/{uuid}`** (or a specific
    layer URI).
-3. Edit the returned **`content`**, then apply changes with **`tune`** (or
-   re-register via **`train`** when replacing whole adapter text).
+3. Edit the returned **`content`**, then apply changes with **`tune`** for
+   in-place adapter/layer updates. Use **`train`** with `force_update: true`
+   when making structural adapter replacements.
 
 ## See also
 

--- a/docs/architecture/workflow-train.md
+++ b/docs/architecture/workflow-train.md
@@ -286,7 +286,7 @@ and do not claim success.
 
 - [export workflow](workflow-export.md) — inspect existing
   content before overwriting
-- [tune workflow](workflow-tune.md) — update individual
-  steps
+- [tune workflow](workflow-tune.md) — in-place adapter/layer
+  updates
 - [activate workflow](workflow-activate.md) — find existing
   adapters before training a duplicate

--- a/docs/architecture/workflow-tune.md
+++ b/docs/architecture/workflow-tune.md
@@ -47,10 +47,19 @@ body (see server implementation).
 2. Edit offline.
 3. **`tune`** with the same target URIs and parallel **`markdown_doc`** entries.
 
+## When to use `tune` vs `train`
+
+Use **`tune`** for in-place updates to existing adapter/layer records.
+
+Use **`train`** with `force_update: true` when the change is structural (for
+example, a changed H1 that resolves to a different adapter id, or a different
+layer count than the stored adapter).
+
 ## Recovery hint
 
 When **`forward`** returns **`must_obey: false`** after retries, **`next_action`**
-may mention **`tune`** as a way to repair broken stored layers before new runs.
+may mention **`tune`** as a way to repair broken stored adapter/layer content
+before new runs.
 
 ## See also
 

--- a/src/embed-docs/tools/train.md
+++ b/src/embed-docs/tools/train.md
@@ -20,7 +20,10 @@ Register a new **adapter** from markdown (one H1 = one adapter; each verifiable 
 
 **Output:** `status: stored` and `items` with `layer_uuid`, `adapter_uri`, `layer` URIs, labels, tags.
 
-**After train:** Use **`activate`** / **`forward`** to execute; use **`tune`** to edit stored layers; **`export`** to dump markdown or datasets.
+**After train:** Use **`activate`** / **`forward`** to execute; use **`tune`**
+for in-place adapter/layer edits (non-structural); use **`train`** with
+`force_update: true` for structural adapter replacement; use **`export`** to
+dump markdown or datasets.
 
 For contract shapes and examples, call **`forward`** with
 `kairos://adapter/create-new-protocol` and omit `solution` on the first call of

--- a/src/embed-docs/tools/tune.md
+++ b/src/embed-docs/tools/tune.md
@@ -9,4 +9,14 @@ Update existing **adapter** content in place.
 
 **Output:** `results` with per-URI `status` (`updated` | `error`) and `message`, plus totals.
 
-**Rules:** When you pass layer URIs, the server normalizes to the underlying stored memories. Refresh execution context after large structural **`tune`** changes (new **`forward`** from the adapter URI).
+**Rules:**
+
+- Pass layer URIs when you want to edit specific layers.
+- Pass adapter URIs when you want in-place edits across that adapter's stored
+  layers without replacing adapter identity.
+- Use **`train`** with `force_update: true` for structural replacements (for
+  example, changing adapter identity/H1 mapping or layer count).
+- When you pass layer URIs, the server normalizes to the underlying stored
+  memories.
+- Refresh execution context after large **`tune`** edits (new **`forward`**
+  from the adapter URI).


### PR DESCRIPTION
## Summary
- align embedded tool docs to describe `tune` as in-place adapter/layer edits and `train --force_update` as structural replacement
- update architecture workflow docs to consistently distinguish in-place vs structural update paths
- refresh CLI guidance with adapter-target `tune` usage and a structural fallback example using `train --force`

## Test plan
- [x] Run `npm run lint -- "docs/CLI.md" "docs/architecture/README.md" "docs/architecture/workflow-export.md" "docs/architecture/workflow-train.md" "docs/architecture/workflow-tune.md" "src/embed-docs/tools/train.md" "src/embed-docs/tools/tune.md"`
- [x] Verify no remaining "layers-only" wording in edited docs