### PR TITLE
chore(helm): migrate operators to OLM

### DIFF
--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -20,18 +20,16 @@ post-install verification.
 
 The chart can create Custom Resources for Qdrant, Redis, PostgreSQL, and
 Keycloak. Each CR requires its operator pre-installed. Use the idempotent
-scripts in `helm/prerequisites/` or install manually.
+OLM-native manifests live under `helm/operators/` and `helm/infrastructure/`.
 
 ```sh
-# All scripts are safe to re-run (idempotent).
-./helm/prerequisites/install-redis-operator.sh      # Spotahome Redis Operator
-./helm/prerequisites/install-pg-operator.sh         # Percona PG Operator
-./helm/prerequisites/install-keycloak-operator.sh   # Keycloak Operator
-./helm/prerequisites/install-ngrok-operator.sh      # ngrok (if using ngrok Gateway)
+# 1) Install OLM (official guide):
+# https://olm.operatorframework.io/docs/getting-started/
+#
+# 2) Install operators and infrastructure (idempotent):
+kubectl apply -k helm/operators
+kubectl apply -k helm/infrastructure
 ```
-
-Each script accepts optional namespace arguments. See script headers for
-environment variables and version pinning (renovate-managed).
 
 ---
 

--- a/helm/.dev/k3b.sh
+++ b/helm/.dev/k3b.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-# Idempotent: safe to re-run (repos, namespaces, kubectl apply, helm upgrade --install).
+# Idempotent: safe to re-run (namespaces, kubectl apply, helm upgrade --install).
 #
 # Default: full local stack — operators, ngrok GatewayClass, then Helm install of
 # kairos (helm/values.dev.yaml) so Qdrant, Postgres, Keycloak, MCP app, and Gateway
@@ -10,96 +10,32 @@ set -euxo pipefail
 # Optional: KAIROS_NGROK_HOSTNAME=your-subdomain.ngrok-free.dev
 # to override gateway hostname / app.keycloakUrl if it differs from values.dev.yaml.
 # Operators only (no chart): KAIROS_SKIP_CHART=1 ./helm/.dev/k3b.sh
-helm_repo_ensure() {
-    local name="$1" url="$2" out ec=0
-    out=$(helm repo add "$name" "$url" 2>&1) || ec=$?
-    if [[ $ec -eq 0 ]]; then
-        [[ -n "$out" ]] && printf '%s\n' "$out"
-        return 0
-    fi
-    if [[ "$out" == *"already exists"* ]] || [[ "$out" == *"Already exists"* ]]; then
-        printf '%s\n' "$out"
-        return 0
-    fi
-    printf '%s\n' "$out" >&2
-    return "$ec"
-}
-
-# Dependency versions
-# Do not use redis-operator Helm chart ≥3.3.0: CRDs under crds/ contain Helm templates and fail to install.
-# Use ≥3.2.x for policy/v1 PodDisruptionBudget (required on Kubernetes 1.25+; 3.1.x hits "requested resource" errors).
-# renovate: datasource=helm registryUrl=https://spotahome.github.io/redis-operator depName=redis-operator
-REDIS_OPERATOR_CHART_VERSION=3.2.9
-# renovate: datasource=github-tags depName=keycloak/keycloak-k8s-resources
-KEYCLOAK_OPERATOR_VERSION=26.5.6
-# renovate: datasource=helm registryUrl=https://percona.github.io/percona-helm-charts/ depName=pg-operator
-PG_OPERATOR_CHART_VERSION=2.8.2
-# renovate: datasource=helm registryUrl=https://charts.ngrok.com depName=ngrok-operator
-# Pin empty to use latest from repo; set e.g. 0.23.0 to pin.
-NGROK_OPERATOR_CHART_VERSION=""
 KAIROS_NAMESPACE="${KAIROS_NAMESPACE:-kairos}"
-PG_OPERATOR_NAMESPACE="${PG_OPERATOR_NAMESPACE:-$KAIROS_NAMESPACE}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 k3d cluster list | grep -q '^local-ha-cluster[[:space:]]' || \
     k3d cluster create local-ha-cluster --agents 3 \
       --servers-memory 4g \
       --agents-memory 4g
 kubectl config use-context k3d-local-ha-cluster
