### PR TITLE
feat(cli): add --timeout and --retries global options

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -63,6 +63,27 @@ kairos search "release checklist"
 
 When the server requires auth, the CLI uses a stored Bearer token.
 
+### Timeout and retry
+
+By default each HTTP request times out after **15 seconds** and failed requests
+are retried up to **2 times** on transient network errors (connection refused,
+reset, timeout). Both can be overridden:
+
+```bash
+kairos --timeout 120 train ./adapters --force --recursive
+kairos --timeout 120 --retries 5 train ./adapters --force --recursive
+kairos --retries 0 spaces   # disable retry, fail fast
+```
+
+Environment variables (useful in CI / scripts):
+
+| Variable | Description |
+|----------|-------------|
+| `KAIROS_TIMEOUT_MS` | Request timeout in milliseconds (e.g. `120000`) |
+| `KAIROS_RETRIES` | Max network-error retries (e.g. `5`, or `0` to disable) |
+
+Precedence: CLI flag > env var > default.
+
 ### Storage model
 
 The CLI and MCP hosts share the same local config path:

--- a/src/cli/api-client.ts
+++ b/src/cli/api-client.ts
@@ -20,6 +20,17 @@ import type { DeleteOutput } from '../tools/delete_schema.js';
 import { downloadExportRef } from './download-export-ref.js';
 
 const PROACTIVE_REFRESH_SKEW_SEC = 60;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RETRIES = 2;
