### PR TITLE
fix(helm): add groups client scope as realm default for DCR clients

### DIFF
--- a/helm/kairos-mcp/files/kairos-realm.json
+++ b/helm/kairos-mcp/files/kairos-realm.json
@@ -24,6 +24,33 @@
     }
   ],
   "defaultGroups": ["/shared/operator"],
+  "clientScopes": [
+    {
+      "name": "kairos-groups",
+      "description": "Group membership claim — required for KAIROS space isolation",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "kairos-oidc-groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": ["kairos-groups"],
   "clients": [
     {
       "clientId": "kairos-mcp",


### PR DESCRIPTION
## Summary

- DCR clients (e.g. Cursor MCP) don't inherit per-client `protocolMappers` — they only get realm-level default client scopes
- Adds `kairos-groups` client scope with `oidc-group-membership-mapper` (matching `deploy-configure-keycloak-realms.py` behavior)
- Registers it as `defaultDefaultClientScopes` so DCR clients get the `groups` claim automatically
- Fixes: `spaces` tool via MCP returning only Personal + Kairos app, missing group spaces

## Context

Per-client mappers (added in 06c678d) cover `kairos-mcp` and `kairos-cli` but not dynamically registered OAuth clients. The scope name (`kairos-groups`) and mapper name (`kairos-oidc-groups`) align with `deploy-configure-keycloak-realms.py`.

## Test plan

- [ ] Deploy with updated realm import → DCR client tokens include `groups` claim
- [ ] `spaces` via MCP returns group spaces after re-authentication