+
+if ! kubectl get crd subscriptions.operators.coreos.com >/dev/null 2>&1; then
+    kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/latest/download/crds.yaml
+    kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/latest/download/olm.yaml
+    kubectl wait -n olm --for=condition=Available deployment/olm-operator --timeout=10m
+    kubectl wait -n olm --for=condition=Available deployment/catalog-operator --timeout=10m
+    kubectl wait -n olm --for=condition=Available deployment/packageserver --timeout=10m
+fi
+
 kubectl create namespace "${KAIROS_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
 
-# Helm chart repositories
-helm_repo_ensure redis-operator https://spotahome.github.io/redis-operator
-helm_repo_ensure percona https://percona.github.io/percona-helm-charts/
-helm_repo_ensure ngrok https://charts.ngrok.com
-helm repo update
+kubectl apply -k "${REPO_ROOT}/helm/operators"
+kubectl -n operators patch operatorgroup kairos-operators --type=merge -p "{\"spec\":{\"targetNamespaces\":[\"${KAIROS_NAMESPACE}\"]}}" >/dev/null
 
-# 1. Redis operator (Spotahome)
-helm upgrade --install redis-operator redis-operator/redis-operator -n redis-operator --create-namespace --version "${REDIS_OPERATOR_CHART_VERSION}"
-
-# 2. Keycloak operator (new CRDs)
-kubectl create namespace keycloak --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_OPERATOR_VERSION}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml"
-kubectl apply -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_OPERATOR_VERSION}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml"
-kubectl -n keycloak apply -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_OPERATOR_VERSION}/kubernetes/kubernetes.yml"
-kubectl apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keycloak-operator-watch
-  namespace: ${KAIROS_NAMESPACE}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keycloakcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
-    namespace: keycloak
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keycloak-realmimport-watch
-  namespace: ${KAIROS_NAMESPACE}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keycloakrealmimportcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
-    namespace: keycloak
-EOF
-kubectl -n keycloak set env deployment/keycloak-operator \
-    QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKREALMIMPORTCONTROLLER_NAMESPACES="${KAIROS_NAMESPACE}" \
-    QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKCONTROLLER_NAMESPACES="${KAIROS_NAMESPACE}"
-kubectl rollout status deployment/keycloak-operator -n keycloak --timeout=120s
-
-# 3. Percona PostgreSQL operator
-# Install the operator in the same namespace as the chart-managed PerconaPGCluster.
-helm upgrade --install pg-operator percona/pg-operator -n "${PG_OPERATOR_NAMESPACE}" --create-namespace \
-    --version "${PG_OPERATOR_CHART_VERSION}"
-kubectl rollout status deployment/pg-operator -n "${PG_OPERATOR_NAMESPACE}" --timeout=120s
+kubectl wait --for=condition=Established "crd/redisfailovers.databases.spotahome.com" --timeout=10m
+kubectl wait --for=condition=Established "crd/keycloaks.k8s.keycloak.org" --timeout=10m
+kubectl wait --for=condition=Established "crd/keycloakrealmimports.k8s.keycloak.org" --timeout=10m
+kubectl wait --for=condition=Established "crd/perconapgclusters.pgv2.percona.com" --timeout=10m
 
 # 4. ngrok Kubernetes operator (Gateway API)
 # Credentials: read from NGROK_CONFIG with yq when yq is available and the file is readable;
@@ -127,25 +63,9 @@ kubectl create secret generic "$NGROK_CREDENTIALS_SECRET" -n "$NGROK_OPERATOR_NA
     --from-literal=AUTHTOKEN="$resolved_authtoken" \
     --dry-run=client -o yaml | kubectl apply -f -
 set -x