+
+export interface ApiClientOptions {
+    baseUrl?: string | undefined;
+    openInBrowser?: boolean | undefined;
+    /** Request timeout in milliseconds (default: 15 000). */
+    timeoutMs?: number | undefined;
+    /** Max retries on transient network errors (default: 2). Set 0 to disable. */
+    maxRetries?: number | undefined;
+}
 
 type SpacesOutput = {
     spaces: Array<{
@@ -31,15 +42,34 @@ type SpacesOutput = {
     }>;
 };
 
+function isRetryableNetworkError(err: unknown): boolean {
+    if (err instanceof Error) {
+        if (err.name === 'AbortError') return true;
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code && ['ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ENOTFOUND', 'UND_ERR_CONNECT_TIMEOUT'].includes(code)) {
+            return true;
+        }
+        if (err.name === 'TypeError' && /fetch|network/i.test(err.message)) return true;
+    }
+    return false;
+}
+
 export class ApiClient {
     private baseUrl: string;
     private openInBrowser: boolean;
+    private timeoutMs: number;
+    private maxRetries: number;
     /** Coalesces concurrent refresh_token exchanges for this client instance. */
     private refreshInFlight: Promise<boolean> | null = null;
 
-    constructor(baseUrl?: string, openInBrowser?: boolean) {
-        // Precedence: explicit parameter (from global --url), then env, then config file, then default.
-        const explicit = baseUrl?.trim();
+    constructor(baseUrlOrOpts?: string | ApiClientOptions, openInBrowser?: boolean) {
+        let opts: ApiClientOptions;
+        if (typeof baseUrlOrOpts === 'string' || baseUrlOrOpts === undefined) {
+            opts = { baseUrl: baseUrlOrOpts, openInBrowser };
+        } else {
+            opts = baseUrlOrOpts;
+        }
+        const explicit = opts.baseUrl?.trim();
         const configUrl = getDefaultApiUrlFromFile();
         const resolvedBaseUrl =
             explicit ||
@@ -47,7 +77,9 @@ export class ApiClient {
             configUrl ||
             getApiUrl();
         this.baseUrl = normalizeAndValidateApiBaseUrl(resolvedBaseUrl);
-        this.openInBrowser = !isBrowserDisabled() && (openInBrowser !== false);
+        this.openInBrowser = !isBrowserDisabled() && (opts.openInBrowser !== false);
+        this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+        this.maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
     }
 
     private async sleep(ms: number): Promise<void> {
@@ -107,116 +139,129 @@ export class ApiClient {
             defaultHeaders['Authorization'] = `Bearer ${bearer}`;
         }
 
-        const requestTimeoutMs = 15_000;
-        const ac = new AbortController();
-        const timeoutId = setTimeout(() => ac.abort(), requestTimeoutMs);
-        let response: Response;
-        try {
-            response = await fetch(url, {
-                ...options,
-                signal: ac.signal,
-                headers: {
-                    ...defaultHeaders,
-                    ...(options.headers as Record<string, string> || {}),
-                },
-            });
-        } catch (err) {
+        const requestTimeoutMs = this.timeoutMs;
+        let lastErr: unknown;
+        const maxAttempts = 1 + this.maxRetries;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            const ac = new AbortController();
+            const timeoutId = setTimeout(() => ac.abort(), requestTimeoutMs);
+            let response: Response;
+            try {
+                response = await fetch(url, {
+                    ...options,
+                    signal: ac.signal,
+                    headers: {
+                        ...defaultHeaders,
+                        ...(options.headers as Record<string, string> || {}),
+                    },
+                });
+            } catch (err) {
+                clearTimeout(timeoutId);
+                if (isRetryableNetworkError(err) && attempt < maxAttempts) {
+                    const delayMs = Math.min(1000 * 2 ** (attempt - 1), 10_000) + Math.random() * 200;
+                    const label = err instanceof Error && err.name === 'AbortError'
+                        ? `timed out after ${requestTimeoutMs / 1000}s`
+                        : (err instanceof Error ? err.message : 'network error');
+                    process.stderr.write(
+                        `[kairos] retry ${attempt}/${this.maxRetries}: ${label} — waiting ${(delayMs / 1000).toFixed(1)}s\n`
+                    );
+                    await this.sleep(delayMs);
+                    lastErr = err;
+                    continue;
+                }
+                if (err instanceof Error && err.name === 'AbortError') {
+                    throw new Error(`Request to ${url} timed out after ${requestTimeoutMs / 1000}s`);
+                }
+                throw err;
+            }
             clearTimeout(timeoutId);
-            if (err instanceof Error && err.name === 'AbortError') {
-                throw new Error(`Request to ${url} timed out after ${requestTimeoutMs / 1000}s`);
+
+            if (response.status === 429 && rateLimitRetryCount < 2) {
+                const retryAfterSeconds = Number(response.headers.get('Retry-After') ?? '1');
+                const retryDelayMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+                    ? retryAfterSeconds * 1000
+                    : 1000;
+                await this.sleep(retryDelayMs);
+                return this.request<T>(
+                    endpoint,
+                    options,
+                    isRetryAfterLogin,
+                    isRetryAfterRefresh,
+                    preLoginIfTokenMissing,
+                    rateLimitRetryCount + 1
+                );
             }
-            throw err;
-        }
-        clearTimeout(timeoutId);
 
-        if (response.status === 429 && rateLimitRetryCount < 2) {
-            const retryAfterSeconds = Number(response.headers.get('Retry-After') ?? '1');
-            const retryDelayMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
-                ? retryAfterSeconds * 1000
-                : 1000;
-            await this.sleep(retryDelayMs);
-            return this.request<T>(
-                endpoint,
-                options,
-                isRetryAfterLogin,
-                isRetryAfterRefresh,
-                preLoginIfTokenMissing,
-                rateLimitRetryCount + 1
-            );
-        }
+            const data = await response.json().catch(() => {
+                throw new Error(`Failed to parse response from ${url}`);
+            });
 
-        const data = await response.json().catch(() => {
-            throw new Error(`Failed to parse response from ${url}`);
-        });
-
-        if (!response.ok) {
-            const errorData = data as {
-                message?: string;
-                error?: string;
-                login_url?: string;
-                available_spaces?: unknown;
-            };
-            let msg = errorData.message || errorData.error || `HTTP ${response.status}: ${response.statusText}`;
-            if (
-                (errorData.error === 'SPACE_NOT_FOUND' || errorData.error === 'SPACE_READ_ONLY') &&
-                Array.isArray(errorData.available_spaces)
-            ) {
-                const availableSpaces = errorData.available_spaces.filter((entry): entry is string => typeof entry === 'string');
-                if (availableSpaces.length > 0) {
-                    msg += `\nAvailable writable spaces: ${availableSpaces.join(', ')}`;
-                }
-            }
-            if (response.status === 401) {
-                const cfg401 = await readConfig(this.baseUrl);
-                if (!isRetryAfterRefresh && cfg401.refreshToken) {
-                    const refreshed = await this.runRefreshWithSingleflight(cfg401.refreshToken);
-                    if (refreshed) {
-                        return this.request<T>(
-                            endpoint,
-                            options,
-                            isRetryAfterLogin,
-                            true,
-                            preLoginIfTokenMissing,
-                            rateLimitRetryCount
-                        );
+            if (!response.ok) {
+                const errorData = data as {
+                    message?: string;
+                    error?: string;
+                    login_url?: string;
+                    available_spaces?: unknown;
+                };
+                let msg = errorData.message || errorData.error || `HTTP ${response.status}: ${response.statusText}`;
+                if (
+                    (errorData.error === 'SPACE_NOT_FOUND' || errorData.error === 'SPACE_READ_ONLY') &&
+                    Array.isArray(errorData.available_spaces)
+                ) {
+                    const availableSpaces = errorData.available_spaces.filter((entry): entry is string => typeof entry === 'string');
+                    if (availableSpaces.length > 0) {
+                        msg += `\nAvailable writable spaces: ${availableSpaces.join(', ')}`;
                     }
                 }
-                if (this.openInBrowser && !isRetryAfterLogin) {
-                    const ok = await loginWithBrowser(this.baseUrl);
-                    if (ok) {
-                        return this.request<T>(
-                            endpoint,
-                            options,
-                            true,
-                            false,
-                            preLoginIfTokenMissing,
-                            rateLimitRetryCount
-                        );
+                if (response.status === 401) {
+                    const cfg401 = await readConfig(this.baseUrl);
+                    if (!isRetryAfterRefresh && cfg401.refreshToken) {
+                        const refreshed = await this.runRefreshWithSingleflight(cfg401.refreshToken);
+                        if (refreshed) {
+                            return this.request<T>(
+                                endpoint,
+                                options,
+                                isRetryAfterLogin,
+                                true,
+                                preLoginIfTokenMissing,
+                                rateLimitRetryCount
+                            );
+                        }
                     }
-                }
-                if (errorData.login_url) {
-                    const loginUrl = rewriteLoginUrlRedirectToApiBase(errorData.login_url, this.baseUrl);
-                    throw new AuthRequiredError(`${msg}\n\nLog in at:\n${loginUrl}`, loginUrl);
+                    if (this.openInBrowser && !isRetryAfterLogin) {
+                        const ok = await loginWithBrowser(this.baseUrl);
+                        if (ok) {
+                            return this.request<T>(
+                                endpoint,
+                                options,
+                                true,
+                                false,
+                                preLoginIfTokenMissing,
+                                rateLimitRetryCount
+                            );
+                        }
+                    }
+                    if (errorData.login_url) {
+                        const loginUrl = rewriteLoginUrlRedirectToApiBase(errorData.login_url, this.baseUrl);
+                        throw new AuthRequiredError(`${msg}\n\nLog in at:\n${loginUrl}`, loginUrl);
+                    }
+                    throw new Error(msg);
                 }
                 throw new Error(msg);
             }
-            throw new Error(msg);
-        }
 
-        return data as T;
+            return data as T;
+        }
+        throw lastErr instanceof Error
+            ? lastErr
+            : new Error(`Request to ${url} failed after ${maxAttempts} attempts`);
     }
     async activate(query: string): Promise<ActivateOutput> {
-        return this.request<ActivateOutput>('/api/activate', {
-            method: 'POST',
-            body: JSON.stringify({ query }),
-        });
+        return this.request<ActivateOutput>('/api/activate', { method: 'POST', body: JSON.stringify({ query }) });
     }
 
     async forward(uri: string, solution?: unknown): Promise<ForwardOutput> {
-        return this.request<ForwardOutput>('/api/forward', {
-            method: 'POST',
-            body: JSON.stringify({ uri, solution }),
-        });
+        return this.request<ForwardOutput>('/api/forward', { method: 'POST', body: JSON.stringify({ uri, solution }) });
     }
 
     async train(
@@ -224,55 +269,27 @@ export class ApiClient {
         options?: { llmModelId?: string; force?: boolean; space?: string },
         isRetryAfterLogin = false
     ): Promise<TrainOutput> {
-        const headers: Record<string, string> = {
-            'Content-Type': 'text/markdown',
-        };
-
-        if (options?.llmModelId) {
-            headers['x-llm-model-id'] = options.llmModelId;
-        }
-
-        if (options?.force) {
-            headers['x-force-update'] = 'true';
-        }
-
+        const headers: Record<string, string> = { 'Content-Type': 'text/markdown' };
+        if (options?.llmModelId) headers['x-llm-model-id'] = options.llmModelId;
+        if (options?.force) headers['x-force-update'] = 'true';
         if (typeof options?.space === 'string' && options.space.trim().length > 0) {
             headers['x-space'] = options.space.trim();
         }
-
-        return this.request<TrainOutput>(
-            '/api/train/raw',
-            {
-                method: 'POST',
-                headers,
-                body: markdown,
-            },
-            isRetryAfterLogin,
-            false,
-            false
-        );
+        return this.request<TrainOutput>('/api/train/raw', { method: 'POST', headers, body: markdown }, isRetryAfterLogin, false, false);
     }
 
     async tune(
         uris: string[],
-        opts?: {
-            markdownDoc?: SafeMarkdownUpload[];
-            updates?: Record<string, unknown>;
-            space?: string;
-        }
+        opts?: { markdownDoc?: SafeMarkdownUpload[]; updates?: Record<string, unknown>; space?: string }
     ): Promise<TuneOutput> {
         const body: Record<string, unknown> = { uris };
         if (opts?.markdownDoc) body['content'] = opts.markdownDoc;
         if (opts?.updates) body['updates'] = opts.updates;
         const sp = typeof opts?.space === 'string' ? opts.space.trim() : '';
         if (sp.length > 0) body['space'] = sp;
-        return this.request<TuneOutput>('/api/tune', {
-            method: 'POST',
-            body: JSON.stringify(body),
-        });
+        return this.request<TuneOutput>('/api/tune', { method: 'POST', body: JSON.stringify(body) });
     }
 
-    /** JSON body train (space, source_adapter_uri fork, etc.); distinct from markdown POST /api/train/raw. */
     async trainJson(body: {
         llm_model_id: string;
         force_update?: boolean;
@@ -281,60 +298,38 @@ export class ApiClient {
         content?: string;
         protocol_version?: string;
     }): Promise<TrainOutput> {
-        return this.request<TrainOutput>('/api/train', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-        });
+        return this.request<TrainOutput>('/api/train', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
     }
 
     async delete(uris: string[]): Promise<DeleteOutput> {
-        return this.request<DeleteOutput>('/api/delete', {
-            method: 'POST',
-            body: JSON.stringify({ uris }),
-        });
+        return this.request<DeleteOutput>('/api/delete', { method: 'POST', body: JSON.stringify({ uris }) });
     }
 
     async spaces(options?: { include_adapter_titles?: boolean }): Promise<SpacesOutput> {
         const body: Record<string, unknown> = {};
-        if (options?.include_adapter_titles === true) {
-            body['include_adapter_titles'] = true;
-        }
-        return this.request<SpacesOutput>('/api/spaces', {
-            method: 'POST',
-            body: JSON.stringify(body),
-        });
+        if (options?.include_adapter_titles === true) body['include_adapter_titles'] = true;
+        return this.request<SpacesOutput>('/api/spaces', { method: 'POST', body: JSON.stringify(body) });
     }
 
     async reward(
-        uri: string,
-        outcome: 'success' | 'failure',
-        feedback: string,
+        uri: string, outcome: 'success' | 'failure', feedback: string,
         options?: { score?: number; rater?: string; rubricVersion?: string; llmModelId?: string }
     ): Promise<RewardOutput> {
         return this.request<RewardOutput>('/api/reward', {
             method: 'POST',
             body: JSON.stringify({
-                uri,
-                outcome,
-                feedback,
-                score: options?.score,
-                rater: options?.rater,
-                rubric_version: options?.rubricVersion,
-                llm_model_id: options?.llmModelId,
+                uri, outcome, feedback,
+                score: options?.score, rater: options?.rater,
+                rubric_version: options?.rubricVersion, llm_model_id: options?.llmModelId,
             }),
         });
     }
 
     async export(input: ExportInput): Promise<ExportOutput> {
-        return this.request<ExportOutput>('/api/export', {
-            method: 'POST',
-            body: JSON.stringify(input),
-        });
+        return this.request<ExportOutput>('/api/export', { method: 'POST', body: JSON.stringify(input) });
     }
 
     async downloadExportRef(urlOrPath: string): Promise<{ data: Buffer; filename?: string; contentType?: string }> {
         return downloadExportRef(this.baseUrl, urlOrPath);
     }
-
 }

--- a/src/cli/client-factory.ts
+++ b/src/cli/client-factory.ts
@@ -1,0 +1,55 @@
+/**
+ * Factory for creating ApiClient instances with resolved global CLI options.
+ * Separated from program.ts to avoid circular imports with command modules.
+ */
+
+import type { Command } from 'commander';
+import { ApiClient, type ApiClientOptions } from './api-client.js';
+import { getResolvedApiBaseFromProgram } from './resolve-api-base.js';
+
+/**
+ * Resolve timeout and retry settings from program global options + environment variables.
+ * Precedence: CLI flag > env var > default.
+ */
+export function resolveClientOptions(program: Command): ApiClientOptions {
+    const g = program.optsWithGlobals?.() ?? program.opts();
+
+    let timeoutMs: number | undefined;
+    const rawTimeout = g['timeout'] as string | undefined;
+    if (rawTimeout !== undefined) {
+        const sec = Number(rawTimeout);
+        if (Number.isFinite(sec) && sec > 0) timeoutMs = sec * 1000;
+    }
+    if (timeoutMs === undefined) {
+        const envTimeout = process.env['KAIROS_TIMEOUT_MS'];
+        if (envTimeout) {
+            const ms = Number(envTimeout);
+            if (Number.isFinite(ms) && ms > 0) timeoutMs = ms;
+        }
+    }
+
+    let maxRetries: number | undefined;
+    const rawRetries = g['retries'] as string | undefined;
+    if (rawRetries !== undefined) {
+        const n = Number(rawRetries);
+        if (Number.isFinite(n) && n >= 0) maxRetries = n;
+    }
+    if (maxRetries === undefined) {
+        const envRetries = process.env['KAIROS_RETRIES'];
+        if (envRetries) {
+            const n = Number(envRetries);
+            if (Number.isFinite(n) && n >= 0) maxRetries = n;
+        }
+    }
+
+    return {
+        baseUrl: getResolvedApiBaseFromProgram(program),
+        timeoutMs,
+        maxRetries,
+    };
+}
+
+/** Create an ApiClient with resolved global options (--url, --timeout, --retries). */
+export function createClientFromProgram(program: Command): ApiClient {
+    return new ApiClient(resolveClientOptions(program));
+}

--- a/src/cli/commands/attest.ts
+++ b/src/cli/commands/attest.ts
@@ -3,11 +3,10 @@
  */
 
 import { Command } from 'commander';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
 import { writeError, writeJson } from '../output.js';
 import { formatNextCallBlock } from '../format-next-call.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 export function rewardCommand(program: Command): void {
     program
@@ -40,7 +39,7 @@ export function rewardCommand(program: Command): void {
                     return;
                 }
 
-                const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+                const client = createClientFromProgram(program);
                 
                 const rewardOptions: { score?: number; rater?: string; rubricVersion?: string; llmModelId?: string } = {};
                 if (score !== undefined) {

--- a/src/cli/commands/begin.ts
+++ b/src/cli/commands/begin.ts
@@ -3,11 +3,10 @@
  */
 
 import { Command } from 'commander';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
 import { writeJson } from '../output.js';
 import { formatNextCallBlock } from '../format-next-call.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 export function forwardCommand(program: Command): void {
     program
@@ -17,7 +16,7 @@ export function forwardCommand(program: Command): void {
         .option('--solution <json>', 'Forward solution as JSON string')
         .action(async (uri: string, options: { solution?: string }) => {
             try {
-                const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+                const client = createClientFromProgram(program);
                 const solution = options.solution ? JSON.parse(options.solution) : undefined;
                 const response = await client.forward(uri, solution);
                 const nextCall = formatNextCallBlock(response);

--- a/src/cli/commands/cli-train.ts
+++ b/src/cli/commands/cli-train.ts
@@ -11,11 +11,10 @@
 import { Command } from 'commander';
 import { readdirSync, statSync } from 'fs';
 import { join, relative, resolve } from 'path';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
 import { writeError, writeJson } from '../output.js';
 import { readMarkdownUploadFromFile } from '../upload-guards.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 /** Directory batch skips `README.md` (human docs); single-file `train path/to/README.md` still works. */
 function isReadmeMarkdownFileName(name: string): boolean {
@@ -77,7 +76,7 @@ export function trainCliCommand(program: Command): void {
         }
       ) => {
         try {
-          const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+          const client = createClientFromProgram(program);
           const src = typeof options.sourceAdapterUri === 'string' ? options.sourceAdapterUri.trim() : '';
           if (src.length > 0) {
             if (target) {

--- a/src/cli/commands/delete.ts
+++ b/src/cli/commands/delete.ts
@@ -3,11 +3,10 @@
  */
 
 import { Command } from 'commander';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
 import { writeJson } from '../output.js';
 import { DELETE_COMMAND_DESCRIPTION, DELETE_COMMAND_URI_ARGUMENT_DESCRIPTION } from './delete-metadata.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 export function deleteCommand(program: Command): void {
     program
@@ -16,7 +15,7 @@ export function deleteCommand(program: Command): void {
         .argument('<uris...>', DELETE_COMMAND_URI_ARGUMENT_DESCRIPTION)
         .action(async (uris: string[]) => {
             try {
-                const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+                const client = createClientFromProgram(program);
                 const response = await client.delete(uris);
                 writeJson(response);
             } catch (error) {

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,10 +1,9 @@
 import { Command } from 'commander';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
 import type { ExportInput } from '../../tools/export_schema.js';
 import { writeJson, writeMarkdown, writeStderr } from '../output.js';
 import { resolveSkillZipOutputPath, writeExportedSkillZipToFile } from '../skill-zip-local-write.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 interface ExportCliOptions {
     format?: string;
@@ -101,7 +100,7 @@ export function exportCommand(program: Command): void {
             ) => {
                 try {
                     const input = buildExportInput(uri, options);
-                    const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+                    const client = createClientFromProgram(program);
                     const response = await client.export(input);
                     if (options.output === 'json' || options.jsonOnly || options.noDownload) {
                         writeJson(response);

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -3,11 +3,10 @@
  */
 
 import { Command } from 'commander';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
 import { writeJson } from '../output.js';
 import { formatNextCallBlock } from '../format-next-call.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 export function activateCommand(program: Command): void {
     program
@@ -16,7 +15,7 @@ export function activateCommand(program: Command): void {
         .argument('<query...>', 'Search query (multiple words allowed)')
         .action(async (query: string[]) => {
             try {
-                const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+                const client = createClientFromProgram(program);
                 const response = await client.activate(query.join(' '));
                 const nextCall = formatNextCallBlock(response);
                 writeJson(nextCall ? { ...response, cli_next_call: nextCall } : response);

--- a/src/cli/commands/spaces.ts
+++ b/src/cli/commands/spaces.ts
@@ -1,8 +1,7 @@
 import { Command } from 'commander';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
 import { writeJson } from '../output.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 /**
  * spaces command
@@ -17,7 +16,7 @@ export function spacesCommand(program: Command): void {
     )
     .action(async (options: { includeAdapterTitles?: boolean }) => {
       try {
-        const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+        const client = createClientFromProgram(program);
         const response = await client.spaces({
           include_adapter_titles: Boolean(options.includeAdapterTitles)
         });

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -3,11 +3,10 @@
  */
 
 import { Command } from 'commander';
-import { ApiClient } from '../api-client.js';
 import { handleApiError, isBrowserDisabled } from '../auth-error.js';
-import { getResolvedApiBaseFromProgram } from '../resolve-api-base.js';
 import { writeError, writeJson } from '../output.js';
 import { readMarkdownUploadFromFile, type SafeMarkdownUpload } from '../upload-guards.js';
+import { createClientFromProgram } from '../client-factory.js';
 
 export function updateCommand(program: Command): void {
     program
@@ -33,7 +32,7 @@ export function updateCommand(program: Command): void {
             }
         ) => {
             try {
-                const client = new ApiClient(getResolvedApiBaseFromProgram(program));
+                const client = createClientFromProgram(program);
                 let markdownDoc: SafeMarkdownUpload[] | undefined;
                 let updates: Record<string, any> | undefined;
                 const rawSpace = typeof options.space === 'string' ? options.space.trim() : '';

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -14,6 +14,8 @@ import { tokenCommand } from './commands/token.js';
 import { serveCommand } from './commands/serve.js';
 import { getCliApiUrlDefault } from './config.js';
 
+export { createClientFromProgram, resolveClientOptions } from './client-factory.js';
+
 const loadPackageJson = createRequire(import.meta.url);
 const { version } = loadPackageJson('../../package.json') as { version: string };
 
@@ -34,6 +36,8 @@ export function createProgram(): Command {
     .description('CLI tool for interacting with KAIROS REST API')
     .version(version)
     .option('-u, --url <url>', 'KAIROS API base URL', getCliApiUrlDefault())
+    .option('--timeout <seconds>', 'request timeout in seconds (env: KAIROS_TIMEOUT_MS, default: 15)')
+    .option('--retries <n>', 'max retries on network errors (env: KAIROS_RETRIES, default: 2)')
     .option('--no-browser', 'do not open browser when auth is required (e.g. in tests or scripts)')
     .hook('preAction', (_thisCommand, actionCommand) => {
       // optsWithGlobals merges root --url / --no-browser for nested commands (e.g. kairos --url … train …).


### PR DESCRIPTION
## Summary

- Adds `--timeout <seconds>` global CLI option (env: `KAIROS_TIMEOUT_MS`) to override the default 15s request timeout — needed for bulk `train` with slow backends like Ollama.
- Adds `--retries <n>` global CLI option (env: `KAIROS_RETRIES`, default: 2) with exponential backoff for transient network errors (ECONNREFUSED, ECONNRESET, timeout, etc.) — handles server restart during import gracefully.
- Extracts `client-factory.ts` for clean dependency graph; all commands now use `createClientFromProgram()`.

## Test plan

- [ ] `kairos --timeout 120 train ./adapters --force` uses 120s per request
- [ ] `kairos --retries 0 spaces` disables retry (fast-fail on network error)
- [ ] `KAIROS_TIMEOUT_MS=120000 kairos train ./adapters` equivalent via env
- [ ] Default behavior unchanged (15s timeout, 2 retries on network errors only)
- [ ] `kairos --help` shows both new options