### PR TITLE
fix: patch qdrant fetch compatibility on Node 25

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
 import { qdrantService } from './services/qdrant/index.js';
 import { triggerQdrantSnapshot } from './services/qdrant/snapshots.js';
 import { probeEmbeddingDimension } from './services/embedding/service.js';
+import { installQdrantFetchCompatibility } from './services/qdrant/undici-compat.js';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 // Import system metrics to ensure they're initialized
@@ -72,6 +73,7 @@ async function waitForQdrant(memoryStore: MemoryQdrantStore, maxRetries: number 
  */
 export async function runKairosServer(): Promise<void> {
     try {
+        installQdrantFetchCompatibility();
         // Install once at startup to capture any background errors/warnings
         installGlobalErrorHandlers();
 

--- a/src/services/qdrant/undici-compat.ts
+++ b/src/services/qdrant/undici-compat.ts
@@ -1,0 +1,23 @@
+let patched = false;
+
+/**
+ * Qdrant client currently injects `dispatcher` into fetch init.
+ * On Node 25, that dispatcher from qdrant's undici v6 is not compatible
+ * with the runtime fetch internals and causes `InvalidArgumentError: invalid onError method`.
+ * Strip only that field and preserve all other init options.
+ */
+export function installQdrantFetchCompatibility(): void {
+  if (patched) return;
+  if (typeof globalThis.fetch !== 'function') return;
+
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = ((input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    if (init && typeof init === 'object' && 'dispatcher' in init) {
+      const { dispatcher: _dispatcher, ...rest } = init as RequestInit & { dispatcher?: unknown };
+      return nativeFetch(input, rest);
+    }
+    return nativeFetch(input, init);
+  }) as typeof fetch;
+
+  patched = true;
+}


### PR DESCRIPTION
## Summary
- add a targeted fetch compatibility shim that strips only the incompatible `dispatcher` option before Node 25 fetch calls
- install the shim at server startup before Qdrant health checks run
- keep Node 25 as-is and avoid forcing a runtime bump while preserving current behavior

## Test plan
- [x] Run `npm run dev:deploy`
- [x] Confirm server health check passes and startup completes
- [x] Confirm no Qdrant `invalid onError method` failure on startup