### PR TITLE
fix(mem): recover boot system adapter points

### DIFF
--- a/src/resources/mem-resources-boot.ts
+++ b/src/resources/mem-resources-boot.ts
@@ -6,6 +6,8 @@ import { KAIROS_APP_SPACE_ID } from '../config.js';
 import { readdir, readFile } from 'fs/promises';
 import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
+import { parseFrontmatter } from '../utils/frontmatter.js';
+import { IDGenerator } from '../services/id-generator.js';
 
 /** Mem markdown whose basename (no .md) is a UUID — inject as a layer-row URI (`kairos://layer/{uuid}`). */
 const MEM_FILE_UUID_KEY =
@@ -19,6 +21,72 @@ const SYSTEM_PROTOCOL_UUID_BY_SLUG: Record<string, string> = {
   'phase-critic': '00000000-0000-0000-0000-000000002005',
   'protocol-linking-guide': '00000000-0000-0000-0000-000000002006'
 };
+
+function extractFirstH1Title(markdown: string): string | null {
+  const lines = markdown.split(/\r?\n/);
+  for (const line of lines) {
+    const m = line.match(/^#\s+(.+)$/);
+    if (m && m[1]) {
+      const title = m[1].trim();
+      return title.length > 0 ? title : null;
+    }
+  }
+  return null;
+}
+
+async function deletePreexistingAppSpaceEntries(
+  memoryStore: MemoryQdrantStore,
+  markdownContent: string,
+  targetUuid: string
+): Promise<void> {
+  const parsed = parseFrontmatter(markdownContent);
+  const body = parsed.body.length > 0 ? parsed.body : markdownContent;
+  const slug = typeof parsed.slugRaw === 'string' ? parsed.slugRaw.trim() : '';
+  const h1Title = extractFirstH1Title(body);
+
+  const filters: any[] = [];
+  if (slug.length > 0) {
+    filters.push({
+      must: [
+        { key: 'slug', match: { value: slug } },
+        { key: 'space_id', match: { value: KAIROS_APP_SPACE_ID } }
+      ]
+    });
+  }
+  if (h1Title) {
+    const adapterId = IDGenerator.generateAdapterUUIDv5(h1Title);
+    filters.push({
+      must: [
+        { key: 'adapter.id', match: { value: adapterId } },
+        { key: 'space_id', match: { value: KAIROS_APP_SPACE_ID } }
+      ]
+    });
+  }
+
+  if (filters.length === 0) {
+    return;
+  }
+
+  const { client, collection } = memoryStore.getQdrantAccess();
+
+  const { redisCacheService } = await import('../services/redis-cache.js');
+  await redisCacheService.invalidateMemoryCache(targetUuid);
+
+  for (const filter of filters) {
+    await client.delete(collection, { filter } as any);
+  }
+  await redisCacheService.invalidateAfterUpdate();
+
+  if (slug.length > 0) {
+    structuredLogger.warn(
+      `[mem-resources-boot] Removed preexisting app-space points for slug=${slug}; preparing canonical UUID=${targetUuid}`
+    );
+  } else {
+    structuredLogger.warn(
+      `[mem-resources-boot] Removed preexisting app-space points; preparing canonical UUID=${targetUuid}`
+    );
+  }
+}
 
 /**
  * Get the directory containing mem files at runtime
@@ -75,61 +143,6 @@ async function readMemFiles(memDir?: string): Promise<Record<string, string>> {
   }
 
   return memResources;
-}
-
-/**
- * Boot dedup helper (currently not called). Compared Qdrant point id to canonical filename UUID;
- * only layer 1 is remapped to that id, so sibling layers were wrongly deleted as "duplicates".
- * Re-enable after fixing to dedupe by `adapter.id`, not point id.
- */
-async function _removeAppSpaceSystemProtocolDuplicates(memoryStore: MemoryQdrantStore): Promise<void> {
-  const { client, collection } = memoryStore.getQdrantAccess();
-  let totalRemoved = 0;
-
-  for (const [slug, expectedUuid] of Object.entries(SYSTEM_PROTOCOL_UUID_BY_SLUG)) {
-    let offset: string | number | undefined;
-    const duplicateIds: string[] = [];
-
-    do {
-      const page = await client.scroll(collection, {
-        limit: 128,
-        offset,
-        with_payload: true,
-        with_vector: false,
-        filter: {
-          must: [
-            { key: 'slug', match: { value: slug } },
-            { key: 'space_id', match: { value: KAIROS_APP_SPACE_ID } }
-          ]
-        }
-      } as any);
-
-      const points = page.points ?? [];
-      for (const point of points) {
-        const pointId = String(point.id);
-        if (pointId !== expectedUuid) {
-          duplicateIds.push(pointId);
-        }
-      }
-
-      const next = page.next_page_offset;
-      offset = typeof next === 'string' || typeof next === 'number' ? next : undefined;
-    } while (offset !== undefined);
-
-    if (duplicateIds.length > 0) {
-      await client.delete(collection, { points: duplicateIds });
-      totalRemoved += duplicateIds.length;
-      structuredLogger.warn(
-        `[mem-resources-boot] Removed ${duplicateIds.length} non-canonical app-space points for slug=${slug}; kept UUID=${expectedUuid}`
-      );
-    }
-  }
-
-  if (totalRemoved === 0) {
-    structuredLogger.info('[mem-resources-boot] No non-canonical app-space system protocol points found');
-  } else {
-    structuredLogger.warn(`[mem-resources-boot] Removed total ${totalRemoved} non-canonical app-space system protocol points`);
-  }
 }
 
 async function assertSystemProtocolStaticUuids(memoryStore: MemoryQdrantStore): Promise<void> {
@@ -238,7 +251,8 @@ export async function injectMemResourcesAtBoot(memoryStore: MemoryQdrantStore, o
           }
         }
 
-        const memories = await memoryStore.storeAdapter([markdownContent], llmModelId, { forceUpdate: true });
+        await deletePreexistingAppSpaceEntries(memoryStore, markdownContent, targetUuid);
+        const memories = await memoryStore.storeAdapter([markdownContent], llmModelId, { forceUpdate: false });
 
         if (memories.length > 0) {
           // Only the first step is remapped to the file UUID; other layers of the same adapter keep server-generated IDs.
@@ -280,7 +294,6 @@ export async function injectMemResourcesAtBoot(memoryStore: MemoryQdrantStore, o
 
     structuredLogger.info(`[mem-resources-boot] Successfully injected ${injectedCount} mem resources into Qdrant`);
 
-    // await _removeAppSpaceSystemProtocolDuplicates(memoryStore); // see docstring on _removeAppSpaceSystemProtocolDuplicates
     await assertSystemProtocolStaticUuids(memoryStore);
     structuredLogger.info('[mem-resources-boot] Verified static UUID invariant for bundled system protocols');
 
@@ -290,4 +303,3 @@ export async function injectMemResourcesAtBoot(memoryStore: MemoryQdrantStore, o
     }
   });
 }
