### PR TITLE
fix: add Group Membership mapper to realm default scopes for DCR clients

### DIFF
--- a/helm/kairos-mcp/files/kairos-realm.json
+++ b/helm/kairos-mcp/files/kairos-realm.json
@@ -23,6 +23,33 @@
       ]
     }
   ],
+  "clientScopes": [
+    {
+      "name": "groups",
+      "description": "Group membership claim — required for KAIROS space isolation",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "group-membership",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": ["groups"],
   "clients": [
     {
       "clientId": "kairos-mcp",
@@ -50,6 +77,7 @@
         "http://127.0.0.1:3301",
         "https://__KAIROS_PUBLIC_HOST__"
       ],
+      "defaultClientScopes": ["groups"],
       "attributes": {
         "post.logout.redirect.uris": "http://localhost:3300/auth/continue-signin##http://localhost:3301/auth/continue-signin##http://127.0.0.1:3300/auth/continue-signin##http://127.0.0.1:3301/auth/continue-signin##https://__KAIROS_PUBLIC_HOST__/auth/continue-signin",
         "logout.confirmation.enabled": "false"
@@ -64,6 +92,7 @@
       "directAccessGrantsEnabled": true,
       "redirectUris": ["http://localhost:*", "http://localhost:*/callback", "http://localhost:*/callback/*", "http://localhost:*/*", "http://127.0.0.1:*", "http://127.0.0.1:*/callback", "http://127.0.0.1:*/callback/*", "https://__KAIROS_PUBLIC_HOST__/*"],
       "webOrigins": ["http://localhost", "https://__KAIROS_PUBLIC_HOST__"],
+      "defaultClientScopes": ["groups"],
       "attributes": {
         "pkce.code.challenge.method": "S256"
       }

--- a/src/http/bearer-validate.ts
+++ b/src/http/bearer-validate.ts
@@ -83,7 +83,14 @@ async function fetchGroupsFromOidcUserinfo(issuer: string, accessToken: string):
       return [];
     }
     const body = (await res.json()) as Record<string, unknown>;
-    return extractGroupsFromPayload(body);
+    const groups = extractGroupsFromPayload(body);
+    if (groups.length === 0) {
+      structuredLogger.info(
+        `[auth] userinfo returned no groups — the issuing client likely lacks a Group Membership protocol mapper. ` +
+        `Add the mapper to the realm's default client scope or the specific client to enable group spaces for DCR/MCP tokens.`
+      );
+    }
+    return groups;
   } catch (err) {
     structuredLogger.debug(
       `[auth] userinfo groups: fetch failed url=${url} err=${err instanceof Error ? err.message : String(err)}`

--- a/tests/unit/bearer-validate-group-fallback.test.ts
+++ b/tests/unit/bearer-validate-group-fallback.test.ts
@@ -80,4 +80,32 @@ describe('validateBearerToken group extraction', () => {
     expect(auth).not.toBeNull();
     expect(auth?.groups).toEqual(['/SHARED/PE-TEAM']);
   });
+
+  test('returns empty groups when DCR token has no groups and userinfo also lacks groups mapper', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sub: 'user-1',
+        email_verified: true,
+        name: 'Test User',
+        preferred_username: 'test@example.com',
+        email: 'test@example.com'
+      })
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const issuer = 'https://kc.example/realms/kairos';
+    const token = tokenFor({
+      iss: issuer,
+      sub: 'user-1',
+      aud: ['account'],
+      azp: '01361763-d756-4c79-a124-0180e58e3f8e',
+      scope: 'openid email profile'
+    });
+
+    const auth = await validateBearerToken(token, [issuer], ['kairos-mcp', 'kairos-cli', 'account']);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(auth).not.toBeNull();
+    expect(auth?.groups).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- Group spaces (e.g. `/shared/hackaton`) were missing from `spaces` tool output when called via MCP (Cursor), while the CLI returned them correctly.
- Root cause: Cursor authenticates via a Dynamically Client Registered (DCR) OAuth client. The Keycloak realm's default client scopes did not include a Group Membership protocol mapper, so DCR tokens had no `groups` claim — and userinfo also returned none.
- Adds the `groups` client scope with `oidc-group-membership-mapper` to the realm import as a `defaultDefaultClientScope`, ensuring all clients (including DCR) inherit it.
- Adds info-level logging when userinfo returns empty groups (operator guidance).
- Adds regression test for the DCR no-groups scenario.

## Diagnosis

1. `AUTH_TRACE=true` revealed the Bearer token from Cursor's DCR client (`azp: 01361763-...`) had `scope: "openid email profile"` but no `groups` claim.
2. The `fetchGroupsFromOidcUserinfo` fallback was called (confirmed via code tracing) but also returned no groups — because Keycloak scopes userinfo claims per-client, and DCR clients had no Group Membership mapper.
3. The CLI worked because `kairos-cli` (manually configured client) had the mapper.

## Test plan

- [x] Unit test passes: `node --experimental-vm-modules npx jest tests/unit/bearer-validate-group-fallback.test.ts`
- [ ] After Helm deploy: re-authenticate MCP client → `spaces` returns group spaces
- [ ] Existing CLI flow (`kairos spaces`) continues to work
- [ ] DCR clients created after realm reimport get groups in tokens