-ngrok_helm_version_args=()
-[[ -n "${NGROK_OPERATOR_CHART_VERSION}" ]] && ngrok_helm_version_args+=(--version "$NGROK_OPERATOR_CHART_VERSION")
-helm upgrade --install ngrok-operator ngrok/ngrok-operator -n "$NGROK_OPERATOR_NAMESPACE" --create-namespace \
-    --set credentials.secret.name="$NGROK_CREDENTIALS_SECRET" \
-    --set gateway.enabled=true \
-    "${ngrok_helm_version_args[@]}"
-kubectl rollout status deployment/ngrok-operator-manager -n "$NGROK_OPERATOR_NAMESPACE" --timeout=120s
-kubectl rollout status deployment/ngrok-operator-agent -n "$NGROK_OPERATOR_NAMESPACE" --timeout=120s
-kubectl apply -f - <<'EOF'
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: ngrok
-spec:
-  controllerName: ngrok.com/gateway-controller
-EOF
-kubectl wait --for=condition=Accepted gatewayclass/ngrok --timeout=120s
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+kubectl apply -k "${REPO_ROOT}/helm/infrastructure"
+kubectl wait --for=condition=Accepted gatewayclass/ngrok --timeout=120s
 CHART_DIR="${REPO_ROOT}/helm/kairos-mcp"
 VALUES_FILE="${REPO_ROOT}/helm/values.dev.yaml"
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,17 @@
+# Helm assets
+
+## Layout
+
+- `helm/operators/`: OLM-native operator bootstrap (OperatorGroup + Subscriptions)
+- `helm/infrastructure/`: Cluster infrastructure bootstrap (ngrok GatewayClass + ngrok operator via OLM)
+- `helm/kairos-mcp/`: KAIROS MCP Helm chart
+
+## Quick start
+
+1. Install OLM on your cluster following the official guide: https://olm.operatorframework.io/docs/getting-started/
+2. Install operators:
+
+```bash
+kubectl apply -k helm/operators
+kubectl apply -k helm/infrastructure
+```

--- a/helm/infrastructure/README.md
+++ b/helm/infrastructure/README.md
@@ -1,0 +1,37 @@
+# Infrastructure (OLM)
+
+This directory contains cluster infrastructure prerequisites used by KAIROS MCP:
+
+- `GatewayClass/ngrok`
+- ngrok operator installation via OLM (`CatalogSource` + `Subscription`)
+
+## Prerequisite: OLM
+
+Install OLM on your cluster following the official guide:
+
+https://olm.operatorframework.io/docs/getting-started/
+
+## Install
+
+```bash
+kubectl apply -k helm/infrastructure
+```
+
+## ngrok catalog
+
+The ngrok operator is not installed from the default OperatorHub catalog in this repo.
+`helm/infrastructure/catalogsource-ngrok.yaml` assumes you provide and publish an OCI image that serves a gRPC catalog (index image) containing an `ngrok-operator` package and a `stable` channel.
+
+If you publish your catalog under a different image/tag, update:
+
+- `helm/infrastructure/catalogsource-ngrok.yaml` → `spec.image`
+
+## ngrok credentials
+
+Do not commit ngrok credentials to git. Create the secret at runtime in the `ngrok-operator` namespace:
+
+```bash
+kubectl create secret generic ngrok-k8s-credentials -n ngrok-operator \
+  --from-literal=API_KEY="$NGROK_API_KEY" \
+  --from-literal=AUTHTOKEN="$NGROK_AUTHTOKEN"
+```

--- a/helm/infrastructure/catalogsource-ngrok.yaml
+++ b/helm/infrastructure/catalogsource-ngrok.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ngrok-catalog
+  namespace: olm
+spec:
+  displayName: ngrok operator catalog
+  publisher: ngrok
+  sourceType: grpc
+  image: ghcr.io/debian777/ngrok-operator-catalog:latest

--- a/helm/infrastructure/gatewayclass-ngrok.yaml
+++ b/helm/infrastructure/gatewayclass-ngrok.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ngrok
+spec:
+  controllerName: ngrok.com/gateway-controller

--- a/helm/infrastructure/kustomization.yaml
+++ b/helm/infrastructure/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - gatewayclass-ngrok.yaml
+  - catalogsource-ngrok.yaml
+  - operatorgroup.yaml
+  - subscription-ngrok-operator.yaml

--- a/helm/infrastructure/namespace.yaml
+++ b/helm/infrastructure/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ngrok-operator

--- a/helm/infrastructure/operatorgroup.yaml
+++ b/helm/infrastructure/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ngrok-operator
+  namespace: ngrok-operator
+spec:
+  targetNamespaces: []

--- a/helm/infrastructure/subscription-ngrok-operator.yaml
+++ b/helm/infrastructure/subscription-ngrok-operator.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ngrok-operator
+  namespace: ngrok-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: ngrok-operator
+  source: ngrok-catalog
+  sourceNamespace: olm

--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "3.0.0"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kaiiros-mcp.svg
 keywords:

--- a/helm/kairos-mcp/README.md
+++ b/helm/kairos-mcp/README.md
@@ -41,8 +41,7 @@ must still provide an embedding provider configuration.
 - **Use your own clusters:** set `redisCluster.useOwnCluster`, `keycloakInstance.useOwnCluster`, or `postgresCluster.useOwnCluster` to `true` and set app.*Url. No CRs are created.
 - **Chart creates clusters:** set `redisCluster.enabled`,
   `keycloakInstance.enabled`, or `postgresCluster.enabled` to `true`.
