### PR TITLE
fix(dev): bootstrap starts server; disable broken mem boot dedup

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -2,7 +2,7 @@
  * Bootstrap entry: installs process error handlers before any app code loads,
  * so uncaught exceptions during import (e.g. [Object: null prototype]) are
  * logged with a readable message instead of Node's default dump.
- * Then dynamically imports the real entry (index.js).
+ * Then dynamically imports index.js and awaits runKairosServer() (argv[1] is bootstrap.js, so index’s isDirectRun() is false).
  * Uses process.stderr (not console) so verify-clean-source allows this file.
  * Handlers are registered immediately (first statements) so they run before any import().
  */
@@ -50,4 +50,5 @@ process.on('unhandledRejection', (reason: unknown) => {
   }
 });
 
-await import('./index.js');
+const { runKairosServer } = await import('./index.js');
+await runKairosServer();

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,11 @@ async function waitForQdrant(memoryStore: MemoryQdrantStore, maxRetries: number 
     throw new Error(`Qdrant did not become available after ${maxRetries} attempts (${maxRetries * intervalMs / 1000}s)`);
 }
 
-/** Boot the HTTP/MCP application (same path as `node dist/index.js`). Safe to import when not the entry script. */
+/**
+ * Boot the HTTP/MCP application.
+ * Invoked when `node dist/index.js` is the process entrypoint, or after `dist/bootstrap.js` loads this module
+ * (bootstrap is not `index.js`, so `isDirectRun()` is false there and bootstrap must call this explicitly).
+ */
 export async function runKairosServer(): Promise<void> {
     try {
         // Install once at startup to capture any background errors/warnings

--- a/src/resources/mem-resources-boot.ts
+++ b/src/resources/mem-resources-boot.ts
@@ -77,7 +77,12 @@ async function readMemFiles(memDir?: string): Promise<Record<string, string>> {
   return memResources;
 }
 
-async function removeAppSpaceSystemProtocolDuplicates(memoryStore: MemoryQdrantStore): Promise<void> {
+/**
+ * Boot dedup helper (currently not called). Compared Qdrant point id to canonical filename UUID;
+ * only layer 1 is remapped to that id, so sibling layers were wrongly deleted as "duplicates".
+ * Re-enable after fixing to dedupe by `adapter.id`, not point id.
+ */
+async function _removeAppSpaceSystemProtocolDuplicates(memoryStore: MemoryQdrantStore): Promise<void> {
   const { client, collection } = memoryStore.getQdrantAccess();
   let totalRemoved = 0;
 
@@ -275,7 +280,7 @@ export async function injectMemResourcesAtBoot(memoryStore: MemoryQdrantStore, o
 
     structuredLogger.info(`[mem-resources-boot] Successfully injected ${injectedCount} mem resources into Qdrant`);
 
-    await removeAppSpaceSystemProtocolDuplicates(memoryStore);
+    // await _removeAppSpaceSystemProtocolDuplicates(memoryStore); // see docstring on _removeAppSpaceSystemProtocolDuplicates
     await assertSystemProtocolStaticUuids(memoryStore);
     structuredLogger.info('[mem-resources-boot] Verified static UUID invariant for bundled system protocols');
 


### PR DESCRIPTION
## Summary
- **`bootstrap`**: After dynamic `import('./index.js')`, await **`runKairosServer()`**. Dev was started with `node dist/bootstrap.js`, so `isDirectRun()` in `index` was false (`argv[1]` is bootstrap, not index) and **nothing listened on :3300**.
- **`mem-resources-boot`**: Comment out the boot-time slug dedup call; it treated every layer whose Qdrant point id ≠ canonical filename UUID as a duplicate, but only layer 1 is remapped to that id, so **layers 2+ were deleted**. Renamed helper to `_removeAppSpaceSystemProtocolDuplicates` with a short doc for a follow-up fix (dedupe by `adapter.id`).

## Verification
- `npm run dev:build`
- `npm run dev:restart` (health passed)
- `npm run dev:test -- tests/integration/kairos-mem-boot-injection.test.ts`