### PR TITLE
Implement artifact slug parity for train/export

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -76,6 +76,7 @@ docs.
 | [workflow-tune](workflow-tune.md) | **`tune`** (edit stored bodies / fields). |
 | [workflow-delete](workflow-delete.md) | **`delete`** (adapter or layer URIs). |
 | [workflow-export](workflow-export.md) | **`export`** and related inspection; see embedded docs. |
+| [artifacts](artifacts.md) | Artifact lifecycle across MCP, API, CLI, and UI. |
 | [quality_metadata](quality-metadata.md) | How `quality_metadata` is used in Qdrant payloads; JSON examples and data flow. |
 
 ## Agent recovery UX

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -1,0 +1,422 @@
+# Artifacts architecture
+
+Target repository path:
+
+```text
+docs/architecture/artifacts.md
+```
+
+This document explains how artifacts work in KAIROS MCP, what is currently
+implemented, and the intended near-term direction for artifact slug support.
+
+It deliberately avoids package-directory, zip-bundle, and skill-folder concepts.
+The current KAIROS artifact model is simpler:
+
+```text
+one adapter/protocol markdown file
++ one or more attached artifact files
+```
+
+Example:
+
+```text
+Daily-Briefing-Dashboard.md
+sort-jira.py
+```
+
+The adapter is trained as markdown. The script is trained as an attached
+artifact.
+
+## What artifacts are
+
+An artifact is non-markdown content attached to an existing adapter.
+
+Typical artifact examples:
+
+- Python scripts
+- shell scripts
+- JavaScript files
+- Perl scripts
+- TOML files
+- YAML files
+- plain text helper files
+- templates
+
+Artifacts are not adapter layers.
+
+| Object | Purpose | URI shape |
+|---|---|---|
+| Adapter | Protocol / workflow root | `kairos://adapter/{uuid-or-slug}` |
+| Layer | Markdown execution step | `kairos://layer/{uuid}` |
+| Artifact | Attached script/config/source file | `kairos://artifact/{uuid-or-slug}` |
+
+The current stable runtime principle is:
+
+```text
+Protocol markdown defines agent behaviour.
+Artifacts are real attached files.
+Artifact metadata is minimal.
+```
+
+## Current implementation status
+
+Artifacts already exist in the core train/export path, but slug parity is not
+complete everywhere yet.
+
+### Implemented today
+
+Current implemented behavior supports artifact storage by using `train` in
+non-markdown MIME mode.
+
+If `mime` is omitted or set to `text/markdown`, `train` stores adapter markdown.
+If `mime` is non-markdown, `train` treats the input as artifact content.
+
+For artifact mode, these fields are required:
+
+- `content`
+- `llm_model_id`
+- `mime`
+- `artifact_name`
+- `adapter_uri`
+
+The current schema describes `content` as protocol markdown for adapters and
+script/config source for artifacts, with the format determined by `mime`.
+
+Current allowed artifact MIME types are maintained in the train/store path and
+include text/script-like content such as:
+
+- `text/x-python`
+- `text/x-shellscript`
+- `text/javascript`
+- `text/x-perl`
+- `text/x-toml`
+- `text/yaml`
+- `text/plain`
+
+### Current URI limitations
+
+Adapter slug support exists in the runtime URI model, but some artifact-adjacent
+schemas still lag behind that model.
+
+Current `kairos-uri.ts` defines both UUID-only and UUID-or-slug adapter URI
+regexes:
+
+```text
+ADAPTER_UUID_URI_REGEX
+ADAPTER_URI_INPUT_REGEX
+```
+
+`ADAPTER_URI_INPUT_REGEX` accepts both adapter UUIDs and adapter slugs.
+
+However, current `train_schema.ts` still validates `adapter_uri` and
+`source_adapter_uri` using UUID-only adapter URI validation. This means artifact
+training against `kairos://adapter/{slug}` may fail schema validation until the
+schema is updated.
+
+Current `export_schema.ts` validates artifact URIs as UUID-only:
+
+```text
+kairos://artifact/{uuid}
+```
+
+Current `export.ts` also detects artifact URIs with a UUID-only regex. Therefore
+artifact export by slug is not yet complete on current main.
+
+## Current storage model
+
+Artifact persistence is implemented by `storeArtifact`.
+
+Current storage behavior:
+
+- generates a random artifact memory UUID
+- stores the artifact body in `payload.text`
+- stores the MIME type in `payload.content_type`
+- stores tags including `artifact`
+- stores adapter linkage under `payload.adapter.id`
+- initializes artifact vectors as zero vectors
+
+Current storage does not yet persist first-class artifact metadata fields such as:
+
+- artifact slug
+- artifact version
+- artifact SHA-256 hash
+
+Those fields are part of the target design described below.
+
+## Minimal artifact metadata
+
+KAIROS protocols aim to minimize noise for AI agents.
+
+Adapter markdown already has minimal frontmatter, for example:
+
+```markdown
+---
+slug: daily-briefing-generation-multi-source-work-dashboard
+version: 2.2.0
+---
+```
+
+Artifact files should follow the same low-noise principle.
+
+A Python artifact may carry only:
+
+```python
+#!/usr/bin/env python3
+# kairos-artifact:
+#   slug: sort-jira-py
+#   version: 1
+```
+
+A shell artifact may carry only:
+
+```bash
+#!/usr/bin/env bash
+# kairos-artifact:
+#   slug: verify-briefing-sh
+#   version: 1
+```
+
+This metadata is intentionally small.
+
+Do not duplicate adapter metadata inside artifacts. Training links the artifact
+to the adapter.
+
+## Artifact slug model
+
+Artifact slug support should mirror adapter slug support.
+
+Target URI examples:
+
+```text
+kairos://adapter/daily-briefing-generation-multi-source-work-dashboard
+kairos://artifact/sort-jira-py
+```
+
+The artifact slug is the stable agent-facing identity.
+
+The UUID remains the storage identity.
+
+```text
+artifact slug  -> stable human/agent identity
+artifact UUID  -> storage identity
+artifact name  -> original/materialized filename
+```
+
+For example:
+
+```text
+sort-jira-py     -> kairos://artifact/sort-jira-py
+sort-jira.py     -> materialized filename
+<uuid>           -> Qdrant memory UUID
+```
+
+## Target train behavior
+
+Target artifact training flow:
+
+1. Train adapter markdown.
+2. Train script/config artifact with non-markdown `mime`.
+3. Attach the artifact to the adapter by adapter UUID or adapter slug.
+4. Parse optional minimal artifact header.
+5. Persist slug, version, and hash in artifact payload.
+6. Return both canonical UUID metadata and slug-facing URI where available.
+
+Example input shape:
+
+```json
+{
+  "content": "#!/usr/bin/env python3\n# kairos-artifact:\n#   slug: sort-jira-py\n#   version: 1\n",
+  "llm_model_id": "gpt-5",
+  "mime": "text/x-python",
+  "artifact_name": "sort-jira.py",
+  "adapter_uri": "kairos://adapter/daily-briefing-generation-multi-source-work-dashboard"
+}
+```
+
+Target output should include enough metadata for agents to use the slug URI:
+
+```json
+{
+  "uri": "kairos://artifact/sort-jira-py",
+  "artifact_uuid": "00000000-0000-0000-0000-000000000000",
+  "artifact_uri": "kairos://artifact/00000000-0000-0000-0000-000000000000",
+  "artifact_slug": "sort-jira-py",
+  "artifact_version": "1",
+  "content_type": "text/x-python"
+}
+```
+
+Exact field names may follow existing output conventions, but the model should
+expose both slug and UUID identity.
+
+## Target export behavior
+
+Artifact export should support both slug and UUID forms:
+
+```text
+export uri=kairos://artifact/sort-jira-py
+export uri=kairos://artifact/{uuid}
+```
+
+Both should return the artifact source content.
+
+Adapter source listing should expose attached artifact metadata:
+
+```json
+{
+  "uri": "kairos://artifact/sort-jira-py",
+  "uuid_uri": "kairos://artifact/00000000-0000-0000-0000-000000000000",
+  "artifact_uuid": "00000000-0000-0000-0000-000000000000",
+  "slug": "sort-jira-py",
+  "version": "1",
+  "sha256": "...",
+  "name": "sort-jira.py",
+  "content_type": "text/x-python"
+}
+```
+
+## Versioning and update detection
+
+Artifacts are independently versioned runtime resources.
+
+This is different from normal application package versioning. For AI/MCP usage,
+the goal is to minimize unnecessary changes and avoid refreshing unrelated
+files.
+
+Recommended model:
+
+```text
+adapter version  -> behaviour contract version
+artifact version -> individual file/content version
+artifact sha256  -> exact content integrity
+```
+
+If only `sort-jira.py` changes, only `sort-jira-py` needs a new artifact version.
+
+Executions should pin the artifact versions they start with. A running execution
+must not silently switch to newer artifact versions mid-run.
+
+New activations may use newer artifact versions.
+
+## Runtime dependency rule
+
+KAIROS must not depend on local source-package files at runtime.
+
+Source files are authoring inputs. After training, runtime state is:
+
+```text
+trained adapter
++ attached artifacts in KAIROS storage
+```
+
+Agents should resolve and export artifacts through KAIROS URIs, not through local
+repository paths.
+
+Good:
+
+```text
+export kairos://artifact/sort-jira-py
+```
+
+Bad:
+
+```text
+run ./artifacts/sort-jira.py from the authoring checkout
+```
+
+## Execution semantics
+
+Artifacts are attached resources, not standalone adapter runs.
+
+`activate`, `forward`, and `reward` remain adapter execution tools.
+
+Artifacts support adapter execution by providing scripts, configuration, or
+templates that the agent can export/materialize and run when a protocol step
+requires them.
+
+## HTTP API behavior
+
+The HTTP API reuses the same tool-level train/export schemas and execution
+paths.
+
+Expected API surfaces:
+
+- `POST /api/train` for artifact creation through JSON input.
+- `POST /api/export` for artifact source retrieval and adapter source listing.
+
+`POST /api/train/raw` is markdown-body oriented and should not be treated as the
+primary artifact creation path.
+
+## CLI and UI status
+
+CLI and UI support are still secondary compared to MCP/API behavior.
+
+Known gaps to keep visible:
+
+- dedicated CLI artifact upload flags are not complete
+- CLI export format lists may not expose `source` everywhere
+- UI protocol pages do not yet provide a complete artifact management workflow
+- artifact slug/version/hash display needs to be added after storage support is complete
+
+## Implementation gaps to close
+
+To complete artifact slug parity:
+
+1. Update shared URI parsing/types so `kairos://artifact/{slug}` is accepted.
+2. Update train schemas so `adapter_uri` accepts adapter slug or UUID.
+3. Update export schemas so artifact URIs accept slug or UUID.
+4. Parse minimal artifact metadata from top comments:
+   - `slug`
+   - `version`
+5. Store artifact metadata:
+   - `artifact.slug`
+   - `artifact.version`
+   - `artifact.sha256`
+   - original `artifact_name`
+6. Resolve adapter slugs during artifact train.
+7. Resolve artifact slugs during artifact export.
+8. Include artifact slug/version/hash in adapter source listing.
+9. Add integration tests for:
+   - train artifact attached to adapter slug
+   - export artifact by slug
+   - export artifact by UUID
+   - list artifacts from adapter
+   - duplicate artifact slug behavior
+
+## Design constraints
+
+Keep the model small.
+
+Do not introduce package folders, zip files, manifests, or skill-bundle runtime
+dependencies as part of artifact slug parity.
+
+The preferred minimum is:
+
+```text
+Daily-Briefing-Dashboard.md
+sort-jira.py
+```
+
+with:
+
+```python
+# kairos-artifact:
+#   slug: sort-jira-py
+#   version: 1
+```
+
+## Summary
+
+KAIROS artifacts are real files attached to adapters.
+
+The near-term architecture should make artifacts slug-addressable and
+version-aware while preserving UUID compatibility and keeping metadata minimal.
+
+The target model is:
+
+```text
+adapter markdown frontmatter -> adapter slug/version
+script top comments          -> artifact slug/version
+KAIROS storage               -> UUID, content, MIME, adapter link, hash
+export                       -> source by artifact slug or UUID
+```