-  Operators must be installed first, must watch the release namespace, and
-  must have RBAC in that namespace.
+  Operators must be installed first, and must be scoped to the release namespace (for example via an OLM `OperatorGroup`).
 
 ## Operator pre-check
 

--- a/helm/kairos-mcp/docs/OPERATORS.md
+++ b/helm/kairos-mcp/docs/OPERATORS.md
@@ -1,146 +1,49 @@
-# Step-by-step operator installation
+# Step-by-step operator installation (OLM)
 
-Install these operators before you install the KAIROS MCP chart when you use
-chart-created clusters. In this repository, `helm/.dev/k3b.sh` performs the same
-bootstrap for `k3d local-ha-cluster`, including the ngrok `GatewayClass`.
-Standalone idempotent scripts are available in `helm/prerequisites/`.
-If you install an operator outside the chart release namespace, you must also
-configure that operator to watch the release namespace and grant it RBAC in
-that namespace. The default upstream installs watch only their own namespace.
-See [Keycloak operator installation](https://www.keycloak.org/operator/installation)
-for the upstream Keycloak references.
+Install these operators before you install the KAIROS MCP chart when you enable any chart-created clusters (RedisFailover, Keycloak, PerconaPGCluster).
 
-### Helm chart repositories (once)
+## 0. Install OLM
+
+Install OLM on your cluster following the official guide:
+
+https://olm.operatorframework.io/docs/getting-started/
+
+## 1. Install operators (Subscriptions)
 
 ```bash
-helm repo add redis-operator https://spotahome.github.io/redis-operator
-helm repo add percona https://percona.github.io/percona-helm-charts/
-helm repo update
+kubectl apply -k helm/operators
 ```
 
----
+If you install the KAIROS chart into a namespace other than `kairos`, update `helm/operators/operatorgroup.yaml` so `spec.targetNamespaces` includes your release namespace.
 
-## 1. Redis operator (Spotahome)
-
-Uses the **RedisFailover** CRD. Do **not** use Helm chart **≥3.3.0** (CRDs under
-`crds/` are templated and fail to install). Use **3.2.9** (or another **3.2.x**):
-it keeps the **policy/v1** `PodDisruptionBudget` API required on Kubernetes **1.25+**;
-**3.1.x** controllers hit `the server could not find the requested resource` on
-modern clusters.
-
-`helm/.dev/k3b.sh` pins **3.2.9** for `k3d local-ha-cluster`.
+## 2. Install infrastructure (ngrok)
 
 ```bash
-helm upgrade --install redis-operator redis-operator/redis-operator -n redis-operator --create-namespace --version 3.2.9
+kubectl apply -k helm/infrastructure
 ```
 
-Verify: `kubectl get pods -n redis-operator` and
-`kubectl get crd redisfailovers.databases.spotahome.com`.
-
-The KAIROS chart creates a ClusterIP **`rfr-<redisCluster.name>`** Service
-(selecting the Redis **master** pod) because some operator versions do not
-expose that Service; set `app.redisUrl` to `redis://rfr-<name>:6379` (see
-`helm/values.dev.yaml`).
-
----
-
-## 2. Keycloak operator
-
-Use the current operator (CRD `keycloaks.k8s.keycloak.org`). The CRDs are
-separate from the operator deployment.
+Do not commit ngrok credentials to git. Create them at runtime:
 
 ```bash
-kubectl create namespace keycloak
-export KEYCLOAK_OPERATOR_VERSION=26.5.6
-
-# CRDs (cluster-scoped)
-kubectl apply -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_OPERATOR_VERSION}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml"
-kubectl apply -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_OPERATOR_VERSION}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml"
-
-# Operator in keycloak namespace
-kubectl -n keycloak apply -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_OPERATOR_VERSION}/kubernetes/kubernetes.yml"
-kubectl create namespace kairos
-kubectl apply -f - <<'EOF'
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keycloak-operator-watch
-  namespace: kairos
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keycloakcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
-    namespace: keycloak
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keycloak-realmimport-watch
-  namespace: kairos
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keycloakrealmimportcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
-    namespace: keycloak
-EOF
-kubectl -n keycloak set env deployment/keycloak-operator \
-  QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKREALMIMPORTCONTROLLER_NAMESPACES=kairos \
-  QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKCONTROLLER_NAMESPACES=kairos
+kubectl create secret generic ngrok-k8s-credentials -n ngrok-operator \
+  --from-literal=API_KEY="$NGROK_API_KEY" \
+  --from-literal=AUTHTOKEN="$NGROK_AUTHTOKEN"
 ```
 
-Verify: `kubectl get pods -n keycloak` and
-`kubectl get crd keycloaks.k8s.keycloak.org`.
-
-The chart now renders `k8s.keycloak.org/v2alpha1` Keycloak resources and
-expects PostgreSQL-backed Keycloak configuration.
-
----
-
-## 3. Percona PostgreSQL operator
+## 3. Verify required CRDs
 
 ```bash
-helm install pg-operator percona/pg-operator \
-  -n kairos --create-namespace
+kubectl get crd redisfailovers.databases.spotahome.com
+kubectl get crd keycloaks.k8s.keycloak.org
+kubectl get crd perconapgclusters.pgv2.percona.com
 ```
 
-Verify: `kubectl get pods -n kairos` and
-`kubectl get crd perconapgclusters.pgv2.percona.com`.
+The chart creates a ClusterIP `rfr-<redisCluster.name>` Service (selecting the Redis master pod). Set `app.redisUrl` to `redis://rfr-<name>:6379` when you enable Redis.
 
----
-
-## 4. ngrok operator and GatewayClass
-
-For the repo-local `k3d` workflow, run `./helm/.dev/k3b.sh`. It reads ngrok
-credentials from `~/.config/ngrok/ngrok.yml` (or `NGROK_AUTHTOKEN` and
-`NGROK_API_KEY`), installs the ngrok operator, and applies
-`GatewayClass/ngrok`.
-
-Verify: `kubectl get gatewayclass ngrok`.
-
----
-
-## 5. Install KAIROS MCP chart
+## 4. Install KAIROS MCP chart
 
 ```bash
 cd helm/kairos-mcp
 helm dependency update
 helm install kairos . -n kairos --create-namespace -f my-values.yaml
 ```
-
-On the repo-local `k3d` profile, export `OPENAI_API_KEY` (for example
-`set -a && source .env && set +a`), then run `./helm/.dev/k3b.sh` for the default
-full Helm install; it creates the embedding Secret from that env var. Use
-`KAIROS_SKIP_CHART=1` if you only want operators and ngrok. Use
-`KAIROS_NGROK_HOSTNAME` when your reserved ngrok hostname does not match
-`helm/values.dev.yaml`.
-
-Set `app.qdrantUrl`, `app.keycloakUrl`, `app.keycloakInternalUrl`, and
-`app.embedding` or `app.extraEnv` when you enable the app. Set `app.redisUrl`
-only when you configure Redis. Credentials are autogenerated and stored only
-in the Kubernetes Secret unless you set `credentials.existingSecret`.

--- a/helm/operators/README.md
+++ b/helm/operators/README.md
@@ -1,0 +1,40 @@
+# Operators (OLM)
+
+This directory installs the operators required by the KAIROS MCP Helm chart using OLM primitives:
+
+- `OperatorGroup` (scopes operators to the KAIROS release namespace)
+- `Subscription` (installs/upgrades operators from catalogs)
+
+## Prerequisite: OLM
+
+Install OLM on your cluster following the official guide:
+
+https://olm.operatorframework.io/docs/getting-started/
+
+## Install
+
+```bash
+kubectl apply -k helm/operators
+```
+
+## Configure scope (release namespace)
+
+The default KAIROS release namespace is `kairos`. If you install the chart into a different namespace, update:
+
+- `helm/operators/operatorgroup.yaml` → `spec.targetNamespaces`
+
+## Verify
+
+```bash
+kubectl get operatorgroup,subscription,installplan,csv -n operators
+kubectl get crd | rg -i 'redisfailovers\\.databases\\.spotahome\\.com|keycloaks\\.k8s\\.keycloak\\.org|perconapgclusters\\.pgv2\\.percona\\.com'
+```
+
+If a `Subscription` stays unresolved, validate that the operator exists in your catalogs:
+
+```bash
+kubectl get catalogsource -n olm
+kubectl get packagemanifest -n olm | rg -i 'redis|keycloak|percona|postgres'
+```
+
+Then update the `spec.name` / `spec.channel` in the relevant `subscription-*.yaml` file.

--- a/helm/operators/kustomization.yaml
+++ b/helm/operators/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - operatorgroup.yaml
+  - subscription-redis-operator.yaml
+  - subscription-keycloak-operator.yaml
+  - subscription-percona-postgresql-operator.yaml

--- a/helm/operators/namespace.yaml
+++ b/helm/operators/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: operators

--- a/helm/operators/operatorgroup.yaml
+++ b/helm/operators/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kairos-operators
+  namespace: operators
+spec:
+  targetNamespaces:
+    - kairos

--- a/helm/operators/subscription-keycloak-operator.yaml
+++ b/helm/operators/subscription-keycloak-operator.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: keycloak-operator
+  namespace: operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: keycloak-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm

--- a/helm/operators/subscription-percona-postgresql-operator.yaml
+++ b/helm/operators/subscription-percona-postgresql-operator.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: percona-postgresql-operator
+  namespace: operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: percona-postgresql-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm

--- a/helm/operators/subscription-redis-operator.yaml
+++ b/helm/operators/subscription-redis-operator.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: redis-operator
+  namespace: operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: redis-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm

--- a/helm/prerequisites/install-keycloak-operator.sh
+++ b/helm/prerequisites/install-keycloak-operator.sh
@@ -1,71 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Idempotent: install Keycloak Operator CRDs and deployment.
-# Usage: ./install-keycloak-operator.sh [OPERATOR_NAMESPACE] [WATCH_NAMESPACE]
-#
-# OPERATOR_NAMESPACE: where the operator deployment lives (default: keycloak).
-# WATCH_NAMESPACE: namespace the operator watches for Keycloak CRs (default: kairos).
-# On PSA-restricted clusters, applies security context patches.
-# renovate: datasource=github-tags depName=keycloak/keycloak-k8s-resources
-VERSION="${KEYCLOAK_OPERATOR_VERSION:-26.5.6}"
-OPERATOR_NAMESPACE="${1:-keycloak}"
-WATCH_NAMESPACE="${2:-kairos}"
-BASE_URL="https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${VERSION}/kubernetes"
+# Idempotent: install Keycloak Operator via OLM.
+# Usage: ./install-keycloak-operator.sh [RELEASE_NAMESPACE]
+TARGET_NAMESPACE="${1:-kairos}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-echo "Installing Keycloak Operator ${VERSION} (ns: ${OPERATOR_NAMESPACE}, watching: ${WATCH_NAMESPACE})"
+kubectl apply -f "${REPO_ROOT}/helm/operators/namespace.yaml"
+kubectl apply -f "${REPO_ROOT}/helm/operators/operatorgroup.yaml"
+kubectl -n operators patch operatorgroup kairos-operators --type=merge -p "{\"spec\":{\"targetNamespaces\":[\"${TARGET_NAMESPACE}\"]}}" >/dev/null
+kubectl apply -f "${REPO_ROOT}/helm/operators/subscription-keycloak-operator.yaml"
 
-# 1. CRDs (cluster-scoped)
-kubectl apply -f "${BASE_URL}/keycloaks.k8s.keycloak.org-v1.yml"
-kubectl apply -f "${BASE_URL}/keycloakrealmimports.k8s.keycloak.org-v1.yml"
-
-# 2. Operator deployment
-kubectl create namespace "$OPERATOR_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-kubectl -n "$OPERATOR_NAMESPACE" apply -f "${BASE_URL}/kubernetes.yml"
-
-# 3. Cross-namespace RBAC so the operator can reconcile in WATCH_NAMESPACE
-kubectl create namespace "$WATCH_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keycloak-operator-watch
-  namespace: ${WATCH_NAMESPACE}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keycloakcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
-    namespace: ${OPERATOR_NAMESPACE}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: keycloak-realmimport-watch
-  namespace: ${WATCH_NAMESPACE}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: keycloakrealmimportcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
-    namespace: ${OPERATOR_NAMESPACE}
-EOF
-
-# 4. Configure operator to watch the target namespace
-kubectl -n "$OPERATOR_NAMESPACE" set env deployment/keycloak-operator \
-    QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKREALMIMPORTCONTROLLER_NAMESPACES="${WATCH_NAMESPACE}" \
-    QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKCONTROLLER_NAMESPACES="${WATCH_NAMESPACE}"
-
-# 5. PSA hardening (safe to re-apply)
-kubectl -n "$OPERATOR_NAMESPACE" patch deployment keycloak-operator --type=json -p='[
-  {"op":"add","path":"/spec/template/spec/securityContext","value":{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}},
-  {"op":"add","path":"/spec/template/spec/containers/0/securityContext","value":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}}
-]' 2>/dev/null || true
-
-# 6. Wait for rollout
-kubectl -n "$OPERATOR_NAMESPACE" rollout status deployment/keycloak-operator --timeout=120s
-echo "Keycloak Operator ${VERSION} ready in ${OPERATOR_NAMESPACE} (watching ${WATCH_NAMESPACE})."
+kubectl wait --for=condition=Established "crd/keycloaks.k8s.keycloak.org" --timeout=10m
+kubectl wait --for=condition=Established "crd/keycloakrealmimports.k8s.keycloak.org" --timeout=10m
+echo "Keycloak Operator ready (release namespace: ${TARGET_NAMESPACE})."

