### PR TITLE
feat(helm): lock down Keycloak admin paths

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "4.5.2"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kaiiros-mcp.svg
 keywords:

--- a/helm/kairos-mcp/templates/_helpers.tpl
+++ b/helm/kairos-mcp/templates/_helpers.tpl
@@ -11,3 +11,14 @@ Explicit .Values.gateway.mode wins; "auto" picks based on gatewayClassName prese
   {{- $mode -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "kairos.adminHostname" -}}
+{{- $gw := default dict .Values.gateway -}}
+{{- $routes := default dict $gw.routes -}}
+{{- $kc := default dict $routes.keycloak -}}
+{{- $lock := default dict $kc.adminLockdown -}}
+{{- $enabled := ternary $lock.enabled true (hasKey $lock "enabled") -}}
+{{- if and $enabled $gw.hostname -}}
+  {{- default (printf "admin.%s" $gw.hostname) $lock.adminHostname -}}
+{{- end -}}
+{{- end -}}

--- a/helm/kairos-mcp/templates/httproute-keycloak-admin-redirect.yaml
+++ b/helm/kairos-mcp/templates/httproute-keycloak-admin-redirect.yaml
@@ -1,0 +1,38 @@
+{{- $gw := default dict .Values.gateway }}
+{{- $routes := default dict $gw.routes }}
+{{- $kcRoute := default dict $routes.keycloak }}
+{{- $kc := .Values.keycloakInstance }}
+{{- $adminHost := include "kairos.adminHostname" . | trim }}
+{{- $relativePath := default "/sso" $kc.httpRelativePath }}
+{{- $mode := include "kairos.ingressMode" . | trim }}
+{{- if and $adminHost (eq $mode "gateway") $gw.enabled $gw.hostname $kcRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keycloak-admin-redirect
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+spec:
+  parentRefs:
+    - name: {{ $gw.existingGatewayName | default $gw.gatewayName }}
+      {{- if $gw.existingGatewayNamespace }}
+      namespace: {{ $gw.existingGatewayNamespace }}
+      {{- else }}
+      namespace: {{ .Release.Namespace }}
+      {{- end }}
+  hostnames:
+    - {{ $gw.hostname }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ printf "%s/admin" $relativePath }}
+        - path:
+            type: PathPrefix
+            value: {{ printf "%s/realms/master" $relativePath }}
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            hostname: {{ $adminHost }}
+            statusCode: 302
+{{- end }}

--- a/helm/kairos-mcp/templates/keycloak-admin-authz-policy.yaml
+++ b/helm/kairos-mcp/templates/keycloak-admin-authz-policy.yaml
@@ -1,0 +1,27 @@
+{{- $kc := .Values.keycloakInstance }}
+{{- $adminHost := include "kairos.adminHostname" . | trim }}
+{{- $relativePath := default "/sso" $kc.httpRelativePath }}
+{{- if and $adminHost (.Capabilities.APIVersions.Has "security.istio.io/v1") }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: keycloak-deny-admin-public
+  namespace: {{ $kc.namespace | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+spec:
+  selector:
+    matchLabels:
+      app: keycloak
+  action: DENY
+  rules:
+    - to:
+        - operation:
+            paths:
+              - "{{ $relativePath }}/admin/*"
+              - "{{ $relativePath }}/realms/master/*"
+      when:
+        - key: request.headers[host]
+          notValues:
+            - {{ $adminHost | quote }}
+{{- end }}

--- a/helm/kairos-mcp/templates/keycloak-cr.yaml
+++ b/helm/kairos-mcp/templates/keycloak-cr.yaml
@@ -78,6 +78,11 @@ spec:
     - name: proxy-trusted-addresses
       value: {{ $proxyTrusted | quote }}
     {{- end }}
+    {{- $adminHost := include "kairos.adminHostname" . | trim }}
+    {{- if $adminHost }}
+    - name: hostname-admin
+      value: {{ printf "https://%s%s" $adminHost $relativePath | quote }}
+    {{- end }}
   unsupported:
     podTemplate:
       spec:

--- a/helm/kairos-mcp/values.yaml
+++ b/helm/kairos-mcp/values.yaml
@@ -113,6 +113,9 @@ gateway:
       serviceName: ""
       serviceNamespace: ""
       port: 8080
+      adminLockdown:
+        enabled: true
+        adminHostname: ""
 
 qdrant:
   enabled: true


### PR DESCRIPTION
Add adminLockdown values and templates to redirect/deny Keycloak admin endpoints on the public gateway.