--- a/skills/.system/kairos-bug-report/SKILL.md
+++ b/skills/.system/kairos-bug-report/SKILL.md
@@ -16,7 +16,8 @@ to a specific call.
 **MISSION:** Produce a single Markdown bug report for the latest MCP
 interaction (or a user-specified one). Keep an exact 1-to-1 mapping
 between the structure below and the report: every section in this order,
-with no extra top-level sections.
+with no extra top-level sections. The Calls and responses section must be
+a **raw JSON trace** of each request and response, with redaction only.
 
 **STRUCTURE (exact order, never skip):**
 1. Summary
@@ -38,6 +39,9 @@ infrastructure component status needed for the Environment section.
   (server, tool/resource, arguments) **immediately followed by** its
   response in fenced `json` (full payload or error). Preserve
   chronological order.
+  - **Raw trace rule:** Request and response blocks must be raw,
+    verbatim JSON payloads from execution (except redaction of secrets).
+    Do not paraphrase, normalize, summarize, or rewrite JSON fields.
   - **Retry rule:** When a flow ends in `MAX_RETRIES_EXCEEDED` or
     similar retry exhaustion, include **every** retry attempt
     (request + response), not just the first and last. If `retry_count`
@@ -77,6 +81,8 @@ infrastructure component status needed for the Environment section.
 - Emit all six sections in order.
 - Use fenced code blocks with language `json` for every request and
   response.
+- Keep request and response blocks as **raw/verbatim JSON trace**
+  (redaction-only edits are allowed).
 - Redact secrets, tokens, cookies, and API keys in any JSON.
 - Save under `reports/` as
   `mcp-bug-<server>-<short-description>-<date>.md`.
@@ -93,6 +99,8 @@ infrastructure component status needed for the Environment section.
   stale nonce, targeted the wrong URI, or ignored `next_action`, the
   Reasoning section must classify this as agent error.
 - Put request/response in plain text or non-JSON code blocks.
+- Paraphrase, normalize, or rewrite request/response JSON instead of
+  preserving a raw trace (except redaction).
 - Include unredacted secrets, tokens, cookies, or API keys.
 
 ---
@@ -103,7 +111,7 @@ infrastructure component status needed for the Environment section.
   sentence.
 - [ ] Every MCP call in the flow has both request **and** response JSON
   blocks — including **all retry attempts** (no skipped intermediate
-  responses), with secrets redacted.
+  responses), with secrets redacted and raw/verbatim JSON preserved.
 - [ ] Reasoning includes explicit fault attribution for each failed
   attempt (agent error / server error / unclear) with evidence.
 - [ ] Environment includes KAIROS MCP version and infrastructure

