### PR TITLE
fix(mcp): JSON-RPC auth error for unauthenticated /mcp

### DIFF
--- a/src/http/http-auth-middleware.ts
+++ b/src/http/http-auth-middleware.ts
@@ -334,11 +334,13 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     `[auth] 401 ${req.method} ${req.path}${isMcp ? ' (announcing auth need for MCP client)' : ''}`
   );
   setWwwAuthenticate(res);
-  res.status(401).json({
-    error: 'Unauthorized',
-    message: 'Authentication required',
-    login_url: loginUrlForJson
-  });
+  const body = req.body as Record<string, unknown> | undefined;
+  const isJsonRpc = isMcp && body?.['jsonrpc'] === '2.0';
+  res.status(401).json(
+    isJsonRpc
+      ? { jsonrpc: '2.0', error: { code: -32001, message: 'Authentication required', data: { error: 'unauthorized', message: 'Authentication required', reauth_required: true, next_step: MCP_SSO_REAUTH_NEXT_STEP, login_url: loginUrlForJson } }, id: body?.['id'] ?? null }
+      : { error: 'Unauthorized', message: 'Authentication required', login_url: loginUrlForJson }
+  );
 }
 
 export { SESSION_COOKIE_NAME };

--- a/tests/integration/mcp-list-offerings-for-ui.test.ts
+++ b/tests/integration/mcp-list-offerings-for-ui.test.ts
@@ -2,7 +2,7 @@
  * MCP Apps discovery: `listOfferingsForUI` is handled in http-mcp-handler (not SDK).
  */
 import { waitForHealthCheck } from '../utils/health-check.js';
-import { getTestAuthBaseUrl, getAuthHeaders } from '../utils/auth-headers.js';
+import { getTestAuthBaseUrl, getAuthHeaders, serverRequiresAuth } from '../utils/auth-headers.js';
 import {
   KAIROS_ACTIVATE_UI_SKYBRIDGE_URI,
   KAIROS_ACTIVATE_UI_URI,
@@ -100,5 +100,37 @@ describe('MCP listOfferingsForUI', () => {
     expect(resources.find((r) => r.uri === KAIROS_ACTIVATE_UI_URI)?.mimeType).toBe(MCP_APP_HTML_MIME_TYPE);
     expect(resources.some((r) => r.uri === KAIROS_ACTIVATE_UI_SKYBRIDGE_URI)).toBe(true);
     expect(resources.find((r) => r.uri === KAIROS_ACTIVATE_UI_SKYBRIDGE_URI)?.mimeType).toBe(SKYBRIDGE_HTML_MIME_TYPE);
+  });
+
+  test('returns a JSON-RPC auth error for unauthenticated JSON-RPC requests', async () => {
+    if (!serverAvailable) return;
+    if (!serverRequiresAuth()) return;
+
+    const res = await fetch(`${BASE_URL}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {}
+      })
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as {
+      jsonrpc?: string;
+      id?: number;
+      error?: { code?: number; message?: string; data?: Record<string, unknown> };
+    };
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.id).toBe(1);
+    expect(body.error?.code).toBe(-32001);
+    expect(body.error?.message).toBe('Authentication required');
+    expect(body.error?.data?.['reauth_required']).toBe(true);
+    expect(typeof body.error?.data?.['next_step']).toBe('string');
+    expect(typeof body.error?.data?.['login_url']).toBe('string');
   });
 });


### PR DESCRIPTION
When auth is enabled, unauthenticated Streamable HTTP calls to `/mcp` currently return a plain JSON 401 body. Some MCP clients surface this as a generic Unauthorized (or even null at the host layer).

This change detects JSON-RPC requests (`{"jsonrpc":"2.0", ...}`) and returns a JSON-RPC error envelope on 401, while keeping the existing non-JSON-RPC JSON shape for other clients.

- Keeps `WWW-Authenticate` with `resource_metadata` and `scope`
- Adds actionable `next_step` + `login_url` inside `error.data`
- Adds integration test for unauthenticated JSON-RPC request
