### PR TITLE
fix(mcp): return JSON-RPC error envelope on unauthenticated /mcp requests

### DIFF
--- a/src/http/http-auth-middleware.ts
+++ b/src/http/http-auth-middleware.ts
@@ -27,6 +27,7 @@ import { validateBearerToken, type AuthPayload } from './bearer-validate.js';
 import { getSpaceContext, runWithSpaceContext, type SpaceContext } from '../utils/tenant-context.js';
 import { structuredLogger } from '../utils/structured-logger.js';
 import { setWwwAuthenticate } from './http-www-authenticate.js';
+import { buildJsonRpcAuthError } from './mcp-ui-offerings-auth-jsonrpc.js';
 export { setWwwAuthenticate };
 
 export type { AuthPayload };
@@ -305,11 +306,20 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     `[auth] 401 ${req.method} ${req.path}${isMcp ? ' (announcing auth need for MCP client)' : ''}`
   );
   setWwwAuthenticate(res);
-  res.status(401).json({
-    error: 'Unauthorized',
-    message: 'Authentication required',
-    login_url: loginUrlForJson
-  });
+
+  // Return a JSON-RPC 2.0 error envelope when the request is a JSON-RPC call to /mcp,
+  // so MCP clients can parse a structured error instead of a generic 401 body.
+  const body = req.body as Record<string, unknown> | undefined;
+  const isJsonRpc = isMcp && body?.['jsonrpc'] === '2.0';
+  if (isJsonRpc) {
+    res.status(401).json(buildJsonRpcAuthError(body?.['id'], 'Authentication required', loginUrlForJson));
+  } else {
+    res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Authentication required',
+      login_url: loginUrlForJson
+    });
+  }
 }
 
 export { SESSION_COOKIE_NAME };

--- a/src/http/mcp-ui-offerings-auth-jsonrpc.ts
+++ b/src/http/mcp-ui-offerings-auth-jsonrpc.ts
@@ -1,18 +1,34 @@
 import { safeCreateOidcLoginUrlForApiResponse } from './http-auth-oidc-redirect.js';
 
-/** JSON-RPC body for `listOfferingsForUI` when auth is required (machine-actionable remediation). */
-export function buildListOfferingsUnauthorizedJsonRpc(id: unknown): Record<string, unknown> {
-  const loginUrl = safeCreateOidcLoginUrlForApiResponse();
+/**
+ * Implementation-defined JSON-RPC error code for authentication-required responses.
+ * Range -32000 to -32099 is reserved for implementation-defined server errors per JSON-RPC 2.0 spec.
+ */
+export const JSONRPC_ERR_AUTH_REQUIRED = -32001;
+
+/** Build a JSON-RPC 2.0 error envelope for unauthenticated requests to /mcp. */
+export function buildJsonRpcAuthError(
+  id: unknown,
+  message: string,
+  loginUrl: string | undefined
+): Record<string, unknown> {
   return {
     jsonrpc: '2.0',
     error: {
-      code: -32001,
-      message: 'Authentication required for UI offerings',
+      code: JSONRPC_ERR_AUTH_REQUIRED,
+      message,
       data: {
+        error: 'unauthorized',
         reauth_required: true,
         ...(loginUrl ? { login_url: loginUrl } : {})
       }
     },
-    id
+    id: id ?? null
   };
+}
+
+/** JSON-RPC body for `listOfferingsForUI` when auth is required (machine-actionable remediation). */
+export function buildListOfferingsUnauthorizedJsonRpc(id: unknown): Record<string, unknown> {
+  const loginUrl = safeCreateOidcLoginUrlForApiResponse();
+  return buildJsonRpcAuthError(id, 'Authentication required for UI offerings', loginUrl ?? undefined);
 }

--- a/tests/integration/mcp-auth-jsonrpc-error.test.ts
+++ b/tests/integration/mcp-auth-jsonrpc-error.test.ts
@@ -1,0 +1,103 @@
+/**
+ * MCP auth: unauthenticated JSON-RPC requests to /mcp must receive a JSON-RPC 2.0
+ * error envelope (not a plain JSON 401), so MCP clients can parse structured errors.
+ *
+ * Skipped when AUTH_ENABLED is false (SIMPLE mode).
+ */
+import { getTestAuthBaseUrl, serverRequiresAuth } from '../utils/auth-headers.js';
+import { setupServerCheck } from './cli-commands-shared.js';
+import { JSONRPC_ERR_AUTH_REQUIRED } from '../../src/http/mcp-ui-offerings-auth-jsonrpc.js';
+
+const BASE_URL = getTestAuthBaseUrl();
+let serverAvailable = false;
+
+beforeAll(async () => {
+  serverAvailable = await setupServerCheck();
+}, 60000);
+
+describe('MCP unauthenticated JSON-RPC error envelope', () => {
+  test('returns JSON-RPC error envelope for unauthenticated JSON-RPC POST to /mcp', async () => {
+    if (!serverAvailable) return;
+    if (!serverRequiresAuth()) return;
+
+    const res = await fetch(`${BASE_URL}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 42,
+        method: 'tools/list',
+        params: {}
+      })
+    });
+
+    expect(res.status).toBe(401);
+
+    // WWW-Authenticate header must still be present
+    expect(res.headers.get('www-authenticate')).toBeTruthy();
+
+    const body = (await res.json()) as {
+      jsonrpc?: string;
+      id?: number | null;
+      error?: { code?: number; message?: string; data?: Record<string, unknown> };
+    };
+
+    // JSON-RPC 2.0 envelope structure
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.id).toBe(42);
+    expect(body.error).toBeDefined();
+    expect(body.error?.code).toBe(JSONRPC_ERR_AUTH_REQUIRED);
+    expect(body.error?.message).toBe('Authentication required');
+
+    // Actionable data for the client
+    expect(body.error?.data?.['error']).toBe('unauthorized');
+    expect(body.error?.data?.['reauth_required']).toBe(true);
+    expect(typeof body.error?.data?.['login_url']).toBe('string');
+  });
+
+  test('returns plain JSON 401 for non-JSON-RPC POST to /mcp', async () => {
+    if (!serverAvailable) return;
+    if (!serverRequiresAuth()) return;
+
+    const res = await fetch(`${BASE_URL}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      },
+      body: JSON.stringify({ hello: 'world' })
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: string; message?: string; login_url?: string };
+    expect(body.error).toBe('Unauthorized');
+    expect(body.message).toBe('Authentication required');
+    expect(typeof body.login_url).toBe('string');
+  });
+
+  test('echoes null id when JSON-RPC request omits id', async () => {
+    if (!serverAvailable) return;
+    if (!serverRequiresAuth()) return;
+
+    const res = await fetch(`${BASE_URL}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        params: {}
+      })
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { jsonrpc?: string; id?: unknown; error?: unknown };
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.id).toBeNull();
+  });
+});


### PR DESCRIPTION
When auth is enabled, unauthenticated JSON-RPC calls to `/mcp` now receive a proper JSON-RPC 2.0 error envelope (code -32001) instead of a plain JSON 401 body. Non-JSON-RPC clients still get the existing shape.

## Changes

- Add `JSONRPC_ERR_AUTH_REQUIRED` constant and `buildJsonRpcAuthError` helper in `mcp-ui-offerings-auth-jsonrpc.ts`
- Refactor `buildListOfferingsUnauthorizedJsonRpc` to use the shared builder
- Detect JSON-RPC requests in `http-auth-middleware.ts` 401 path and return structured envelope
- Add integration tests for JSON-RPC envelope, plain JSON fallback, and null-id edge case

Supersedes closed draft PR #498.