--- a/src/services/memory/artifact-metadata.ts
+++ b/src/services/memory/artifact-metadata.ts
@@ -1,0 +1,74 @@
+const ARTIFACT_SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+export interface ArtifactMetadata {
+  slug: string;
+  version: string;
+}
+
+function normalizeArtifactSlug(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+function deriveSlugFromArtifactName(artifactName: string): string {
+  const normalized = artifactName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+  if (!normalized) {
+    throw new Error(`Could not derive artifact slug from artifact_name "${artifactName}"`);
+  }
+  if (!ARTIFACT_SLUG_REGEX.test(normalized)) {
+    throw new Error(`Derived artifact slug "${normalized}" is invalid`);
+  }
+  return normalized;
+}
+
+function parseTopHeader(content: string): { slug?: string; version?: string } {
+  const lines = content.split(/\r?\n/);
+  let index = 0;
+
+  if (lines[index]?.startsWith('#!')) {
+    index += 1;
+  }
+  while (index < lines.length && lines[index]?.trim() === '') {
+    index += 1;
+  }
+
+  if (!lines[index]?.trim().startsWith('# kairos-artifact:')) {
+    return {};
+  }
+
+  index += 1;
+  const output: { slug?: string; version?: string } = {};
+  for (; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (!trimmed.startsWith('#')) break;
+
+    const body = trimmed.slice(1).trim();
+    const sep = body.indexOf(':');
+    if (sep <= 0) continue;
+    const key = body.slice(0, sep).trim();
+    const value = body.slice(sep + 1).trim();
+    if (!value) continue;
+    if (key === 'slug') output.slug = value;
+    if (key === 'version') output.version = value;
+  }
+  return output;
+}
+
+export function extractArtifactMetadata(content: string, artifactName: string): ArtifactMetadata {
+  const parsed = parseTopHeader(content);
+  const slug = normalizeArtifactSlug(parsed.slug ?? deriveSlugFromArtifactName(artifactName));
+  if (!ARTIFACT_SLUG_REGEX.test(slug)) {
+    throw new Error(`Invalid artifact slug "${slug}". Use lowercase letters, numbers, and hyphens.`);
+  }
+  const version = parsed.version && parsed.version.trim().length > 0 ? parsed.version.trim() : '1';
+  return {
+    slug,
+    version
+  };
+}

--- a/src/services/memory/store-artifact.ts
+++ b/src/services/memory/store-artifact.ts
@@ -11,6 +11,7 @@ import { redisCacheService } from '../redis-cache.js';
 import { parseKairosUri } from '../../tools/kairos-uri.js';
 import type { Memory } from '../../types/memory.js';
 import type { StoreArtifactOptions } from './store-adapter.js';
+import { extractArtifactMetadata } from './artifact-metadata.js';
 
 export async function storeArtifact(
   client: QdrantClient,
@@ -19,10 +20,12 @@ export async function storeArtifact(
   options: StoreArtifactOptions
 ): Promise<Memory[]> {
   const parsed = parseKairosUri(options.adapterUri);
-  if (parsed.kind !== 'adapter') {
+  if (parsed.kind !== 'adapter' || parsed.idKind !== 'uuid') {
     throw new Error('adapterUri must be a kairos://adapter/{uuid} URI');
   }
   const adapterId = parsed.id;
+  const artifact = extractArtifactMetadata(content, options.name);
+  const sha256 = crypto.createHash('sha256').update(content, 'utf8').digest('hex');
   const vectorSize = getEmbeddingDimension();
   const zeroVector = Array.from({ length: vectorSize }, () => 0);
   const context = getSpaceContext();
@@ -30,7 +33,22 @@ export async function storeArtifact(
   const actorId = context.userId || 'system';
   const now = new Date().toISOString();
   const memoryUuid = crypto.randomUUID();
-  const tags = ['artifact', options.mime.replace('text/', '')];
+  const tags = ['artifact', options.mime.replace('text/', ''), `artifact:${artifact.slug}`];
+
+  const duplicate = await client.scroll(collection, {
+    filter: {
+      must: [
+        { key: 'space_id', match: { value: spaceId } },
+        { key: 'artifact.slug', match: { value: artifact.slug } }
+      ]
+    },
+    limit: 2,
+    with_payload: true,
+    with_vector: false
+  });
+  if (Array.isArray(duplicate.points) && duplicate.points.length > 0) {
+    throw new Error(`Artifact slug "${artifact.slug}" already exists in this space`);
+  }
 
   await client.upsert(collection, {
     points: [{
@@ -51,6 +69,12 @@ export async function storeArtifact(
         modified_at: now,
         modified_by: actorId,
         content_type: options.mime,
+        artifact: {
+          slug: artifact.slug,
+          version: artifact.version,
+          name: options.name,
+          sha256
+        },
         adapter: {
           id: adapterId,
           name: options.name
@@ -69,6 +93,12 @@ export async function storeArtifact(
     llm_model_id: options.llmModelId,
     created_at: now,
     content_type: options.mime,
+    artifact: {
+      slug: artifact.slug,
+      version: artifact.version,
+      name: options.name,
+      sha256
+    },
     adapter: {
       id: adapterId,
       name: options.name,

--- a/src/services/qdrant/memory-retrieval.ts
+++ b/src/services/qdrant/memory-retrieval.ts
@@ -213,6 +213,11 @@ export interface SlugResolveOutcome {
   disambiguation_note?: string;
 }
 
+export interface ArtifactSlugResolveOutcome {
+  artifactUuid: string | null;
+  disambiguation_note?: string;
+}
+
 function getSlugSpacePrecedence(spaceId: string): number {
   if (spaceId.startsWith('user:')) return 0;
   if (spaceId.startsWith('group:')) return 1;
@@ -299,5 +304,43 @@ export async function findFirstStepMemoryUuidBySlug(
     const note = `Slug "${normalized}" matched ${unique.length} adapters; selected "${adapterHint}" from "${winnerSpaceId}" by precedence (personal > group > app/system, then stable id). Candidates: ${contenderSummary}. Prefer an explicit adapter URI such as kairos://adapter/${adapterHint} to avoid ambiguity.`;
     structuredLogger.warn(`[slug-resolve] ${note}`);
     return { layerUuid: chosenId, disambiguation_note: note };
+  });
+}
+
+export async function findArtifactMemoryUuidBySlug(
+  conn: QdrantConnection,
+  slug: string
+): Promise<ArtifactSlugResolveOutcome> {
+  return conn.executeWithReconnect(async () => {
+    const normalized = (slug || '').trim().toLowerCase();
+    if (!normalized) return { artifactUuid: null };
+    const filter = buildSpaceFilter(getSearchSpaceIds(), {
+      must: [{ key: 'artifact.slug', match: { value: normalized } }]
+    });
+
+    const allPts: any[] = [];
+    let offset: any = undefined;
+    do {
+      const page = await conn.client.scroll(conn.collectionName, {
+        filter,
+        limit: 64,
+        offset,
+        with_payload: true,
+        with_vector: false
+      } as any);
+      const pts = page.points || [];
+      allPts.push(...pts);
+      offset = page.next_page_offset;
+    } while (offset);
+
+    if (allPts.length === 0) return { artifactUuid: null };
+    if (allPts.length > 1) {
+      const candidates = allPts.map((point) => String(point.id)).join(', ');
+      return {
+        artifactUuid: null,
+        disambiguation_note: `Artifact slug "${normalized}" is ambiguous. Matching artifact UUIDs: ${candidates}`
+      };
+    }
+    return { artifactUuid: String(allPts[0]!.id) };
   });
 }

--- a/src/services/qdrant/service.ts
+++ b/src/services/qdrant/service.ts
@@ -83,6 +83,10 @@ export class QdrantService {
     return retrieval.findFirstStepMemoryUuidBySlug(this.conn, slug);
   }
 
+  findArtifactMemoryUuidBySlug(slug: string) {
+    return retrieval.findArtifactMemoryUuidBySlug(this.conn, slug);
+  }
+
   updateMemoryByUUID(uuid: string, updatesPayload: any) {
     return updateMemoryByUUID(this.conn, uuid, updatesPayload);
   }

--- a/src/tools/export-resolve-adapter.ts
+++ b/src/tools/export-resolve-adapter.ts
@@ -1,0 +1,43 @@
+import type { MemoryQdrantStore } from '../services/memory/store.js';
+import type { QdrantService } from '../services/qdrant/service.js';
+import { getAdapterId } from '../services/memory/memory-accessors.js';
+import { parseKairosUri } from './kairos-uri.js';
+
+export async function resolveExportAdapter(
+  memoryStore: MemoryQdrantStore,
+  qdrantService: QdrantService | undefined,
+  uri: string
+): Promise<{ adapterId: string; layerId: string }> {
+  const parsed = parseKairosUri(uri);
+  if (parsed.kind === 'adapter') {
+    if (parsed.idKind === 'slug') {
+      if (!qdrantService) {
+        throw new Error('Adapter slug lookup is unavailable');
+      }
+      const outcome = await qdrantService.findFirstStepMemoryUuidBySlug(parsed.id);
+      if (!outcome.layerUuid) {
+        throw new Error('Adapter not found');
+      }
+      const adapterId = outcome.layerUuid;
+      const layers = await qdrantService.getAdapterLayers(adapterId);
+      const firstLayerId = layers[0]?.uuid ?? adapterId;
+      return { adapterId, layerId: firstLayerId };
+    }
+    if (qdrantService) {
+      const layers = await qdrantService.getAdapterLayers(parsed.id);
+      const firstLayerId = layers[0]?.uuid;
+      if (firstLayerId) {
+        return { adapterId: parsed.id, layerId: firstLayerId };
+      }
+    }
+    const layer = await memoryStore.getMemory(parsed.id);
+    if (layer) {
+      return { adapterId: parsed.id, layerId: layer.memory_uuid };
+    }
+    throw new Error('Adapter not found');
+  }
+
+  const memory = await memoryStore.getMemory(parsed.id);
+  const adapterId = memory ? getAdapterId(memory) : parsed.id;
+  return { adapterId, layerId: parsed.id };
+}

--- a/src/tools/export-reward-jsonl.ts
+++ b/src/tools/export-reward-jsonl.ts
@@ -1,0 +1,181 @@
+import { isRewardEligibleForPreference, isRewardEligibleForSft } from '../services/reward-evals.js';
+import type { TrainingPair } from '../services/execution-trace-store.js';
+import type { RewardRecord, TensorValue } from '../types/memory.js';
+import { parseKairosUri } from './kairos-uri.js';
+
+interface RewardJsonlItem {
+  instruction: {
+    activation_query: string | null;
+    tensor_in: Record<string, unknown>;
+    layer_instructions: string;
+  };
+  response: {
+    tensor_out: TensorValue | null;
+    trace: string | null;
+    raw_solution: unknown | null;
+  };
+  reward: {
+    outcome: RewardRecord['outcome'];
+    score: number | null;
+    signed_score: number | null;
+    quality_bonus: number | null;
+    feedback: string | null;
+    rater: string | null;
+    llm_model_id: string | null;
+    rubric_version: string | null;
+    grader_kind: NonNullable<RewardRecord['grader_kind']>;
+    evaluation_label: RewardRecord['evaluation_label'] | null;
+    exportable_for_sft: boolean;
+    exportable_for_preference: boolean;
+    sft_blockers: string[];
+    preference_blockers: string[];
+    rated_at: string;
+  };
+  metadata: {
+    execution_id: string;
+    adapter_uri: string;
+    layer_uri: string;
+    layer_index: number;
+    timestamp: string;
+  };
+}
+
+function canonicalLayerUri(uri: string): string {
+  try {
+    const parsed = parseKairosUri(uri);
+    return parsed.kind === 'layer' ? `kairos://layer/${parsed.id}` : uri;
+  } catch {
+    return uri;
+  }
+}
+
+function toRewardJsonlItem(pair: TrainingPair & { reward: RewardRecord }): RewardJsonlItem {
+  return {
+    instruction: {
+      activation_query: pair.instruction.activation_query ?? null,
+      tensor_in: pair.instruction.tensor_in,
+      layer_instructions: pair.instruction.layer_instructions
+    },
+    response: {
+      tensor_out: pair.response.tensor_out ?? null,
+      trace: pair.response.trace ?? null,
+      raw_solution: pair.response.raw_solution ?? null
+    },
+    reward: {
+      outcome: pair.reward.outcome,
+      score: pair.reward.score ?? null,
+      signed_score: pair.reward.signed_score ?? null,
+      quality_bonus: pair.reward.quality_bonus ?? null,
+      feedback: pair.reward.feedback ?? null,
+      rater: pair.reward.rater ?? null,
+      llm_model_id: pair.reward.llm_model_id ?? null,
+      rubric_version: pair.reward.rubric_version ?? null,
+      grader_kind: pair.reward.grader_kind ?? 'unknown',
+      evaluation_label: pair.reward.evaluation_label ?? null,
+      exportable_for_sft: pair.reward.exportable_for_sft ?? isRewardEligibleForSft(pair.reward),
+      exportable_for_preference:
+        pair.reward.exportable_for_preference ?? isRewardEligibleForPreference(pair.reward),
+      sft_blockers: pair.reward.sft_blockers ?? [],
+      preference_blockers: pair.reward.preference_blockers ?? [],
+      rated_at: pair.reward.rated_at
+    },
+    metadata: {
+      execution_id: pair.execution_id,
+      adapter_uri: pair.adapter_uri,
+      layer_uri: canonicalLayerUri(pair.layer_uri),
+      layer_index: pair.layer_index,
+      timestamp: pair.timestamp
+    }
+  };
+}
+
+export function stringifyLines(items: unknown[]): string {
+  return items.map((item) => JSON.stringify(item)).join('\n');
+}
+
+export function buildRewardJsonlItems(pairs: TrainingPair[]): RewardJsonlItem[] {
+  return pairs
+    .filter((pair): pair is TrainingPair & { reward: RewardRecord } => Boolean(pair.reward))
+    .map((pair) => toRewardJsonlItem(pair));
+}
+
+export function buildSftJsonlItems(
+  pairs: TrainingPair[],
+  includeReward: boolean
+): Array<{
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  metadata: { adapter_uri: string; layer_uri: string; layer_index: number; reward?: RewardRecord };
+}> {
+  const sftPairs = includeReward ? pairs.filter((pair) => isRewardEligibleForSft(pair.reward)) : pairs;
+  return sftPairs.map((pair) => ({
+    messages: [
+      {
+        role: 'user',
+        content: JSON.stringify({
+          activation_query: pair.instruction.activation_query,
+          tensor_in: pair.instruction.tensor_in,
+          layer_instructions: pair.instruction.layer_instructions
+        })
+      },
+      {
+        role: 'assistant',
+        content: JSON.stringify({
+          tensor_out: pair.response.tensor_out,
+          trace: pair.response.trace,
+          raw_solution: pair.response.raw_solution
+        })
+      }
+    ],
+    metadata: {
+      adapter_uri: pair.adapter_uri,
+      layer_uri: pair.layer_uri,
+      layer_index: pair.layer_index,
+      ...(pair.reward ? { reward: pair.reward } : {})
+    }
+  }));
+}
+
+export function buildPreferenceJsonlItems(pairs: TrainingPair[]): Array<{
+  prompt: string;
+  chosen: string;
+  rejected: string;
+  metadata: { adapter_uri: string; layer_uri: string; layer_index: number };
+}> {
+  const preferenceItems: Array<{
+    prompt: string;
+    chosen: string;
+    rejected: string;
+    metadata: { adapter_uri: string; layer_uri: string; layer_index: number };
+  }> = [];
+
+  const byLayer = new Map<string, TrainingPair[]>();
+  for (const pair of pairs) {
+    const key = `${canonicalLayerUri(pair.layer_uri)}:${pair.layer_index}`;
+    byLayer.set(key, [...(byLayer.get(key) ?? []), pair]);
+  }
+
+  for (const layerPairs of byLayer.values()) {
+    const eligiblePairs = layerPairs.filter((pair) => isRewardEligibleForPreference(pair.reward));
+    const chosen = eligiblePairs
+      .filter((pair) => pair.reward?.outcome === 'success')
+      .sort((a, b) => (b.reward?.score ?? 0) - (a.reward?.score ?? 0))[0];
+    const rejected = eligiblePairs
+      .filter((pair) => pair.reward?.outcome === 'failure')
+      .sort((a, b) => (b.reward?.score ?? 0) - (a.reward?.score ?? 0))[0];
+    if (!chosen || !rejected) {
+      continue;
+    }
+    preferenceItems.push({
+      prompt: JSON.stringify(chosen.instruction),
+      chosen: JSON.stringify(chosen.response),
+      rejected: JSON.stringify(rejected.response),
+      metadata: {
+        adapter_uri: chosen.adapter_uri,
+        layer_uri: canonicalLayerUri(chosen.layer_uri),
+        layer_index: chosen.layer_index
+      }
+    });
+  }
+
+  return preferenceItems;
+}

--- a/src/tools/export-source.ts
+++ b/src/tools/export-source.ts
@@ -13,9 +13,33 @@ const ALLOWED_ARTIFACT_MIMES = [
   'text/plain'
 ] as const;
 
-function parseArtifactUri(uri: string): string | null {
-  const match = /^kairos:\/\/artifact\/([0-9a-f-]{36})$/i.exec((uri || '').trim());
-  return match?.[1] ?? null;
+interface ArtifactUriResolution {
+  requestedUri: string;
+  artifactUuid: string;
+  uri: string;
+}
+
+async function resolveArtifactUri(qdrantService: QdrantService | undefined, uri: string): Promise<ArtifactUriResolution | null> {
+  const parsed = parseKairosUri((uri || '').trim());
+  if (parsed.kind !== 'artifact') return null;
+  if (parsed.idKind === 'uuid') {
+    return { requestedUri: uri, artifactUuid: parsed.id, uri };
+  }
+  if (!qdrantService) {
+    throw new Error('Artifact slug lookup is unavailable');
+  }
+  const resolved = await qdrantService.findArtifactMemoryUuidBySlug(parsed.id);
+  if (resolved.disambiguation_note) {
+    throw new Error(resolved.disambiguation_note);
+  }
+  if (!resolved.artifactUuid) {
+    throw new Error(`Artifact slug "${parsed.id}" not found`);
+  }
+  return {
+    requestedUri: uri,
+    artifactUuid: resolved.artifactUuid,
+    uri
+  };
 }
 
 async function sourceFromMemory(memoryStore: MemoryQdrantStore, uri: string, memoryId: string): Promise<ExportOutput> {
@@ -38,8 +62,13 @@ async function sourceListForAdapter(memoryStore: MemoryQdrantStore, uri: string,
   const { client, collection } = memoryStore.getQdrantAccess();
   const artifacts: Array<{
     uri: string;
+    uuid_uri: string;
     artifact_uuid: string;
     label: string;
+    slug: string;
+    version: string;
+    sha256: string;
+    name: string;
     content_type: string;
     tags: string[];
   }> = [];
@@ -63,10 +92,26 @@ async function sourceListForAdapter(memoryStore: MemoryQdrantStore, uri: string,
       const idRaw = point?.id;
       const id = typeof idRaw === 'string' ? idRaw : typeof idRaw === 'number' ? String(idRaw) : '';
       if (!id) continue;
+      const artifactPayload = (payload['artifact'] ?? {}) as Record<string, unknown>;
+      const slug = typeof artifactPayload['slug'] === 'string' && artifactPayload['slug'].trim().length > 0
+        ? artifactPayload['slug']
+        : id;
+      const version = typeof artifactPayload['version'] === 'string' && artifactPayload['version'].trim().length > 0
+        ? artifactPayload['version']
+        : '1';
+      const sha256 = typeof artifactPayload['sha256'] === 'string' ? artifactPayload['sha256'] : '';
+      const name = typeof artifactPayload['name'] === 'string' && artifactPayload['name'].trim().length > 0
+        ? artifactPayload['name']
+        : (typeof payload['label'] === 'string' ? payload['label'] : id);
       artifacts.push({
-        uri: `kairos://artifact/${id}`,
+        uri: `kairos://artifact/${slug}`,
+        uuid_uri: `kairos://artifact/${id}`,
         artifact_uuid: id,
         label: typeof payload['label'] === 'string' ? payload['label'] : id,
+        slug,
+        version,
+        sha256,
+        name,
         content_type: typeof payload['content_type'] === 'string' ? payload['content_type'] : 'text/plain',
         tags: Array.isArray(payload['tags']) ? payload['tags'].map((t) => String(t)) : []
       });
@@ -92,14 +137,15 @@ export async function executeExportSource(
   uri: string,
   resolveAdapter: (memoryStore: MemoryQdrantStore, qdrantService: QdrantService | undefined, uri: string) => Promise<{ adapterId: string; layerId: string }>
 ): Promise<ExportOutput> {
-  const parsedArtifactId = parseArtifactUri(uri);
-  if (parsedArtifactId) {
-    return sourceFromMemory(memoryStore, uri, parsedArtifactId);
+  const parsedArtifact = await resolveArtifactUri(qdrantService, uri);
+  if (parsedArtifact) {
+    return sourceFromMemory(memoryStore, parsedArtifact.uri, parsedArtifact.artifactUuid);
   }
 
   const parsed = parseKairosUri(uri);
   if (parsed.kind === 'adapter') {
-    return sourceListForAdapter(memoryStore, uri, parsed.id);
+    const { adapterId } = await resolveAdapter(memoryStore, qdrantService, uri);
+    return sourceListForAdapter(memoryStore, uri, adapterId);
   }
 
   const { layerId } = await resolveAdapter(memoryStore, qdrantService, uri);

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -1,8 +1,6 @@
 import type { MemoryQdrantStore } from '../services/memory/store.js';
 import type { QdrantService } from '../services/qdrant/service.js';
-import { resolveToolDoc } from '../utils/mcp-tool-doc-runtime.js';
-import { executionTraceStore, type TrainingPair } from '../services/execution-trace-store.js';
-import { getAdapterId } from '../services/memory/memory-accessors.js';
+import { executionTraceStore } from '../services/execution-trace-store.js';
 import { getSpaceContextFromStorage, getTenantId } from '../utils/tenant-context.js';
 import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
 import { executeDump } from './dump.js';
@@ -11,137 +9,18 @@ import { parseKairosUri } from './kairos-uri.js';
 import { mcpLooseToolInput } from './mcp-loose-input-schema.js';
 import { mcpToolInputValidationErrorResult } from './mcp-tool-input-teaching.js';
 import { spaceIdToDisplayName, spaceKindFromSpaceId } from '../utils/space-display.js';
-import { isRewardEligibleForPreference, isRewardEligibleForSft } from '../services/reward-evals.js';
-import type { RewardRecord, TensorValue } from '../types/memory.js';
 import { executeExportSource } from './export-source.js';
-
-const ARTIFACT_URI_REGEX = /^kairos:\/\/artifact\/[0-9a-f-]{36}$/i;
+import { resolveExportAdapter } from './export-resolve-adapter.js';
+import { buildPreferenceJsonlItems, buildRewardJsonlItems, buildSftJsonlItems, stringifyLines } from './export-reward-jsonl.js';
+import { resolveToolDoc } from '../utils/mcp-tool-doc-runtime.js';
 
 interface RegisterExportOptions {
   toolName?: string;
   qdrantService?: QdrantService;
 }
 
-interface RewardJsonlItem {
-  instruction: {
-    activation_query: string | null;
-    tensor_in: Record<string, unknown>;
-    layer_instructions: string;
-  };
-  response: {
-    tensor_out: TensorValue | null;
-    trace: string | null;
-    raw_solution: unknown | null;
-  };
-  reward: {
-    outcome: RewardRecord['outcome'];
-    score: number | null;
-    signed_score: number | null;
-    quality_bonus: number | null;
-    feedback: string | null;
-    rater: string | null;
-    llm_model_id: string | null;
-    rubric_version: string | null;
-    grader_kind: NonNullable<RewardRecord['grader_kind']>;
-    evaluation_label: RewardRecord['evaluation_label'] | null;
-    exportable_for_sft: boolean;
-    exportable_for_preference: boolean;
-    sft_blockers: string[];
-    preference_blockers: string[];
-    rated_at: string;
-  };
-  metadata: {
-    execution_id: string;
-    adapter_uri: string;
-    layer_uri: string;
-    layer_index: number;
-    timestamp: string;
-  };
-}
-
-async function resolveAdapter(memoryStore: MemoryQdrantStore, qdrantService: QdrantService | undefined, uri: string) {
-  const parsed = parseKairosUri(uri);
-  if (parsed.kind === 'adapter') {
-    if (qdrantService) {
-      const layers = await qdrantService.getAdapterLayers(parsed.id);
-      const firstLayerId = layers[0]?.uuid;
-      if (firstLayerId) {
-        return { adapterId: parsed.id, layerId: firstLayerId };
-      }
-    }
-    const layer = await memoryStore.getMemory(parsed.id);
-    if (layer) {
-      return { adapterId: parsed.id, layerId: layer.memory_uuid };
-    }
-    throw new Error('Adapter not found');
-  }
-
-  const memory = await memoryStore.getMemory(parsed.id);
-  const adapterId = memory ? getAdapterId(memory) : parsed.id;
-  return { adapterId, layerId: parsed.id };
-}
-
 function toCurrentMarkdown(markdownDoc: string): string {
   return markdownDoc.replaceAll('"challenge":', '"contract":');
-}
-
-function stringifyLines(items: unknown[]): string {
-  return items.map((item) => JSON.stringify(item)).join('\n');
-}
-
-function canonicalLayerUri(uri: string): string {
-  try {
-    const parsed = parseKairosUri(uri);
-    return parsed.kind === 'layer' ? `kairos://layer/${parsed.id}` : uri;
-  } catch {
-    return uri;
-  }
-}
-
-function toRewardJsonlItem(pair: TrainingPair & { reward: RewardRecord }): RewardJsonlItem {
-  return {
-    instruction: {
-      activation_query: pair.instruction.activation_query ?? null,
-      tensor_in: pair.instruction.tensor_in,
-      layer_instructions: pair.instruction.layer_instructions
-    },
-    response: {
-      tensor_out: pair.response.tensor_out ?? null,
-      trace: pair.response.trace ?? null,
-      raw_solution: pair.response.raw_solution ?? null
-    },
-    reward: {
-      outcome: pair.reward.outcome,
-      score: pair.reward.score ?? null,
-      signed_score: pair.reward.signed_score ?? null,
-      quality_bonus: pair.reward.quality_bonus ?? null,
-      feedback: pair.reward.feedback ?? null,
-      rater: pair.reward.rater ?? null,
-      llm_model_id: pair.reward.llm_model_id ?? null,
-      rubric_version: pair.reward.rubric_version ?? null,
-      grader_kind: pair.reward.grader_kind ?? 'unknown',
-      evaluation_label: pair.reward.evaluation_label ?? null,
-      exportable_for_sft: pair.reward.exportable_for_sft ?? isRewardEligibleForSft(pair.reward),
-      exportable_for_preference:
-        pair.reward.exportable_for_preference ?? isRewardEligibleForPreference(pair.reward),
-      sft_blockers: pair.reward.sft_blockers ?? [],
-      preference_blockers: pair.reward.preference_blockers ?? [],
-      rated_at: pair.reward.rated_at
-    },
-    metadata: {
-      execution_id: pair.execution_id,
-      adapter_uri: pair.adapter_uri,
-      layer_uri: canonicalLayerUri(pair.layer_uri),
-      layer_index: pair.layer_index,
-      timestamp: pair.timestamp
-    }
-  };
-}
-
-function buildRewardJsonlItems(pairs: TrainingPair[]): RewardJsonlItem[] {
-  return pairs
-    .filter((pair): pair is TrainingPair & { reward: RewardRecord } => Boolean(pair.reward))
-    .map((pair) => toRewardJsonlItem(pair));
 }
 
 export async function executeExport(
@@ -149,16 +28,16 @@ export async function executeExport(
   qdrantService: QdrantService | undefined,
   input: ExportInput
 ): Promise<ExportOutput> {
-  const isArtifactUri = ARTIFACT_URI_REGEX.test(input.uri.trim());
-  if (isArtifactUri) {
-    return executeExportSource(memoryStore, qdrantService, input.uri, resolveAdapter);
+  const parsedUri = parseKairosUri(input.uri.trim());
+  if (parsedUri.kind === 'artifact') {
+    return executeExportSource(memoryStore, qdrantService, input.uri, resolveExportAdapter);
   }
 
   if (input.format === 'source') {
-    return executeExportSource(memoryStore, qdrantService, input.uri, resolveAdapter);
+    return executeExportSource(memoryStore, qdrantService, input.uri, resolveExportAdapter);
   }
 
-  const { adapterId, layerId } = await resolveAdapter(memoryStore, qdrantService, input.uri);
+  const { adapterId, layerId } = await resolveExportAdapter(memoryStore, qdrantService, input.uri);
 
   if (input.format === 'markdown') {
     const dump = await executeDump(memoryStore, qdrantService, {
@@ -218,33 +97,7 @@ export async function executeExport(
   }
 
   if (input.format === 'sft_jsonl') {
-    const sftPairs = input.include_reward ? pairs.filter((pair) => isRewardEligibleForSft(pair.reward)) : pairs;
-    const sftItems = sftPairs.map((pair) => ({
-      messages: [
-        {
-          role: 'user',
-          content: JSON.stringify({
-            activation_query: pair.instruction.activation_query,
-            tensor_in: pair.instruction.tensor_in,
-            layer_instructions: pair.instruction.layer_instructions
-          })
-        },
-        {
-          role: 'assistant',
-          content: JSON.stringify({
-            tensor_out: pair.response.tensor_out,
-            trace: pair.response.trace,
-            raw_solution: pair.response.raw_solution
-          })
-        }
-      ],
-      metadata: {
-        adapter_uri: pair.adapter_uri,
-        layer_uri: pair.layer_uri,
-        layer_index: pair.layer_index,
-        reward: pair.reward
-      }
-    }));
+    const sftItems = buildSftJsonlItems(pairs, input.include_reward);
     return {
       uri: input.uri,
       format: input.format,
@@ -254,39 +107,7 @@ export async function executeExport(
     };
   }
 
-  const preferenceItems: Array<{
-    prompt: string;
-    chosen: string;
-    rejected: string;
-    metadata: { adapter_uri: string; layer_uri: string; layer_index: number };
-  }> = [];
-  const byLayer = new Map<string, typeof pairs>();
-  for (const pair of pairs) {
-    const key = `${canonicalLayerUri(pair.layer_uri)}:${pair.layer_index}`;
-    byLayer.set(key, [...(byLayer.get(key) ?? []), pair]);
-  }
-  for (const layerPairs of byLayer.values()) {
-    const eligiblePairs = layerPairs.filter((pair) => isRewardEligibleForPreference(pair.reward));
-    const chosen = eligiblePairs
-      .filter((pair) => pair.reward?.outcome === 'success')
-      .sort((a, b) => (b.reward?.score ?? 0) - (a.reward?.score ?? 0))[0];
-    const rejected = eligiblePairs
-      .filter((pair) => pair.reward?.outcome === 'failure')
-      .sort((a, b) => (b.reward?.score ?? 0) - (a.reward?.score ?? 0))[0];
-    if (!chosen || !rejected) {
-      continue;
-    }
-    preferenceItems.push({
-      prompt: JSON.stringify(chosen.instruction),
-      chosen: JSON.stringify(chosen.response),
-      rejected: JSON.stringify(rejected.response),
-      metadata: {
-        adapter_uri: chosen.adapter_uri,
-        layer_uri: canonicalLayerUri(chosen.layer_uri),
-        layer_index: chosen.layer_index
-      }
-    });
-  }
+  const preferenceItems = buildPreferenceJsonlItems(pairs);
   return {
     uri: input.uri,
     format: input.format,

--- a/src/tools/export_schema.ts
+++ b/src/tools/export_schema.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
-import { ADAPTER_UUID_URI_REGEX, LAYER_URI_INPUT_REGEX } from './kairos-uri.js';
+import { ADAPTER_URI_INPUT_REGEX, ARTIFACT_URI_INPUT_REGEX, LAYER_URI_INPUT_REGEX } from './kairos-uri.js';
 
 const adapterUriSchema = z
   .string()
-  .regex(ADAPTER_UUID_URI_REGEX, 'must match kairos://adapter/{uuid}');
+  .regex(ADAPTER_URI_INPUT_REGEX, 'must match kairos://adapter/{uuid|slug}');
 
 const layerUriSchema = z
   .string()
@@ -11,7 +11,7 @@ const layerUriSchema = z
 
 const artifactUriSchema = z
   .string()
-  .regex(/^kairos:\/\/artifact\/[0-9a-f-]{36}$/i, 'must match kairos://artifact/{uuid}');
+  .regex(ARTIFACT_URI_INPUT_REGEX, 'must match kairos://artifact/{uuid|slug}');
 
 const adapterOrLayerUriSchema = z.union([adapterUriSchema, layerUriSchema, artifactUriSchema]);
 

--- a/src/tools/kairos-uri.ts
+++ b/src/tools/kairos-uri.ts
@@ -2,16 +2,21 @@ import { KairosError } from '../types/index.js';
 import { normalizeAuthorSlug } from '../utils/protocol-slug.js';
 
 const UUID_PATTERN = '[0-9a-f-]{36}';
-const SLUG_PATTERN = '[a-z0-9]+(?:-[a-z0-9]+)*';
+const SLUG_PATTERN = '[a-z0-9](?:[a-z0-9-]*[a-z0-9])?';
 
 const UUID_REGEX = new RegExp(`^${UUID_PATTERN}$`, 'i');
 const ADAPTER_URI_BODY_REGEX = /^kairos:\/\/adapter\/([^/?#]+)$/i;
+const ARTIFACT_URI_BODY_REGEX = /^kairos:\/\/artifact\/([^/?#]+)$/i;
 export const ADAPTER_UUID_URI_REGEX = new RegExp(
   `^kairos://adapter/(${UUID_PATTERN})$`,
   'i'
 );
 export const ADAPTER_URI_INPUT_REGEX = new RegExp(
   `^kairos://adapter/(${UUID_PATTERN}|${SLUG_PATTERN})$`,
+  'i'
+);
+export const ARTIFACT_URI_INPUT_REGEX = new RegExp(
+  `^kairos://artifact/(${UUID_PATTERN}|${SLUG_PATTERN})$`,
   'i'
 );
 export const LAYER_URI_INPUT_REGEX = new RegExp(
@@ -21,6 +26,7 @@ export const LAYER_URI_INPUT_REGEX = new RegExp(
 
 export type ParsedKairosUri =
   | { kind: 'adapter'; id: string; idKind: 'uuid' | 'slug'; raw: string }
+  | { kind: 'artifact'; id: string; idKind: 'uuid' | 'slug'; raw: string }
   | { kind: 'layer'; id: string; executionId?: string; raw: string };
 
 export function buildAdapterUri(adapterId: string): string {
@@ -68,7 +74,31 @@ export function parseKairosUri(value: string): ParsedKairosUri {
     };
   }
 
-  throw new Error('Invalid KAIROS URI. Expected kairos://adapter/{uuid|slug} or kairos://layer/{uuid}');
+  const artifactMatch = normalized.match(ARTIFACT_URI_BODY_REGEX);
+  if (artifactMatch?.[1]) {
+    if (UUID_REGEX.test(artifactMatch[1])) {
+      return {
+        kind: 'artifact',
+        id: artifactMatch[1],
+        idKind: 'uuid',
+        raw: normalized
+      };
+    }
+
+    const normalizedSlug = normalizeAuthorSlug(artifactMatch[1]);
+    if (normalizedSlug) {
+      return {
+        kind: 'artifact',
+        id: normalizedSlug,
+        idKind: 'slug',
+        raw: normalized
+      };
+    }
+  }
+
+  throw new Error(
+    'Invalid KAIROS URI. Expected kairos://adapter/{uuid|slug}, kairos://artifact/{uuid|slug}, or kairos://layer/{uuid}'
+  );
 }
 
 export function parseKairosUriOrThrow(value: string): ParsedKairosUri {

--- a/src/tools/train-artifact-adapter-uri.ts
+++ b/src/tools/train-artifact-adapter-uri.ts
@@ -1,0 +1,36 @@
+import type { QdrantService } from '../services/qdrant/service.js';
+import { buildAdapterUri, parseKairosUri } from './kairos-uri.js';
+import { TrainError } from './train-store.js';
+
+export async function resolveCanonicalAdapterUriForArtifact(
+  inputAdapterUri: string | undefined,
+  qdrantService: QdrantService | undefined
+): Promise<string | undefined> {
+  const raw = typeof inputAdapterUri === 'string' ? inputAdapterUri.trim() : '';
+  if (!raw) return undefined;
+
+  const parsed = parseKairosUri(raw);
+  if (parsed.kind !== 'adapter') {
+    throw new TrainError('INVALID_ADAPTER_URI', 'adapter_uri must be kairos://adapter/{uuid|slug}', {
+      must_obey: true
+    });
+  }
+
+  if (parsed.idKind === 'uuid') return buildAdapterUri(parsed.id);
+
+  if (!qdrantService) {
+    throw new TrainError(
+      'ADAPTER_LOOKUP_UNAVAILABLE',
+      'adapter_uri slug resolution requires adapter storage service availability.',
+      { must_obey: true }
+    );
+  }
+
+  const resolved = await qdrantService.findFirstStepMemoryUuidBySlug(parsed.id);
+  if (!resolved.layerUuid) {
+    throw new TrainError('ADAPTER_NOT_FOUND', `adapter_uri adapter slug "${parsed.id}" was not found.`, {
+      must_obey: true
+    });
+  }
+  return buildAdapterUri(resolved.layerUuid);
+}

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -18,6 +18,7 @@ import {
 import { kairosTrainSimilarAdapterFound, mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpToolOutputSize } from '../services/metrics/mcp-metrics.js';
 import { mcpLooseToolInput } from './mcp-loose-input-schema.js';
 import { mcpToolInputValidationErrorResult } from './mcp-tool-input-teaching.js';
+import { resolveCanonicalAdapterUriForArtifact } from './train-artifact-adapter-uri.js';
 
 interface RegisterTrainOptions {
   toolName?: string;
@@ -96,13 +97,31 @@ async function resolveContentForTrain(
       { must_obey: true }
     );
   }
-  const adapterMatch = /^kairos:\/\/adapter\/([0-9a-f-]{36})$/i.exec(sourceUri);
-  if (!adapterMatch?.[1]) {
-    throw new TrainError('INVALID_SOURCE_URI', 'source_adapter_uri must be kairos://adapter/{uuid}', {
+  let adapterId = '';
+  try {
+    const parsed = parseKairosUri(sourceUri);
+    if (parsed.kind !== 'adapter') {
+      throw new TrainError('INVALID_SOURCE_URI', 'source_adapter_uri must be kairos://adapter/{uuid|slug}', {
+        must_obey: true
+      });
+    }
+    if (parsed.idKind === 'uuid') {
+      adapterId = parsed.id;
+    } else {
+      const resolved = await qdrantService.findFirstStepMemoryUuidBySlug(parsed.id);
+      if (!resolved.layerUuid) {
+        throw new TrainError('SOURCE_ADAPTER_NOT_FOUND', `source_adapter_uri adapter slug "${parsed.id}" was not found.`, {
+          must_obey: true
+        });
+      }
+      adapterId = resolved.layerUuid;
+    }
+  } catch (error) {
+    if (error instanceof TrainError) throw error;
+    throw new TrainError('INVALID_SOURCE_URI', 'source_adapter_uri must be kairos://adapter/{uuid|slug}', {
       must_obey: true
     });
   }
-  const adapterId = adapterMatch[1]!;
   const layers = await qdrantService.getAdapterLayers(adapterId);
   const headUuid = layers[0]?.uuid ?? adapterId;
   const dump = await executeDump(memoryStore, qdrantService, {
@@ -130,6 +149,10 @@ export async function executeTrain(
       must_obey: true
     });
   }
+  const isArtifactTrain = typeof input.mime === 'string' && input.mime.trim().length > 0 && input.mime !== 'text/markdown';
+  const canonicalAdapterUri = isArtifactTrain
+    ? await resolveCanonicalAdapterUriForArtifact(input.adapter_uri, qdrantService)
+    : input.adapter_uri;
   const forkedFromSource = typeof input.source_adapter_uri === 'string' && input.source_adapter_uri.trim().length > 0;
   const storePayload = {
     content,
@@ -139,7 +162,7 @@ export async function executeTrain(
     ...(input.space !== undefined && { space: input.space }),
     ...(input.mime !== undefined && { mime: input.mime }),
     ...(input.artifact_name !== undefined && { artifact_name: input.artifact_name }),
-    ...(input.adapter_uri !== undefined && { adapter_uri: input.adapter_uri }),
+    ...(canonicalAdapterUri !== undefined && { adapter_uri: canonicalAdapterUri }),
     ...(forkedFromSource && { fork_new_adapter: true })
   };
   const result = await executeTrainStore(
@@ -164,9 +187,9 @@ export async function executeTrain(
           /* ignore invalid uri */
         }
       }
-      if (!adapterId && isArtifactRow && typeof input.adapter_uri === 'string' && input.adapter_uri.trim().length > 0) {
+      if (!adapterId && isArtifactRow && typeof canonicalAdapterUri === 'string' && canonicalAdapterUri.trim().length > 0) {
         try {
-          const parsed = parseKairosUri(input.adapter_uri.trim());
+          const parsed = parseKairosUri(canonicalAdapterUri.trim());
           if (parsed.kind === 'adapter') adapterId = parsed.id;
         } catch {
           /* ignore invalid uri */
@@ -176,9 +199,19 @@ export async function executeTrain(
         adapterId = storedId;
       }
 
+      const tagSlug = Array.isArray(item.tags)
+        ? item.tags.find((tag) => typeof tag === 'string' && tag.startsWith('artifact:'))?.slice('artifact:'.length)
+        : undefined;
+      const artifactSlug = typeof memory?.artifact?.slug === 'string'
+        ? memory.artifact.slug.trim()
+        : (typeof tagSlug === 'string' ? tagSlug.trim() : '');
+      const artifactUri = artifactSlug.length > 0
+        ? `kairos://artifact/${artifactSlug}`
+        : `kairos://artifact/${storedId}`;
+
       return {
         uri: item.content_type && item.content_type !== 'text/markdown'
-          ? `kairos://artifact/${storedId}`
+          ? artifactUri
           : buildLayerUri(storedId || ''),
         ...(item.layer_uuid && { layer_uuid: item.layer_uuid }),
         ...(item.artifact_uuid && { artifact_uuid: item.artifact_uuid }),

--- a/src/tools/train_schema.ts
+++ b/src/tools/train_schema.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
+import { ADAPTER_URI_INPUT_REGEX } from './kairos-uri.js';
 
 const adapterUriSchema = z
   .string()
-  .regex(/^kairos:\/\/adapter\/[0-9a-f-]{36}$/i, 'must match kairos://adapter/{uuid}');
+  .regex(ADAPTER_URI_INPUT_REGEX, 'must match kairos://adapter/{uuid|slug}');
 
 const sourceAdapterUriSchema = z
   .string()
-  .regex(/^kairos:\/\/adapter\/[0-9a-f-]{36}$/i, 'must match kairos://adapter/{uuid}')
+  .regex(ADAPTER_URI_INPUT_REGEX, 'must match kairos://adapter/{uuid|slug}')
   .describe('Optional fork source: export markdown from this adapter, then train into target space');
 
 export const trainInputSchema = z

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -107,6 +107,12 @@ export interface Memory {
   llm_model_id: string;
   created_at: string;
   content_type?: string;
+  artifact?: {
+    slug: string;
+    version: string;
+    name: string;
+    sha256: string;
+  };
   adapter?: AdapterInfo;
   inference_contract?: InferenceContractDefinition;
 }

--- a/tests/integration/kairos-train-artifact.test.ts
+++ b/tests/integration/kairos-train-artifact.test.ts
@@ -50,10 +50,21 @@ describe('Train artifact storage and source export', () => {
 
   test('stores artifact outside activate search and exports via source format', async () => {
     const ts = Date.now().toString();
+    const adapterSlug = `artifact-parent-${ts}`;
     const artifactName = `artifact-${ts}.py`;
-    const artifactBody = `print("artifact-${ts}")`;
+    const artifactSlug = `artifact-${ts}-py`;
+    const artifactBody = `#!/usr/bin/env python3
+# kairos-artifact:
+#   slug: ${artifactSlug}
+#   version: 1
 
-    const adapterMarkdown = `# Artifact Parent ${ts}
+print("artifact-${ts}")`;
+
+    const adapterMarkdown = `---
+slug: ${adapterSlug}
+---
+
+# Artifact Parent ${ts}
 
 ## Activation Patterns
 Run when user asks for artifact test.
@@ -88,15 +99,15 @@ Done.`;
         llm_model_id: 'test-model',
         mime: 'text/x-python',
         artifact_name: artifactName,
-        adapter_uri: adapterUri
+        adapter_uri: `kairos://adapter/${adapterSlug}`
       }
     });
     const artifactParsed = parseMcpJson(trainArtifact, 'train artifact');
     expect(artifactParsed.status).toBe('stored');
     const artifactUri = artifactParsed.items?.[0]?.uri as string;
-    expect(artifactUri).toMatch(/^kairos:\/\/artifact\//);
     const artifactUuid = artifactParsed.items?.[0]?.artifact_uuid as string;
     expect(artifactUuid).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(artifactUri).toBe(`kairos://artifact/${artifactSlug}`);
     expect(artifactParsed.items?.[0]?.content_type).toBe('text/x-python');
 
     const qdrantPoint = await postJson<{
@@ -111,6 +122,10 @@ Done.`;
     const point = qdrantPoint.result?.points?.[0];
     expect(point).toBeDefined();
     expect(point?.payload?.['content_type']).toBe('text/x-python');
+    const artifactPayload = point?.payload?.['artifact'] as Record<string, unknown> | undefined;
+    expect(artifactPayload?.['slug']).toBe(artifactSlug);
+    expect(artifactPayload?.['version']).toBe('1');
+    expect(typeof artifactPayload?.['sha256']).toBe('string');
     const vectors = point?.vector ?? {};
     const primary = Object.values(vectors)[0];
     expect(Array.isArray(primary)).toBe(true);
@@ -136,22 +151,49 @@ Done.`;
 
     const exportSourceArtifact = await mcpConnection.client.callTool({
       name: 'export',
-      arguments: { uri: artifactUri, format: 'source' }
+      arguments: { uri: `kairos://artifact/${artifactUuid}`, format: 'source' }
     });
     const sourceArtifactParsed = parseMcpJson(exportSourceArtifact, 'export source artifact');
     expect(sourceArtifactParsed.content_type).toBe('text/x-python');
     expect(sourceArtifactParsed.content).toBe(artifactBody);
 
+    const exportSourceArtifactSlug = await mcpConnection.client.callTool({
+      name: 'export',
+      arguments: { uri: `kairos://artifact/${artifactSlug}`, format: 'source' }
+    });
+    const sourceArtifactSlugParsed = parseMcpJson(exportSourceArtifactSlug, 'export source artifact slug');
+    expect(sourceArtifactSlugParsed.content_type).toBe('text/x-python');
+    expect(sourceArtifactSlugParsed.content).toBe(artifactBody);
+
     const exportSourceAdapter = await mcpConnection.client.callTool({
       name: 'export',
-      arguments: { uri: adapterUri, format: 'source' }
+      arguments: { uri: `kairos://adapter/${adapterSlug}`, format: 'source' }
     });
     const sourceAdapterParsed = parseMcpJson(exportSourceAdapter, 'export source adapter');
     expect(sourceAdapterParsed.content_type).toBe('application/json');
     const listed = JSON.parse(String(sourceAdapterParsed.content)) as {
-      artifacts: Array<{ artifact_uuid: string; uri: string; label: string }>;
+      artifacts: Array<{
+        artifact_uuid: string;
+        uri: string;
+        uuid_uri: string;
+        label: string;
+        slug: string;
+        version: string;
+        sha256: string;
+      }>;
     };
     expect(Array.isArray(listed.artifacts)).toBe(true);
-    expect(listed.artifacts.some((a) => a.artifact_uuid === artifactUuid && a.uri === artifactUri)).toBe(true);
+    expect(
+      listed.artifacts.some(
+        (a) =>
+          a.artifact_uuid === artifactUuid &&
+          a.uri === `kairos://artifact/${artifactSlug}` &&
+          a.uuid_uri === `kairos://artifact/${artifactUuid}` &&
+          a.slug === artifactSlug &&
+          a.version === '1' &&
+          typeof a.sha256 === 'string' &&
+          a.sha256.length > 0
+      )
+    ).toBe(true);
   }, 60000);
 });

--- a/tests/unit/artifact-metadata.test.ts
+++ b/tests/unit/artifact-metadata.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+import { extractArtifactMetadata } from '../../src/services/memory/artifact-metadata.js';
+
+describe('extractArtifactMetadata', () => {
+  it('parses python header after shebang', () => {
+    const content = `#!/usr/bin/env python3
+# kairos-artifact:
+#   slug: sort-jira-py
+#   version: 2
+print("ok")`;
+    expect(extractArtifactMetadata(content, 'fallback.py')).toEqual({
+      slug: 'sort-jira-py',
+      version: '2'
+    });
+  });
+
+  it('falls back to slug from artifact name and default version', () => {
+    const content = 'echo "ok"';
+    expect(extractArtifactMetadata(content, 'verify_briefing.sh')).toEqual({
+      slug: 'verify-briefing-sh',
+      version: '1'
+    });
+  });
+
+  it('rejects invalid slug in header', () => {
+    const content = `# kairos-artifact:
+#   slug: Invalid_Slug
+#   version: 1
+echo "ok"`;
+    expect(() => extractArtifactMetadata(content, 'fallback.sh')).toThrow('Invalid artifact slug');
+  });
+});

--- a/tests/unit/kairos-resource-uri-schemas.test.ts
+++ b/tests/unit/kairos-resource-uri-schemas.test.ts
@@ -6,6 +6,7 @@ const ADAPTER_URI = 'kairos://adapter/00000000-0000-0000-0000-000000000001';
 const ADAPTER_WITH_EXEC = `${ADAPTER_URI}?execution_id=00000000-0000-0000-0000-000000000099`;
 const LAYER_URI = 'kairos://layer/00000000-0000-0000-0000-000000000002';
 const LAYER_WITH_EXEC = `${LAYER_URI}?execution_id=00000000-0000-0000-0000-000000000003`;
+const ARTIFACT_SLUG_URI = 'kairos://artifact/sort-jira-py';
 
 describe('resource URI schemas', () => {
   test('tune rejects execution_id on adapter URIs', () => {
@@ -39,6 +40,15 @@ describe('resource URI schemas', () => {
     const result = exportInputSchema.safeParse({
       uri: LAYER_WITH_EXEC,
       format: 'markdown'
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('export accepts artifact slug URIs', () => {
+    const result = exportInputSchema.safeParse({
+      uri: ARTIFACT_SLUG_URI,
+      format: 'source'
     });
 
     expect(result.success).toBe(true);

--- a/tests/unit/kairos-uri.test.ts
+++ b/tests/unit/kairos-uri.test.ts
@@ -9,4 +9,22 @@ describe('parseKairosUri', () => {
       raw: 'kairos://adapter/create-merge-request'
     });
   });
+
+  test('parses artifact slug URIs', () => {
+    expect(parseKairosUri('kairos://artifact/sort-jira-py')).toEqual({
+      kind: 'artifact',
+      id: 'sort-jira-py',
+      idKind: 'slug',
+      raw: 'kairos://artifact/sort-jira-py'
+    });
+  });
+
+  test('parses artifact uuid URIs', () => {
+    expect(parseKairosUri('kairos://artifact/00000000-0000-0000-0000-000000000001')).toEqual({
+      kind: 'artifact',
+      id: '00000000-0000-0000-0000-000000000001',
+      idKind: 'uuid',
+      raw: 'kairos://artifact/00000000-0000-0000-0000-000000000001'
+    });
+  });
 });

--- a/tests/unit/train-schema-fork.test.ts
+++ b/tests/unit/train-schema-fork.test.ts
@@ -46,6 +46,17 @@ describe('trainInputSchema fork fields', () => {
     expect(bad.success).toBe(false);
   });
 
+  it('accepts adapter slug URI when mime is non-markdown', () => {
+    const ok = trainInputSchema.safeParse({
+      llm_model_id: 'm',
+      content: 'print("ok")',
+      mime: 'text/x-python',
+      artifact_name: 'artifact.py',
+      adapter_uri: 'kairos://adapter/daily-briefing-generation-multi-source-work-dashboard'
+    });
+    expect(ok.success).toBe(true);
+  });
+
   it('rejects unsupported artifact mime in store branch', async () => {
     const memoryStore = {
       storeArtifact: async () => {


### PR DESCRIPTION
## Summary
- implement artifact slug parity across train/export flows by adding artifact slug URI parsing, schema support, and slug resolution in both tooling and Qdrant lookup
- persist artifact metadata (`slug`, `version`, `name`, `sha256`) with duplicate-slug protection and expose slug-first artifact metadata in source listings
- add/extend integration and unit tests for slug + UUID paths, plus include related docs and architecture updates from this branch

## Test plan
- [x] `npm run dev:deploy`
- [x] `npm run dev:test -- tests/integration/kairos-train-artifact.test.ts tests/unit/artifact-metadata.test.ts tests/unit/kairos-uri.test.ts tests/unit/train-schema-fork.test.ts tests/unit/kairos-resource-uri-schemas.test.ts`