### PR TITLE
fix(helm): hook jobs + idempotent credentials secret (#495)

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives u
 type: application
 version: 0.3.1
 appVersion: "4.5.2"
-icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kaiiros-mcp.svg
+icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:
   - kairos
   - mcp

--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "4.5.2"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:

--- a/helm/kairos-mcp/templates/NOTES.txt
+++ b/helm/kairos-mcp/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- $secretName := .Values.credentials.existingSecret | default .Values.credentials.name -}}
+{{- $secretName := include "kairos.credentialsSecretName" . -}}
 {{- $baseUrl := .Values.app.auth.callbackBaseUrl | default (printf "https://%s" .Values.global.hostname) -}}
 KAIROS MCP has been deployed to namespace {{ .Release.Namespace }}.
 

--- a/helm/kairos-mcp/templates/_helpers.tpl
+++ b/helm/kairos-mcp/templates/_helpers.tpl
@@ -22,3 +22,37 @@ Explicit .Values.gateway.mode wins; "auto" picks based on gatewayClassName prese
   {{- default (printf "admin.%s" $gw.hostname) $lock.adminHostname -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "kairos.credentialsLegacySecretName" -}}
+{{- printf "kairos-mcp-credentials" -}}
+{{- end -}}
+
+{{- define "kairos.credentialsPreferredSecretName" -}}
+{{- $name := default "" .Values.credentials.name | trim -}}
+{{- if $name -}}
+{{- $name -}}
+{{- else -}}
+{{- printf "%s-credentials" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kairos.credentialsSecretName" -}}
+{{- $existing := default "" .Values.credentials.existingSecret | trim -}}
+{{- if $existing -}}
+{{- $existing -}}
+{{- else -}}
+{{- $preferred := include "kairos.credentialsPreferredSecretName" . -}}
+{{- $legacy := include "kairos.credentialsLegacySecretName" . -}}
+{{- $preferredObj := lookup "v1" "Secret" .Release.Namespace $preferred -}}
+{{- if $preferredObj -}}
+{{- $preferred -}}
+{{- else -}}
+{{- $legacyObj := lookup "v1" "Secret" .Release.Namespace $legacy -}}
+{{- if $legacyObj -}}
+{{- $legacy -}}
+{{- else -}}
+{{- $preferred -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/kairos-mcp/templates/credentials-generator-rbac.yaml
+++ b/helm/kairos-mcp/templates/credentials-generator-rbac.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.credentials.autoGenerate (not .Values.credentials.existingSecret) }}
+{{- $secretName := include "kairos.credentialsSecretName" . -}}
+{{- $existingSecretObj := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and .Values.credentials.autoGenerate (not .Values.credentials.existingSecret) (not $existingSecretObj) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/kairos-mcp/templates/credentials-secret-generator-job.yaml
+++ b/helm/kairos-mcp/templates/credentials-secret-generator-job.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.credentials.autoGenerate (not .Values.credentials.existingSecret) }}
+{{- $secretName := include "kairos.credentialsSecretName" . -}}
+{{- $existingSecretObj := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and .Values.credentials.autoGenerate (not .Values.credentials.existingSecret) (not $existingSecretObj) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-credentials-generator
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-20"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -15,20 +17,20 @@ spec:
       serviceAccountName: {{ .Release.Name }}-credentials-generator
       containers:
         - name: generator
-          image: registry.k8s.io/kubectl:v1.33.0
+          image: {{ .Values.hooks.kubectlImage | quote }}
           command:
             - /bin/sh
             - -c
             - |
               set -e
-              if kubectl get secret {{ .Values.credentials.name }} -n {{ .Release.Namespace }} &>/dev/null; then
-                echo "Secret {{ .Values.credentials.name }} already exists, skipping."
+              if kubectl get secret {{ $secretName }} -n {{ .Release.Namespace }} &>/dev/null; then
+                echo "Secret {{ $secretName }} already exists, skipping."
                 exit 0
               fi
               redis_password="$(head -c 24 /dev/urandom | base64 | tr -d '\n')"
               keycloak_db_password="$(head -c 24 /dev/urandom | base64 | tr -d '\n')"
               session_secret="$(head -c 32 /dev/urandom | base64 | tr -d '\n')"
-              kubectl create secret generic {{ .Values.credentials.name }} -n {{ .Release.Namespace }} \
+              kubectl create secret generic {{ $secretName }} -n {{ .Release.Namespace }} \
                 --from-literal=redis-password="$redis_password" \
                 --from-literal=keycloak-db-password="$keycloak_db_password" \
                 --from-literal=session-secret="$session_secret"

--- a/helm/kairos-mcp/templates/kairos-mcp-deployment.yaml
+++ b/helm/kairos-mcp/templates/kairos-mcp-deployment.yaml
@@ -129,12 +129,12 @@ spec:
             - name: OPENAI_EMBEDDING_MODEL
               value: {{ $openai.model | default "text-embedding-3-small" | quote }}
             {{- end }}
-            {{- $appSecret := .Values.app.existingSecret | default .Values.credentials.name }}
+            {{- $appSecret := .Values.app.existingSecret | default (include "kairos.credentialsSecretName" .) }}
             {{- if $appSecret }}
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ $appSecret }}
+                  name: {{ $appSecret | quote }}
                   key: session-secret
                   optional: true
             {{- end }}

--- a/helm/kairos-mcp/templates/operator-precheck-job.yaml
+++ b/helm/kairos-mcp/templates/operator-precheck-job.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-operator-precheck
       containers:
         - name: precheck
-          image: registry.k8s.io/kubectl:v1.33.0
+          image: {{ .Values.hooks.kubectlImage | quote }}
           command:
             - /bin/sh
             - -c

--- a/helm/kairos-mcp/values.yaml
+++ b/helm/kairos-mcp/values.yaml
@@ -11,7 +11,10 @@ global:
 credentials:
   autoGenerate: true
   existingSecret: ""
-  name: "kairos-mcp-credentials"
+  name: ""
+
+hooks:
+  kubectlImage: "cgr.dev/chainguard/kubectl:1.33-dev"
 
 ha:
   antiAffinity:


### PR DESCRIPTION
Fixes #495.

- Replace distroless kubectl hook image with shell-capable image via `hooks.kubectlImage`.
- Make credentials generator hook truly idempotent at render time using Helm `lookup` (skip Job/RBAC when secret already exists).
- Resolve credentials secret name consistently across hooks/deployment/NOTES.
- Fix Chart icon URL typo and bump chart version.