-

--- a/tests/integration/mem-resources-boot-dedupe-regression.test.ts
+++ b/tests/integration/mem-resources-boot-dedupe-regression.test.ts
@@ -13,18 +13,21 @@ describe('Mem resources boot injection dedupe regression', () => {
 
       const [
         { probeEmbeddingDimension },
+        { installQdrantFetchCompatibility },
         { MemoryQdrantStore },
         { injectMemResourcesAtBoot },
         { KAIROS_APP_SPACE_ID },
         { keyValueStore }
       ] = await Promise.all([
           import('../../src/services/embedding/service.js'),
+          import('../../src/services/qdrant/undici-compat.js'),
           import('../../src/services/memory/store.js'),
           import('../../src/resources/mem-resources-boot.js'),
           import('../../src/config.js'),
           import('../../src/services/key-value-store-factory.js')
         ]);
 
+      installQdrantFetchCompatibility();
       keyValueStoreForThisTest = keyValueStore;
       await probeEmbeddingDimension();
       const memoryStore = new MemoryQdrantStore();

--- a/tests/integration/mem-resources-boot-dedupe-regression.test.ts
+++ b/tests/integration/mem-resources-boot-dedupe-regression.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import crypto from 'node:crypto';
+
+describe('Mem resources boot injection dedupe regression', () => {
+  test('boot injection recovers when app-space already contains duplicate adapter.id/slug entries', async () => {
+    const originalCollection = process.env.QDRANT_COLLECTION;
+    const testCollection = `kairos-test-mem-boot-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+    let keyValueStoreForThisTest: { disconnect(): Promise<void> } | undefined;
+    let collectionToDelete: string | undefined;
+    let qdrantClient: any;
+
+    try {
+      jest.resetModules();
+      process.env.QDRANT_COLLECTION = testCollection;
+
+      const [
+        { probeEmbeddingDimension },
+        { MemoryQdrantStore },
+        { injectMemResourcesAtBoot },
+        { KAIROS_APP_SPACE_ID },
+        { keyValueStore }
+      ] = await Promise.all([
+          import('../../src/services/embedding/service.js'),
+          import('../../src/services/memory/store.js'),
+          import('../../src/resources/mem-resources-boot.js'),
+          import('../../src/config.js'),
+          import('../../src/services/key-value-store-factory.js')
+        ]);
+
+      keyValueStoreForThisTest = keyValueStore;
+      await probeEmbeddingDimension();
+      const memoryStore = new MemoryQdrantStore();
+      await memoryStore.init();
+
+      const { client, collection } = memoryStore.getQdrantAccess();
+      qdrantClient = client;
+      collectionToDelete = collection;
+
+      await injectMemResourcesAtBoot(memoryStore, { force: true });
+
+      const targetUuid = '00000000-0000-0000-0000-000000002001';
+      const base = await client.retrieve(collection, {
+        ids: [targetUuid],
+        with_payload: true,
+        with_vector: true
+      } as any);
+
+      expect(Array.isArray(base)).toBe(true);
+      expect(base[0]).toBeDefined();
+      const basePoint = base[0] as any;
+
+      const conflictId = crypto.randomUUID();
+      await client.delete(collection, { points: [targetUuid] } as any);
+      await client.upsert(collection, {
+        points: [
+          {
+            id: conflictId,
+            payload: basePoint.payload,
+            vector: basePoint.vector
+          }
+        ]
+      } as any);
+
+      await injectMemResourcesAtBoot(memoryStore, { force: true });
+
+      const restored = await client.retrieve(collection, {
+        ids: [targetUuid],
+        with_payload: true,
+        with_vector: false
+      } as any);
+
+      expect(Array.isArray(restored)).toBe(true);
+      expect(restored[0]).toBeDefined();
+      expect((restored[0] as any)?.payload?.space_id).toBe(KAIROS_APP_SPACE_ID);
+
+      await client.delete(collection, { points: [conflictId] } as any);
+    } finally {
+      if (qdrantClient && collectionToDelete) {
+        try {
+          await qdrantClient.deleteCollection(collectionToDelete);
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+      if (keyValueStoreForThisTest) {
+        await keyValueStoreForThisTest.disconnect();
+      }
+      if (originalCollection === undefined) {
+        delete process.env.QDRANT_COLLECTION;
+      } else {
+        process.env.QDRANT_COLLECTION = originalCollection;
+      }
+    }
+  }, 120000);
+});

--- a/tests/integration/mem-resources-boot-dedupe-regression.test.ts
+++ b/tests/integration/mem-resources-boot-dedupe-regression.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, jest, test } from '@jest/globals';
 import crypto from 'node:crypto';
 
 describe('Mem resources boot injection dedupe regression', () => {
@@ -10,7 +9,6 @@ describe('Mem resources boot injection dedupe regression', () => {
     let qdrantClient: any;
 
     try {
-      jest.resetModules();
       process.env.QDRANT_COLLECTION = testCollection;
 
       const [
@@ -79,7 +77,6 @@ describe('Mem resources boot injection dedupe regression', () => {
         try {
           await qdrantClient.deleteCollection(collectionToDelete);
         } catch {
-          // ignore cleanup errors
         }
       }
       if (keyValueStoreForThisTest) {


### PR DESCRIPTION
Summary

- Fixes boot-time system adapter injection getting stuck with “Failed to inject memory … Cannot overwrite adapters in protected app/system spaces”.
- Root cause is preexisting app-space points for the same slug / adapter.id (often from upgrades or previous boot runs) that collide with the canonical UUID injection.

Changes

- Boot injection deletes preexisting app-space points for the target slug and adapter.id before injecting the canonical UUIDs, avoiding protected-space overwrite failures.
- Adds integration regression test that reproduces the collision scenario and asserts boot injection recovers.

Verification

- npm run lint
- npm run dev:test -- tests/integration/mem-resources-boot-dedupe-regression.test.ts

