### PR TITLE
fix(ci): resolve YAML parse error in sync-wiki.yml workflow

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -50,11 +50,11 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             
             git add -A
-            git commit -m "Update wiki from main repository
+            git commit -m 'Update wiki from main repository
 
 Auto-synced from main repository commit: ${{ github.sha }}
 Triggered by: ${{ github.actor }}
-Date: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+Date: $(date -u "+%Y-%m-%d %H:%M:%S UTC")'
             
             echo "📤 Pushing to wiki repository..."
             git push


### PR DESCRIPTION
## Issue

The sync-wiki.yml workflow failed with a YAML parse error:

```
(Line: 55, Col: 1): Unexpected value 'Auto-synced from main repository commit'
(Line: 56, Col: 1): Unexpected value 'Triggered by'
(Line: 57, Col: 1): Unexpected value 'Date'
```

**Failed run:** https://github.com/debian777/kairos-mcp/actions/runs/26269149998

## Root Cause

The multiline commit message in the `git commit -m` command used double quotes, causing GitHub Actions to interpret the continuation lines as YAML keys instead of part of the string.

## Fix

Changed from double quotes to single quotes for the commit message:

```yaml
# Before (broken)
git commit -m "Update wiki from main repository

Auto-synced from main repository commit: ${{ github.sha }}
...

# After (fixed)
git commit -m 'Update wiki from main repository

Auto-synced from main repository commit: ${{ github.sha }}
...
```

This ensures the entire multiline string is treated as a single YAML value.