### PR TITLE
fix(auth): derive session TTL from token TTL

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -7,6 +7,22 @@ symlinks → **`.agents/skills`**).
 They complement shipped agent skills in **`skills/`** (`kairos`, `kairos-bug-report`,
 `kairos-install`).
 
+## MCP environments
+
+This repo commonly uses three MCP server instances. Each one has a different
+purpose and authority boundary.
+
+- **`KAIROS`**: Live, authoritative server. It usually runs the latest released
+  version, not your local code. Use it for adapter behavior and production
+  confirmation.
+- **`KAIROS-DEVELOPMENT`**: Local development server built from this worktree,
+  configured at the project level in [mcp.json](../mcp.json). Use it to test
+  local code changes. Do not treat it as authoritative for adapters.
+- **`KAIROS-HELM-INTEGRATION`**: Kubernetes instance built from the Helm chart in
+  `helm/`, configured at the project level in [mcp.json](../mcp.json). Use it to
+  validate the Helm deployment process and app availability. The app version can
+  vary and is not an authority source for adapters or local code changes.
+
 ## Namespace: `kmcp-dev-*`
 
 Each **`SKILL.md`** frontmatter **`name`** uses the prefix **`kmcp-dev-`**
@@ -17,7 +33,7 @@ ids, npm-only tests).
 | Directory (`…/SKILL.md`) | YAML `name` | When to invoke |
 |----------------|-------------|----------------|
 | [`kmcp-dev-build-test`](kmcp-dev-build-test/SKILL.md) | `kmcp-dev-build-test` | Build, deploy, lint, integration tests — always **`npm run`**; never default to bare Jest. |
-| [`kmcp-dev-mcp-qa-e2e`](kmcp-dev-mcp-qa-e2e/SKILL.md) | `kmcp-dev-mcp-qa-e2e` | Phased E2E QA of tools against **KAIROS-DEVELOPMENT**; `.local/` trace reports. |
+| [`kmcp-dev-mcp-qa-e2e`](kmcp-dev-mcp-qa-e2e/SKILL.md) | `kmcp-dev-mcp-qa-e2e` | Phased E2E QA of tools against **KAIROS-DEVELOPMENT** (local dev); `.local/` trace reports. |
 | [`kmcp-dev-bugfix-ship`](kmcp-dev-bugfix-ship/SKILL.md) | `kmcp-dev-bugfix-ship` | Live reproduce → failing test → fix → PR → CI green → merge-ready. |
 | [`kmcp-dev-release-semver`](kmcp-dev-release-semver/SKILL.md) | `kmcp-dev-release-semver` | Semver bump, `release/*` branch, PR, tag policy (no manual `v*` push). |
 | [`kmcp-dev-ui-spec`](kmcp-dev-ui-spec/SKILL.md) | `kmcp-dev-ui-spec` | Human-facing **`src/ui/`** UX/spec, a11y, tokens; design-lint. |
@@ -25,6 +41,14 @@ ids, npm-only tests).
 | [`kmcp-dev-git-index-repair`](kmcp-dev-git-index-repair/SKILL.md) | `kmcp-dev-git-index-repair` | Invalid object / tree build failures; Husky bisect; index repair. |
 | [`kmcp-dev-worktree-env`](kmcp-dev-worktree-env/SKILL.md) | `kmcp-dev-worktree-env` | Worktree **`.env*`** not shared with main; unique **`PORT`** / **`METRICS_PORT`** per checkout on one host; **`deploy-copy-env-from-main.sh`**; Run Task **Copy .env from main**. |
 | [`kmcp-dev-mcp-host-bridge-pointer`](kmcp-dev-mcp-host-bridge-pointer/SKILL.md) | `kmcp-dev-mcp-host-bridge-pointer` | Router only → **`.agents/skills/mcp-host-bridge`**. |
+
+## Shared skills
+
+These skills live in `.agents/skills/` but do not follow the `kmcp-dev-*`
+namespace.
+
+- [mcp-host-bridge](mcp-host-bridge/SKILL.md): MCP environment purpose and host
+  troubleshooting (server id resolution, auth errors).
 
 ## Default flow (muscle memory)
 
@@ -36,7 +60,7 @@ ids, npm-only tests).
 6. **UI work** → **`kmcp-dev-ui-spec`**.
 7. **Git pain** → **`kmcp-dev-git-editor-safe`** + **`kmcp-dev-git-index-repair`**.
 8. **New worktree / missing `.env`** → **`kmcp-dev-worktree-env`** (sync from main before dev commands if needed).
