### PR TITLE
docs(workflows): document Pattern B path-filter gating + validate skip path end-to-end

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -150,6 +150,14 @@ The integration workflow uses **optional secrets:** `OPENAI_API_KEY` (embedding 
 
 **Caching:** **`verify-ui-primary`** uses the same **`~/.cache/ms-playwright`** key as **`verify-integration-primary`** / **`verify-integration-advisory`** (lockfile hash only). **`verify-ui-advisory`** uses a **Node-version suffix** on the Playwright cache key so the advisory runner does not contend with the Node 24 primary cache. Integration verify jobs restore/save **Docker infra** images (`compose.yaml` hash).
 
+### Path-filter gating (Pattern B)
+
+Both **`integration.yml`** and **`integration-simple.yml`** prefix their job graph with a lightweight **`changes`** job that uses [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter) to set `code=true` only when files that can affect build/test outcomes are touched. Heavy jobs (build, verify-ui, verify-integration, verify-docker) gate on `needs.changes.outputs.code == 'true'`, so docs-only / wiki-only / helm-only PRs skip the expensive matrix while the gate jobs (**Integration workflow passed**, **Integration simple workflow passed**) still report success and satisfy required-status-check branch protection.
+
+**Forced run** (`code=true` regardless of paths) for: `workflow_dispatch`, `merge_group`, tag pushes (`refs/tags/*`), and pushes to `ci/**` branches. The forcing logic lives in the `Combine with forced-run events` step of the `changes` job.
+
+When adding new build inputs, update the `code:` filter list in **both** workflow YAMLs (they are kept intentionally in sync). The full filter list covers `src/**`, `tests/**`, `scripts/**`, `skills/**`, root config (`package.json`, `package-lock.json`, `tsconfig*.json`, `jest.config.js`, `vitest.config.ts`, `vite.config.ts`, `postcss.config.js`, `eslint.config.cjs`, `eslint/**`, `knip.config.ts`), container files (`Dockerfile*`, `compose.yaml`), `.trivyignore`, the workflow's own YAML, and `.env.dev_simple` for the simple variant.
+
 **Note:** Primary integration verify cannot start until **`build-primary`** finishes (artifact). Within that job, **infra starts before the artifact download** so pulls and boot overlap post-build wall clock plus later steps.
 
 **Job summary:** Most steps append a **Vitest-style** block to `$GITHUB_STEP_SUMMARY` (`##` title, `### Summary`, ✅/❌ bullets) via `scripts/ci-github-step-summary.mjs`. The parallel checks step appends tsc and Knip summaries after all three commands finish. **Vitest** adds its own “Vitest Test Report” when `CI=true` (`vitest.config.ts`). **Jest** integration tests append “Jest integration tests” via `tests/reporters/jest-github-summary-reporter.cjs` when `GITHUB_STEP_SUMMARY` is set (`scripts/deploy-run-env.sh`).


### PR DESCRIPTION
## What

Documents the Pattern B path-filter gating that was shipped in PRs #508 and #509, by adding a new **Path-filter gating (Pattern B)** subsection to `.github/workflows/README.md`.

## Why

This PR has a **dual purpose**:

1. **Useful documentation.** The Pattern B mechanism (the `changes` job + `dorny/paths-filter@v3` + forced-run events for `workflow_dispatch` / `merge_group` / tag pushes / `ci/**` branches) was not previously described in the workflows README. New contributors and future maintainers benefit from having the convention written down alongside the rest of the integration-workflow docs.

2. **End-to-end validation of the skip path.** PRs #508 and #509 self-validated the **forced-run** path (their `ci/**` branches forced `code=true`, exercising the full heavy job matrix as proof). This PR validates the symmetric **skip path**: a real PR that touches **only** files outside the filter list. Expected behaviour:

   - The `changes` job runs and outputs `code=false`.
   - All gated heavy jobs (`build-primary`, `build-advisory`, `verify-ui-*`, `verify-integration-*`, `verify-docker`) **skip**.
   - The gate jobs **`Integration workflow passed`** and **`Integration simple workflow passed`** still report **success** (success-on-skip), so branch protection is satisfied.

If the skip path behaves as designed, this PR will merge cleanly with the heavy matrix never running — proving the optimization works end-to-end on a real PR.

## Files touched

- `.github/workflows/README.md` — adds a new `### Path-filter gating (Pattern B)` subsection inside the **Integration workflow** section (8 lines added).

## Path-filter check

The changed file (`.github/workflows/README.md`) is **not** in the `code:` filter list of either `integration.yml` or `integration-simple.yml` — only `.github/workflows/integration.yml` and `.github/workflows/integration-simple.yml` themselves are filtered, not the README.

## Branch naming

Branch is `test/path-filter-skip-validation` (deliberately **not** `ci/*`, which would force `code=true` and defeat the skip-path test).

## Risk

Docs-only. Zero runtime / build / test surface affected.