--- a/helm/prerequisites/install-ngrok-operator.sh
+++ b/helm/prerequisites/install-ngrok-operator.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Idempotent: install ngrok Kubernetes Operator with Gateway API support.
-# Usage: ./install-ngrok-operator.sh [NAMESPACE]
+# Idempotent: install ngrok Kubernetes Operator with Gateway API support (OLM).
+# Usage: ./install-ngrok-operator.sh
 #
 # Requires NGROK_AUTHTOKEN and NGROK_API_KEY in environment (or yq-readable
 # ~/.config/ngrok/ngrok.yml). Creates a GatewayClass named "ngrok".
-# renovate: datasource=helm registryUrl=https://charts.ngrok.com depName=ngrok-operator
-CHART_VERSION="${NGROK_OPERATOR_CHART_VERSION:-}"
-NAMESPACE="${1:-ngrok-operator}"
+# renovate: datasource=helm depName=ngrok-operator
+NAMESPACE="ngrok-operator"
 CREDENTIALS_SECRET="ngrok-k8s-credentials"
 NGROK_CONFIG="${NGROK_CONFIG:-$HOME/.config/ngrok/ngrok.yml}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 resolved_authtoken=""
 resolved_api_key=""
@@ -32,27 +32,6 @@ kubectl create secret generic "$CREDENTIALS_SECRET" -n "$NAMESPACE" \
     --from-literal=AUTHTOKEN="$resolved_authtoken" \
     --dry-run=client -o yaml | kubectl apply -f -
 
