### PR TITLE
release: 4.5.0-rc.0

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -137,7 +137,7 @@ services:
     restart: unless-stopped
 
   app-prod:
-    image: debian777/kairos-mcp:v4.4.0
+    image: debian777/kairos-mcp:v4.5.0-rc.0
     #pull_policy: always
     labels:
       - "environment=prod"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.4.0",
+  "version": "4.5.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "4.4.0",
+      "version": "4.5.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.4.0",
+  "version": "4.5.0-rc.0",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/kairos/SKILL.md
+++ b/skills/kairos/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   → respond.
 
 metadata:
-  version: "4.4.0"
+  version: "4.5.0-rc.0"
   author: kairos-mcp
   always_active: true
 allowed-tools: activate forward reward train tune export delete spaces

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002001.md
@@ -1,6 +1,6 @@
 ---
 slug: create-new-protocol
-version: "4.4.0"
+version: "4.5.0-rc.0"
 title: Create / Review / Refactor KAIROS Protocol
 ---
 

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002002.md
@@ -1,5 +1,5 @@
 ---
-version: "4.4.0"
+version: "4.5.0-rc.0"
 slug: refine-search
 title: Get help refining your search
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002003.md
@@ -1,5 +1,5 @@
 ---
-version: "4.4.0"
+version: "4.5.0-rc.0"
 slug: create-new-protocol-review
 title: Review and Publish New KAIROS Protocol
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002004.md
@@ -1,5 +1,5 @@
 ---
-version: "4.4.0"
+version: "4.5.0-rc.0"
 slug: challenge-type-guide
 title: Challenge Type Selection Guide
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002005.md
@@ -1,5 +1,5 @@
 ---
-version: "4.4.0"
+version: "4.5.0-rc.0"
 slug: phase-critic
 title: Phase Critic
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002006.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002006.md
@@ -1,5 +1,5 @@
 ---
-version: "4.4.0"
+version: "4.5.0-rc.0"
 slug: protocol-linking-guide
 title: Protocol Linking Guide
 ---

--- a/src/embed-docs/mem/00000000-0000-0000-0000-000000002007.md
+++ b/src/embed-docs/mem/00000000-0000-0000-0000-000000002007.md
@@ -1,6 +1,6 @@
 ---
 slug: bulk-insert-adapters-via-cli
-version: "4.4.0"
+version: "4.5.0-rc.0"
 title: Bulk Insert Adapters via KAIROS CLI
 ---
 


### PR DESCRIPTION
Release candidate bump to 4.5.0-rc.0 (preminor).\n\nEvidence since v4.4.0 includes new functionality (feat(helm), artifact export/search flow), plus fixes/docs/ci. Minor is the correct semver line; RC is requested.