-9. **MCP server id / auth errors** → **`kmcp-dev-mcp-host-bridge-pointer`** (canonical bridge skill).
+9. **MCP server id / auth errors** → [mcp-host-bridge](mcp-host-bridge/SKILL.md).
 
 ## Authoring rules
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -12,16 +12,16 @@ They complement shipped agent skills in **`skills/`** (`kairos`, `kairos-bug-rep
 This repo commonly uses three MCP server instances. Each one has a different
 purpose and authority boundary.
 
-- **`KAIROS`**: Live, authoritative server. It usually runs the latest released
-  version, not your local code. Use it for adapter behavior and production
-  confirmation.
-- **`KAIROS-DEVELOPMENT`**: Local development server built from this worktree,
-  configured at the project level in [mcp.json](../mcp.json). Use it to test
-  local code changes. Do not treat it as authoritative for adapters.
+- **`KAIROS`**: Live server. Treat it as authoritative for everything and use it
+  with the shipped [kairos skill](../../skills/kairos/SKILL.md). In this
+  environment, you (the agent) act as a user.
+- **`KAIROS-DEVELOPMENT`**: Development instance built from this worktree,
+  configured at the project level in [mcp.json](../mcp.json). Use it as a
+  developer/QA to validate local code changes.
 - **`KAIROS-HELM-INTEGRATION`**: Kubernetes instance built from the Helm chart in
-  `helm/`, configured at the project level in [mcp.json](../mcp.json). Use it to
-  validate the Helm deployment process and app availability. The app version can
-  vary and is not an authority source for adapters or local code changes.
+  `helm/`, configured at the project level in [mcp.json](../mcp.json). Use it as
+  a developer/QA of the Helm chart to validate the deployment process and app
+  availability. The app version can vary.
 
 ## Namespace: `kmcp-dev-*`
 
@@ -34,7 +34,7 @@ ids, npm-only tests).
 |----------------|-------------|----------------|
 | [`kmcp-dev-build-test`](kmcp-dev-build-test/SKILL.md) | `kmcp-dev-build-test` | Build, deploy, lint, integration tests — always **`npm run`**; never default to bare Jest. |
 | [`kmcp-dev-mcp-qa-e2e`](kmcp-dev-mcp-qa-e2e/SKILL.md) | `kmcp-dev-mcp-qa-e2e` | Phased E2E QA of tools against **KAIROS-DEVELOPMENT** (local dev); `.local/` trace reports. |
-| [`kmcp-dev-bugfix-ship`](kmcp-dev-bugfix-ship/SKILL.md) | `kmcp-dev-bugfix-ship` | Live reproduce → failing test → fix → PR → CI green → merge-ready. |
+| [`kmcp-dev-bugfix-ship`](kmcp-dev-bugfix-ship/SKILL.md) | `kmcp-dev-bugfix-ship` | Dev reproduce → failing test → fix → PR → CI green → merge-ready. |
 | [`kmcp-dev-release-semver`](kmcp-dev-release-semver/SKILL.md) | `kmcp-dev-release-semver` | Semver bump, `release/*` branch, PR, tag policy (no manual `v*` push). |
 | [`kmcp-dev-ui-spec`](kmcp-dev-ui-spec/SKILL.md) | `kmcp-dev-ui-spec` | Human-facing **`src/ui/`** UX/spec, a11y, tokens; design-lint. |
 | [`kmcp-dev-git-editor-safe`](kmcp-dev-git-editor-safe/SKILL.md) | `kmcp-dev-git-editor-safe` | Agent shell Git without opening `code --wait` editor. |

--- a/.agents/skills/kmcp-dev-bugfix-ship/SKILL.md
+++ b/.agents/skills/kmcp-dev-bugfix-ship/SKILL.md
@@ -17,8 +17,10 @@ description: >-
 
 **Authority split**
 
-- **Live MCP** — authoritative for “does the bug still reproduce?”
+- **Live MCP (`KAIROS`)** — authoritative for “does the bug still reproduce?”
 - **This worktree** — authoritative for regression tests and implementation.
+- **Local dev MCP (`KAIROS-DEVELOPMENT`)** — use it to validate local code
+  changes; do not treat it as authoritative for adapters.
 
 ---
 

--- a/.agents/skills/kmcp-dev-bugfix-ship/SKILL.md
+++ b/.agents/skills/kmcp-dev-bugfix-ship/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: kmcp-dev-bugfix-ship
 description: >-
-  kairos-mcp: ship-ready bug workflow from report to merge. Reproduce on live
-  KAIROS MCP, add failing dev test, minimal fix, dev deploy + dev:test, PR,
-  watch CI, iterate until green, merge-ready summary. Use with reports/mcp-bug-*.md
-  or user-requested KAIROS defect work.
+  kairos-mcp: ship-ready bug workflow from report to merge. Reproduce on
+  KAIROS-DEVELOPMENT, add failing dev test, minimal fix, dev deploy + dev:test,
+  PR, watch CI, iterate until green, merge-ready summary. Use with
+  reports/mcp-bug-*.md or user-requested KAIROS defect work.
 ---
 
-# Bug fix: live reproduce → test → PR → CI (kairos-mcp)
+# Bug fix: dev reproduce → test → PR → CI (kairos-mcp)
 
 **Repository:** `kairos-mcp`. **Agent contract:** [`AGENTS.md`](../../../AGENTS.md).
 **Build/test contract:** [`kmcp-dev-build-test`](../kmcp-dev-build-test/SKILL.md).
@@ -15,22 +15,25 @@ description: >-
 
 **Input:** A bug report under **`reports/`** (for example **`reports/mcp-bug-<slug>.md`**) or pasted content. If none exists, capture one first using **[`skills/.system/kairos-bug-report/SKILL.md`](../../../skills/.system/kairos-bug-report/SKILL.md)** (or your host’s equivalent). This skill owns **fixing** once the report exists.
 
-**Authority split**
+**Environment intent**
 
-- **Live MCP (`KAIROS`)** — authoritative for “does the bug still reproduce?”
-- **This worktree** — authoritative for regression tests and implementation.
-- **Local dev MCP (`KAIROS-DEVELOPMENT`)** — use it to validate local code
-  changes; do not treat it as authoritative for adapters.
+- **`KAIROS`**: Live. Treat it as authoritative for everything. When using it,
+  you (the agent) act as a user and run workflows via the shipped
+  [`skills/kairos/SKILL.md`](../../../skills/kairos/SKILL.md).
+- **`KAIROS-DEVELOPMENT`**: Dev/QA instance for validating local code changes and
+  reproducing defects during development.
 
 ---
 
 ## Flow (order matters; loop where noted)
 
-### 1. Confirm on live KAIROS MCP
+### 1. Confirm on KAIROS-DEVELOPMENT
 
 - Read the report: tool, arguments, expected vs actual, steps.
-- **Reproduce with the live connected server**; read tool schemas from the host MCP descriptors before calling.
-- If live matches the report → continue. If not → stop (stale report, wrong server, env drift); do not patch code for an unconfirmed symptom.
+- Reproduce with **`KAIROS-DEVELOPMENT`**; read tool schemas from the host MCP
+  descriptors before calling.
+- If it reproduces → continue. If not → stop (stale report, wrong server, env
+  drift); do not patch code for an unconfirmed symptom.
 
 ### 2. Failing automated test
 
@@ -66,7 +69,7 @@ Iterate until green or the user stops.
 
 When checks pass:
 
-- Bug (one line) + live MCP confirmation.
+- Bug (one line) + dev confirmation (`KAIROS-DEVELOPMENT`).
 - Test added (path + assertion intent).
 - Fix (files / behavior).
 - Commands run (`dev:deploy`, `dev:test`, …).

--- a/.agents/skills/kmcp-dev-mcp-qa-e2e/SKILL.md
+++ b/.agents/skills/kmcp-dev-mcp-qa-e2e/SKILL.md
@@ -26,12 +26,14 @@ as authoritative for adapters.
 This skill targets `KAIROS-DEVELOPMENT`. Use the other environments only for
 their stated purposes.
 
-- **`KAIROS`**: Live, authoritative server. It usually runs the latest released
-  version, not your local code.
+- **`KAIROS`**: Live. Treat it as authoritative for everything. When using it,
+  you (the agent) act as a user and run workflows via the shipped
+  [`skills/kairos/SKILL.md`](../../../skills/kairos/SKILL.md).
 - **`KAIROS-DEVELOPMENT`**: Local development server built from this worktree.
-  Use it to validate local code changes.
+  Use it as a developer/QA to validate local code changes.
 - **`KAIROS-HELM-INTEGRATION`**: Kubernetes instance built from the Helm chart in
-  `helm/`. Use it to validate the Helm deployment process and app availability.
+  `helm/`. Use it as a developer/QA of the Helm chart to validate the Helm
+  deployment process and app availability.
 
 - **Config key:** `KAIROS-DEVELOPMENT` (see `docs/install/README.md#cursor-and-mcp`).
 - **`call_mcp_tool` `server` argument:** the host’s agent-visible id often differs.

--- a/.agents/skills/kmcp-dev-mcp-qa-e2e/SKILL.md
+++ b/.agents/skills/kmcp-dev-mcp-qa-e2e/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: kmcp-dev-mcp-qa-e2e
 description: >-
-  kairos-mcp: phased E2E QA of KAIROS MCP tools against KAIROS-DEVELOPMENT.
+  kairos-mcp: phased E2E QA of KAIROS MCP tools against KAIROS-DEVELOPMENT
+  (local dev).
   Phase 1 MCP-only; phase 2 read-only repo + raw JSON trace reports under
   .local/mcp-qa-reports/; phase 3 failing integration tests; phase 4 plan
   and fix. Not installed via npx skills add (see .agents/skills/README.md).
@@ -17,7 +18,20 @@ Use this skill for **structured end-to-end verification** of KAIROS MCP tools
 against **local dev** (`KAIROS-DEVELOPMENT` in `.cursor/mcp.json`), with strict
 phases so QA does not read implementation source before you intend to.
 
+`KAIROS-DEVELOPMENT` exists to validate **local code changes**. Do not treat it
+as authoritative for adapters.
+
 ## Target MCP server
+
+This skill targets `KAIROS-DEVELOPMENT`. Use the other environments only for
+their stated purposes.
+
+- **`KAIROS`**: Live, authoritative server. It usually runs the latest released
+  version, not your local code.
+- **`KAIROS-DEVELOPMENT`**: Local development server built from this worktree.
+  Use it to validate local code changes.
+- **`KAIROS-HELM-INTEGRATION`**: Kubernetes instance built from the Helm chart in
+  `helm/`. Use it to validate the Helm deployment process and app availability.
 
 - **Config key:** `KAIROS-DEVELOPMENT` (see `docs/install/README.md#cursor-and-mcp`).
 - **`call_mcp_tool` `server` argument:** the host’s agent-visible id often differs.

--- a/.agents/skills/mcp-host-bridge/SKILL.md
+++ b/.agents/skills/mcp-host-bridge/SKILL.md
@@ -18,16 +18,16 @@ you are unsure which server is authoritative for the task.
 This repository commonly uses three MCP server instances. Each one has a
 different purpose and authority boundary.
 
-- **`KAIROS`**: Live, authoritative server. It usually runs the latest released
-  version, not your local code. Use it for adapter behavior and production
-  confirmation.
-- **`KAIROS-DEVELOPMENT`**: Local development server built from this worktree,
-  configured at the project level in [mcp.json](../../mcp.json). Use it to test
-  local code changes. Do not treat it as authoritative for adapters.
+- **`KAIROS`**: Live server. Treat it as authoritative for everything and use it
+  with the shipped [kairos skill](../../../skills/kairos/SKILL.md). In this
+  environment, you (the agent) act as a user, not a developer.
+- **`KAIROS-DEVELOPMENT`**: Development instance built from this worktree,
+  configured at the project level in [mcp.json](../../mcp.json). Use it as a
+  developer/QA to validate local code changes.
 - **`KAIROS-HELM-INTEGRATION`**: Kubernetes instance built from the Helm chart in
   `helm/`, configured at the project level in [mcp.json](../../mcp.json). Use it
-  to validate the Helm deployment process and app availability. The app version
-  can vary and is not an authority source for adapters or local code changes.
+  as a developer/QA of the Helm chart to validate the deployment process and app
+  availability. The app version can vary.
 
 ## Server id resolution
 
@@ -58,8 +58,7 @@ authoritative.
 
 - For runtime tool names, schemas, and responses: treat the **connected server**
   as authority.
-- For adapter correctness and production behavior: treat **`KAIROS`** as
-  authority.
-- For local implementation changes and regression tests: treat
-  **`KAIROS-DEVELOPMENT`** and this worktree as authority.
-
+- For any user-facing behavior or “what is true”: treat **`KAIROS`** as
+  authoritative.
+- For local implementation changes and regression tests: use
+  **`KAIROS-DEVELOPMENT`** and this worktree.

--- a/.agents/skills/mcp-host-bridge/SKILL.md
+++ b/.agents/skills/mcp-host-bridge/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: mcp-host-bridge
+description: >-
+  kairos-mcp: MCP server selection and host-bridge troubleshooting. Defines the
+  intended use of KAIROS, KAIROS-DEVELOPMENT, and KAIROS-HELM-INTEGRATION, plus
+  how to resolve config keys to agent-visible server ids when MCP calls fail.
+---
+
+# MCP host bridge (kairos-mcp)
+
+This skill defines the intended use of each KAIROS MCP environment and gives
+host-bridge troubleshooting steps for server-id and authentication failures.
+Use it when MCP calls fail with 401/403, “MCP server does not exist,” or when
+you are unsure which server is authoritative for the task.
+
+## Environments
+
+This repository commonly uses three MCP server instances. Each one has a
+different purpose and authority boundary.
+
+- **`KAIROS`**: Live, authoritative server. It usually runs the latest released
+  version, not your local code. Use it for adapter behavior and production
+  confirmation.
+- **`KAIROS-DEVELOPMENT`**: Local development server built from this worktree,
+  configured at the project level in [mcp.json](../../mcp.json). Use it to test
+  local code changes. Do not treat it as authoritative for adapters.
+- **`KAIROS-HELM-INTEGRATION`**: Kubernetes instance built from the Helm chart in
+  `helm/`, configured at the project level in [mcp.json](../../mcp.json). Use it
+  to validate the Helm deployment process and app availability. The app version
+  can vary and is not an authority source for adapters or local code changes.
+
+## Server id resolution
+
+Many hosts do not use the config key as the runtime `server` identifier. Resolve
+the agent-visible id before retrying calls.
+
+1. Trigger a minimal MCP call using your configured key.
+2. If the host reports “MCP server does not exist,” read the error’s
+   **Available servers** list (or the host’s MCP panel).
+3. Pick the entry that corresponds to your configured server, often the one
+   whose id ends with the config key, for example `-KAIROS-DEVELOPMENT`.
+
+## Auth and availability failures
+
+If MCP calls fail with 401/403, or tools are missing unexpectedly, treat it as a
+host configuration or authentication problem and fix it before continuing.
+
+- Verify the host points at the intended environment (`KAIROS`,
+  `KAIROS-DEVELOPMENT`, or `KAIROS-HELM-INTEGRATION`).
+- Re-authenticate in the host if the environment requires login.
+- Re-run the minimal call and confirm the tool list matches the connected
+  server’s runtime surface.
+
+## Authority split
+
+When results differ between environments, use this rule to decide what is
+authoritative.
+
+- For runtime tool names, schemas, and responses: treat the **connected server**
+  as authority.
+- For adapter correctness and production behavior: treat **`KAIROS`** as
+  authority.
+- For local implementation changes and regression tests: treat
+  **`KAIROS-DEVELOPMENT`** and this worktree as authority.
+

--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "4.5.0"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kaiiros-mcp.svg
 keywords:

--- a/helm/kairos-mcp/files/kairos-realm.json
+++ b/helm/kairos-mcp/files/kairos-realm.json
@@ -7,7 +7,7 @@
   "duplicateEmailsAllowed": false,
   "ssoSessionIdleTimeout": 604800,
   "ssoSessionMaxLifespan": 604800,
-  "accessTokenLifespan": 3600,
+  "accessTokenLifespan": 28800,
   "accessCodeLifespan": 120,
   "accessCodeLifespanUserAction": 300,
   "accessCodeLifespanLogin": 1800,

--- a/scripts/env/.env.template
+++ b/scripts/env/.env.template
@@ -30,7 +30,7 @@ QDRANT_RESCORE=true
 QDRANT_SNAPSHOT_DIR=.local/var/snapshots
 AUTH_ENABLED=true
 SESSION_SECRET=__SESSION_SECRET__
-SESSION_MAX_AGE_SEC=604800
+SESSION_MAX_AGE_SEC=25200
 AUTH_CALLBACK_BASE_URL=http://localhost:3300
 # Optional: expand kairos-mcp redirect URIs for every port from MIN through MAX (localhost + 127.0.0.1). Defaults match 3300–3301. Run: python3 scripts/deploy-configure-keycloak-realms.py
 # KAIROS_DEV_APP_PORT_MIN=3300

--- a/scripts/keycloak/import/kairos-dev-realm.json
+++ b/scripts/keycloak/import/kairos-dev-realm.json
@@ -7,7 +7,7 @@
   "duplicateEmailsAllowed": false,
   "ssoSessionIdleTimeout": 604800,
   "ssoSessionMaxLifespan": 604800,
-  "accessTokenLifespan": 3600,
+  "accessTokenLifespan": 28800,
   "accessCodeLifespan": 120,
   "accessCodeLifespanUserAction": 300,
   "accessCodeLifespanLogin": 1800,

--- a/scripts/keycloak/import/kairos-prod-realm.json
+++ b/scripts/keycloak/import/kairos-prod-realm.json
@@ -7,7 +7,7 @@
   "duplicateEmailsAllowed": false,
   "ssoSessionIdleTimeout": 604800,
   "ssoSessionMaxLifespan": 604800,
-  "accessTokenLifespan": 3600,
+  "accessTokenLifespan": 28800,
   "groups": [
     { "name": "kairos-admin" },
     { "name": "kairos-auditor" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,8 +124,8 @@ export const KEYCLOAK_CLI_CLIENT_ID = getEnvString('KEYCLOAK_CLI_CLIENT_ID', 'ka
 /** Base URL for redirect_uri (e.g. http://localhost:3500). Must match Keycloak client redirect URIs. */
 export const AUTH_CALLBACK_BASE_URL = getEnvString('AUTH_CALLBACK_BASE_URL', '');
 export const SESSION_SECRET = getEnvString('SESSION_SECRET', '');
-/** Session cookie and payload exp lifetime in seconds; default 7 days. */
-export const SESSION_MAX_AGE_SEC = getEnvInt('SESSION_MAX_AGE_SEC', 604800);
+/** Session cookie and payload exp lifetime in seconds; default 7 hours. */
+export const SESSION_MAX_AGE_SEC = getEnvInt('SESSION_MAX_AGE_SEC', 25_200);
 
 /**
  * Comma-separated scopes advertised from `/.well-known/oauth-protected-resource`.

--- a/src/http/http-auth-callback.ts
+++ b/src/http/http-auth-callback.ts
@@ -144,7 +144,11 @@ export function setupAuthCallback(app: express.Express): void {
       res.redirect(302, '/?error=token_exchange_failed');
       return;
     }
-    const tokens = (await tokenRes.json()) as { id_token?: string; access_token?: string };
+    const tokens = (await tokenRes.json()) as {
+      id_token?: string;
+      access_token?: string;
+      expires_in?: number;
+    };
     const idToken = typeof tokens.id_token === 'string' ? tokens.id_token : undefined;
     const accessToken = typeof tokens.access_token === 'string' ? tokens.access_token : undefined;
     if (!idToken && !accessToken) {
@@ -152,6 +156,7 @@ export function setupAuthCallback(app: express.Express): void {
       res.redirect(302, '/?error=no_tokens');
       return;
     }
+    const tokenExpiresIn = typeof tokens.expires_in === 'number' && Number.isFinite(tokens.expires_in) ? tokens.expires_in : null;
     const idPayload = idToken ? decodeJwtPayloadSegment(idToken) : null;
     const accessPayload = accessToken ? decodeJwtPayloadSegment(accessToken) : null;
     if (idPayload === null && accessPayload === null) {
@@ -173,7 +178,15 @@ export function setupAuthCallback(app: express.Express): void {
     }
     const { merged } = mergedResult;
     merged.groups = applyOidcGroupsAllowlist(merged.groups, OIDC_GROUPS_ALLOWLIST);
-    const exp = Math.floor(Date.now() / 1000) + SESSION_MAX_AGE_SEC;
+    const maxAllowedByAccessToken =
+      tokenExpiresIn && tokenExpiresIn > 120 ? Math.max(60, Math.floor(tokenExpiresIn) - 60) : null;
+    const sessionMaxAgeSec = Math.min(SESSION_MAX_AGE_SEC, maxAllowedByAccessToken ?? SESSION_MAX_AGE_SEC);
+    if (process.env['AUTH_TRACE'] === 'true' || process.env['LOG_LEVEL'] === 'trace') {
+      structuredLogger.info(
+        `[auth] TRACE callback ttl sessionMaxAgeSec=${sessionMaxAgeSec} tokenExpiresIn=${tokenExpiresIn ?? 'missing'}`
+      );
+    }
+    const exp = Math.floor(Date.now() / 1000) + sessionMaxAgeSec;
     const sessionPayload: MergedCallbackClaims & { exp: number; oidc_id_token?: string } = {
       ...merged,
       exp,
@@ -181,7 +194,7 @@ export function setupAuthCallback(app: express.Express): void {
     };
     const cookieValue = signSession(sessionPayload);
     res.setHeader('Set-Cookie', [
-      `${SESSION_COOKIE_NAME}=${encodeURIComponent(cookieValue)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${SESSION_MAX_AGE_SEC}${useSecureCookie ? '; Secure' : ''}`
+      `${SESSION_COOKIE_NAME}=${encodeURIComponent(cookieValue)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${sessionMaxAgeSec}${useSecureCookie ? '; Secure' : ''}`
     ]);
     res.redirect(302, '/ui/');
   });

--- a/src/http/http-auth-callback.ts
+++ b/src/http/http-auth-callback.ts
@@ -31,6 +31,29 @@ import {
   type MergedCallbackClaims
 } from './oidc-profile-claims.js';
 
+export function resolveSessionMaxAgeSec(params: {
+  nowSec: number;
+  sessionMaxAgeSecFallback: number;
+  tokenExpiresIn: number | null;
+  accessTokenExp: number | null;
+}): number {
+  const { nowSec, sessionMaxAgeSecFallback, tokenExpiresIn, accessTokenExp } = params;
+
+  const fromExpiresIn =
+    tokenExpiresIn && Number.isFinite(tokenExpiresIn) && tokenExpiresIn > 120
+      ? Math.max(60, Math.floor(tokenExpiresIn) - 60)
+      : null;
+  if (fromExpiresIn) return fromExpiresIn;
+
+  const fromJwtExp =
+    accessTokenExp && Number.isFinite(accessTokenExp) && accessTokenExp > nowSec + 120
+      ? Math.max(60, Math.floor(accessTokenExp - nowSec) - 60)
+      : null;
+  if (fromJwtExp) return fromJwtExp;
+
+  return sessionMaxAgeSecFallback;
+}
+
 function signSession(
   payload: MergedCallbackClaims & {
     exp: number;
@@ -178,15 +201,23 @@ export function setupAuthCallback(app: express.Express): void {
     }
     const { merged } = mergedResult;
     merged.groups = applyOidcGroupsAllowlist(merged.groups, OIDC_GROUPS_ALLOWLIST);
-    const maxAllowedByAccessToken =
-      tokenExpiresIn && tokenExpiresIn > 120 ? Math.max(60, Math.floor(tokenExpiresIn) - 60) : null;
-    const sessionMaxAgeSec = Math.min(SESSION_MAX_AGE_SEC, maxAllowedByAccessToken ?? SESSION_MAX_AGE_SEC);
+    const nowSec = Math.floor(Date.now() / 1000);
+    const accessTokenExp =
+      accessPayload && typeof accessPayload['exp'] === 'number' && Number.isFinite(accessPayload['exp'])
+        ? accessPayload['exp']
+        : null;
+    const sessionMaxAgeSec = resolveSessionMaxAgeSec({
+      nowSec,
+      sessionMaxAgeSecFallback: SESSION_MAX_AGE_SEC,
+      tokenExpiresIn,
+      accessTokenExp
+    });
     if (process.env['AUTH_TRACE'] === 'true' || process.env['LOG_LEVEL'] === 'trace') {
       structuredLogger.info(
-        `[auth] TRACE callback ttl sessionMaxAgeSec=${sessionMaxAgeSec} tokenExpiresIn=${tokenExpiresIn ?? 'missing'}`
+        `[auth] TRACE callback ttl sessionMaxAgeSec=${sessionMaxAgeSec} tokenExpiresIn=${tokenExpiresIn ?? 'missing'} accessTokenExp=${accessTokenExp ?? 'missing'}`
       );
     }
-    const exp = Math.floor(Date.now() / 1000) + sessionMaxAgeSec;
+    const exp = nowSec + sessionMaxAgeSec;
     const sessionPayload: MergedCallbackClaims & { exp: number; oidc_id_token?: string } = {
       ...merged,
       exp,

--- a/src/http/http-auth-middleware.ts
+++ b/src/http/http-auth-middleware.ts
@@ -20,7 +20,8 @@ import {
   AUTH_MODE,
   AUTH_TRUSTED_ISSUERS,
   AUTH_ALLOWED_AUDIENCES,
-  OIDC_GROUPS_ALLOWLIST
+  OIDC_GROUPS_ALLOWLIST,
+  OIDC_SCOPES_SUPPORTED
 } from '../config.js';
 import { applyOidcGroupsAllowlist } from './oidc-profile-claims.js';
 import { validateBearerToken, type AuthPayload } from './bearer-validate.js';
@@ -169,13 +170,11 @@ function isProtectedPath(path: string): boolean {
 function buildWwwAuthenticate(opts?: { error?: 'invalid_token'; error_description?: string }): string {
   if (!AUTH_CALLBACK_BASE_URL) return '';
   const resourceMetadataUrl = `${AUTH_CALLBACK_BASE_URL.replace(/\/$/, '')}/.well-known/oauth-protected-resource`;
-  const parts = [
-    `Bearer realm="mcp"`,
-    `resource_metadata="${resourceMetadataUrl}"`,
-    'scope="openid profile email"'
-  ];
+  const scopeValue = (OIDC_SCOPES_SUPPORTED || []).join(' ').trim();
+  const parts = [`Bearer realm="mcp"`, `resource_metadata="${resourceMetadataUrl}"`];
+  if (scopeValue) parts.push(`scope="${escapeWwwAuthenticateQuotedValue(scopeValue)}"`);
   if (opts?.error) {
-    parts.unshift(`error="${opts.error}"`);
+    parts.push(`error="${opts.error}"`);
     if (opts.error_description) {
       parts.push(`error_description="${escapeWwwAuthenticateQuotedValue(opts.error_description)}"`);
     }

--- a/tests/integration/session-ttl-alignment.test.ts
+++ b/tests/integration/session-ttl-alignment.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'fs';
 import path from 'path';
-import { describe, expect, jest, test } from '@jest/globals';
 import { getMcpTestBearerToken, hasAuthToken, serverRequiresAuth } from '../utils/auth-headers.js';
 
 function parseJwtPayload(token: string): Record<string, unknown> {
@@ -19,6 +18,17 @@ function readRealmAccessTokenLifespanSec(): number {
     throw new Error(`Invalid accessTokenLifespan in ${realmPath}`);
   }
   return v;
+}
+
+function readConfigDefaultSessionMaxAgeSec(): number {
+  const root = process.cwd();
+  const p = path.join(root, 'src', 'config.ts');
+  const raw = readFileSync(p, 'utf-8');
+  const match = raw.match(/getEnvInt\(\s*'SESSION_MAX_AGE_SEC'\s*,\s*([0-9_]+)\s*\)/);
+  if (!match?.[1]) throw new Error(`SESSION_MAX_AGE_SEC default missing from ${p}`);
+  const parsed = parseInt(match[1].replace(/_/g, ''), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error(`Invalid SESSION_MAX_AGE_SEC default in ${p}`);
+  return parsed;
 }
 
 function readTemplateSessionMaxAgeSec(): number {
@@ -62,18 +72,8 @@ describe('Session TTL alignment', () => {
     ).toBe(25_200);
   });
 
-  test('SESSION_MAX_AGE_SEC default is 25200 when env unset', async () => {
-    const prev = process.env.SESSION_MAX_AGE_SEC;
-    try {
-      delete process.env.SESSION_MAX_AGE_SEC;
-      jest.resetModules();
-      const config = await import('../../src/config.js');
-      expect(config.SESSION_MAX_AGE_SEC).toBe(25_200);
-    } finally {
-      if (prev === undefined) delete process.env.SESSION_MAX_AGE_SEC;
-      else process.env.SESSION_MAX_AGE_SEC = prev;
-      jest.resetModules();
-    }
+  test('src/config.ts default SESSION_MAX_AGE_SEC is 25200', () => {
+    expect(readConfigDefaultSessionMaxAgeSec()).toBe(25_200);
   });
 
   test('repo default session TTL is lower than realm accessTokenLifespan', async () => {

--- a/tests/integration/session-ttl-alignment.test.ts
+++ b/tests/integration/session-ttl-alignment.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, jest, test } from '@jest/globals';
+import { getMcpTestBearerToken, hasAuthToken, serverRequiresAuth } from '../utils/auth-headers.js';
+
+function parseJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split('.');
+  if (parts.length < 2) throw new Error('Invalid JWT format');
+  return JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf-8')) as Record<string, unknown>;
+}
+
+function readRealmAccessTokenLifespanSec(): number {
+  const root = process.cwd();
+  const realmPath = path.join(root, 'helm', 'kairos-mcp', 'files', 'kairos-realm.json');
+  const raw = readFileSync(realmPath, 'utf-8');
+  const parsed = JSON.parse(raw) as { accessTokenLifespan?: unknown };
+  const v = parsed.accessTokenLifespan;
+  if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
+    throw new Error(`Invalid accessTokenLifespan in ${realmPath}`);
+  }
+  return v;
+}
+
+function readTemplateSessionMaxAgeSec(): number {
+  const root = process.cwd();
+  const p = path.join(root, 'scripts', 'env', '.env.template');
+  const raw = readFileSync(p, 'utf-8');
+  const match = raw.match(/^\s*SESSION_MAX_AGE_SEC\s*=\s*([0-9]+)\s*$/m);
+  if (!match?.[1]) throw new Error(`SESSION_MAX_AGE_SEC missing from ${p}`);
+  const parsed = parseInt(match[1], 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error(`Invalid SESSION_MAX_AGE_SEC in ${p}`);
+  return parsed;
+}
+
+describe('Session TTL alignment', () => {
+  test('session TTL resolves from token TTL when available', async () => {
+    const { resolveSessionMaxAgeSec } = await import('../../src/http/http-auth-callback.js');
+    const nowSec = 1000;
+    expect(
+      resolveSessionMaxAgeSec({
+        nowSec,
+        sessionMaxAgeSecFallback: 25_200,
+        tokenExpiresIn: 28_800,
+        accessTokenExp: null
+      })
+    ).toBe(28_740);
+    expect(
+      resolveSessionMaxAgeSec({
+        nowSec,
+        sessionMaxAgeSecFallback: 25_200,
+        tokenExpiresIn: null,
+        accessTokenExp: nowSec + 28_800
+      })
+    ).toBe(28_740);
+    expect(
+      resolveSessionMaxAgeSec({
+        nowSec,
+        sessionMaxAgeSecFallback: 25_200,
+        tokenExpiresIn: null,
+        accessTokenExp: null
+      })
+    ).toBe(25_200);
+  });
+
+  test('SESSION_MAX_AGE_SEC default is 25200 when env unset', async () => {
+    const prev = process.env.SESSION_MAX_AGE_SEC;
+    try {
+      delete process.env.SESSION_MAX_AGE_SEC;
+      jest.resetModules();
+      const config = await import('../../src/config.js');
+      expect(config.SESSION_MAX_AGE_SEC).toBe(25_200);
+    } finally {
+      if (prev === undefined) delete process.env.SESSION_MAX_AGE_SEC;
+      else process.env.SESSION_MAX_AGE_SEC = prev;
+      jest.resetModules();
+    }
+  });
+
+  test('repo default session TTL is lower than realm accessTokenLifespan', async () => {
+    const sessionTtl = readTemplateSessionMaxAgeSec();
+    const realmTtl = readRealmAccessTokenLifespanSec();
+    expect(sessionTtl).toBe(25_200);
+    expect(sessionTtl).toBeLessThan(realmTtl);
+  });
+
+  test('minted access token TTL is >= repo default session TTL (when auth is enabled)', async () => {
+    if (!serverRequiresAuth() || !hasAuthToken()) return;
+    const token = getMcpTestBearerToken();
+    if (!token) return;
+
+    const sessionTtl = readTemplateSessionMaxAgeSec();
+    const realmTtl = readRealmAccessTokenLifespanSec();
+    const payload = parseJwtPayload(token);
+    const exp = payload.exp;
+    const iat = payload.iat;
+    expect(typeof exp).toBe('number');
+    expect(typeof iat).toBe('number');
+    if (typeof exp !== 'number' || typeof iat !== 'number') return;
+
+    const tokenTtl = exp - iat;
+    expect(tokenTtl).toBeGreaterThan(0);
+    expect(tokenTtl).toBeGreaterThanOrEqual(sessionTtl);
+
+    const usingRepoManagedKeycloak = (process.env.KEYCLOAK_URL?.trim() || '') === '';
+    if (usingRepoManagedKeycloak) {
+      expect(tokenTtl).toBeGreaterThanOrEqual(realmTtl - 30);
+      expect(tokenTtl).toBeLessThanOrEqual(realmTtl + 30);
+    }
+  }, 60000);
+});


### PR DESCRIPTION
## Priority: Session (MCP) TTL is derived from IdP token TTL

Problem
- The app session cookie could outlive the OAuth2 access token, which breaks MCP clients that cache credentials and do not refresh automatically.

Changes
- Always derive session TTL from the OAuth token TTL when available:
  - Prefer token response expires_in
  - Fallback to access_token JWT exp
  - Only fallback to SESSION_MAX_AGE_SEC when neither TTL signal is available
- Keeps a small safety margin (60s) so the cookie expires before the token.

Tests
- Adds integration coverage to assert the invariants and the resolver behavior.

---

## Additional changes

Clarifies environment roles for KAIROS MCP instances in maintainer skills.