-helm repo add ngrok https://charts.ngrok.com 2>/dev/null || true
-helm repo update ngrok
-
-version_args=()
-[[ -n "${CHART_VERSION}" ]] && version_args+=(--version "$CHART_VERSION")
-
-helm upgrade --install ngrok-operator ngrok/ngrok-operator -n "$NAMESPACE" --create-namespace \
-    --set credentials.secret.name="$CREDENTIALS_SECRET" \
-    --set gateway.enabled=true \
-    "${version_args[@]}"
-
-kubectl rollout status deployment/ngrok-operator-manager -n "$NAMESPACE" --timeout=120s
-kubectl rollout status deployment/ngrok-operator-agent -n "$NAMESPACE" --timeout=120s
-
-kubectl apply -f - <<'EOF'
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: ngrok
-spec:
-  controllerName: ngrok.com/gateway-controller
-EOF
+kubectl apply -k "${REPO_ROOT}/helm/infrastructure"
 kubectl wait --for=condition=Accepted gatewayclass/ngrok --timeout=120s
-echo "ngrok Operator ready in ${NAMESPACE} with GatewayClass/ngrok."
+echo "ngrok bootstrap applied (namespace: ${NAMESPACE})."

--- a/helm/prerequisites/install-pg-operator.sh
+++ b/helm/prerequisites/install-pg-operator.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Idempotent: install Percona PostgreSQL Operator via Helm.
-# Usage: ./install-pg-operator.sh [NAMESPACE]
-# renovate: datasource=helm registryUrl=https://percona.github.io/percona-helm-charts/ depName=pg-operator
-CHART_VERSION="${PG_OPERATOR_CHART_VERSION:-2.8.2}"
-NAMESPACE="${1:-kairos}"
+# Idempotent: install Percona PostgreSQL Operator via OLM.
+# Usage: ./install-pg-operator.sh [RELEASE_NAMESPACE]
+TARGET_NAMESPACE="${1:-kairos}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-helm repo add percona https://percona.github.io/percona-helm-charts/ 2>/dev/null || true
-helm repo update percona
+kubectl apply -f "${REPO_ROOT}/helm/operators/namespace.yaml"
+kubectl apply -f "${REPO_ROOT}/helm/operators/operatorgroup.yaml"
+kubectl -n operators patch operatorgroup kairos-operators --type=merge -p "{\"spec\":{\"targetNamespaces\":[\"${TARGET_NAMESPACE}\"]}}" >/dev/null
+kubectl apply -f "${REPO_ROOT}/helm/operators/subscription-percona-postgresql-operator.yaml"
 
-helm upgrade --install pg-operator percona/pg-operator \
-  -n "${NAMESPACE}" --create-namespace \
-  --version "${CHART_VERSION}"
-
-kubectl rollout status deployment/pg-operator -n "${NAMESPACE}" --timeout=120s
-echo "Percona PG Operator ${CHART_VERSION} ready in ${NAMESPACE}."
+kubectl wait --for=condition=Established "crd/perconapgclusters.pgv2.percona.com" --timeout=10m
+echo "Percona PostgreSQL Operator ready (release namespace: ${TARGET_NAMESPACE})."

--- a/helm/prerequisites/install-redis-operator.sh
+++ b/helm/prerequisites/install-redis-operator.sh
@@ -1,21 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Idempotent: install Spotahome Redis Operator via Helm.
-# Usage: ./install-redis-operator.sh [NAMESPACE]
-#
-# Do not use redis-operator Helm chart >=3.3.0: CRDs under crds/ contain Helm
-# templates and fail to install. Use >=3.2.x for policy/v1 PodDisruptionBudget.
-# renovate: datasource=helm registryUrl=https://spotahome.github.io/redis-operator depName=redis-operator
-CHART_VERSION="${REDIS_OPERATOR_CHART_VERSION:-3.2.9}"
-NAMESPACE="${1:-redis-operator}"
+# Idempotent: install Redis Operator via OLM.
+# Usage: ./install-redis-operator.sh [RELEASE_NAMESPACE]
+TARGET_NAMESPACE="${1:-kairos}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-helm repo add redis-operator https://spotahome.github.io/redis-operator 2>/dev/null || true
-helm repo update redis-operator
+kubectl apply -f "${REPO_ROOT}/helm/operators/namespace.yaml"
+kubectl apply -f "${REPO_ROOT}/helm/operators/operatorgroup.yaml"
+kubectl -n operators patch operatorgroup kairos-operators --type=merge -p "{\"spec\":{\"targetNamespaces\":[\"${TARGET_NAMESPACE}\"]}}" >/dev/null
+kubectl apply -f "${REPO_ROOT}/helm/operators/subscription-redis-operator.yaml"
 
-helm upgrade --install redis-operator redis-operator/redis-operator \
-  -n "${NAMESPACE}" --create-namespace \
-  --version "${CHART_VERSION}"
-
-kubectl rollout status deployment/redis-operator -n "${NAMESPACE}" --timeout=120s
-echo "Redis Operator ${CHART_VERSION} ready in ${NAMESPACE}."
+kubectl wait --for=condition=Established "crd/redisfailovers.databases.spotahome.com" --timeout=10m
+echo "Redis Operator ready (release namespace: ${TARGET_NAMESPACE})."

--- a/helm/values.prod.yaml
+++ b/helm/values.prod.yaml
@@ -1,8 +1,8 @@
 # Production overlay example.
 #
 # Copy this file and customize for your environment. Install operators first:
-#   ./helm/prerequisites/install-keycloak-operator.sh
-#   ./helm/prerequisites/install-pg-operator.sh
+#   kubectl apply -k helm/operators
+#   kubectl apply -k helm/infrastructure
 #
 # Then install the chart:
 #   helm upgrade --install kairos helm/kairos-mcp -n kairos -f my-values.yaml --wait


### PR DESCRIPTION
Migrates operator bootstrap under helm/ to OLM-native primitives (OperatorGroup + Subscription) and updates docs/scripts to match.

Key changes:
- Adds OLM Kustomize entrypoints: helm/operators/ and helm/infrastructure/
- Updates operator docs to OLM flow only
- Updates prerequisite scripts + local dev flow away from Helm/raw-YAML operator installs

Notes:
- Subscription package/channel values may need adjustment depending on cluster catalogs (kubectl get packagemanifest -n olm ...).
- ngrok is modeled via a custom CatalogSource; spec.image must be set to a real published catalog index image.

Refs #469