### PR TITLE
perf(tests): load env once via globalSetup; run jest integration tests in parallel

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -56,8 +56,9 @@ export default {
             statements: 99,
         },
     },
-    // Load .env.${ENV} first so test process has same vars as server (deploy-run-env.sh); then .env
-    setupFiles: ['<rootDir>/tests/env-loader.ts', 'dotenv/config'],
+    // Environment loading now handled once by globalSetup (tests/global-setup-auth.ts)
+    // env-loader.ts kept to preserve Jest configuration structure (prevents 85+ redundant dotenv logs)
+    setupFiles: ['<rootDir>/tests/env-loader.ts'],
     // Global test setup runs before all tests
     setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
     // When AUTH_ENABLED=true: start Keycloak + server, write .test-auth-env.dev.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.5.3-rc.0",
+  "version": "4.6.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "4.5.3-rc.0",
+      "version": "4.6.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/scripts/deploy-run-env.sh
+++ b/scripts/deploy-run-env.sh
@@ -520,12 +520,12 @@ test() {
             silent_flag=""
             [ "${CI:-}" = "true" ] || silent_flag="--silent"
             declare -a jest_args=()
-            jest_args+=(--runInBand --detectOpenHandles --testTimeout=30000)
+            jest_args+=(--maxWorkers=10 --detectOpenHandles --testTimeout=30000)
             # Job summary (GitHub Actions): same style as Vitest's github-actions reporter
             if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
                 jest_args+=(--reporters default --reporters "$PROJECT_DIR/tests/reporters/jest-github-summary-reporter.cjs")
             fi
-            # Serial tests (--runInBand): one MCP server; extra Jest workers did not improve wall time and caused queueing unless MAX_CONCURRENT_MCP_REQUESTS is high.
+            # Parallel tests (--maxWorkers=10): requires MAX_CONCURRENT_MCP_REQUESTS high enough to avoid queueing.
             # deploy - now need to run manually: npm run dev:deploy
             if [ ${#args[@]} -eq 0 ]; then
                 MCP_URL="http://localhost:${PORT:-3300}/mcp" NODE_OPTIONS='--experimental-vm-modules' jest $silent_flag "${jest_args[@]}" --testPathPatterns "tests/integration/" 2>&1  | tee -a "$REPORT_LOG_FILE"

--- a/tests/env-loader.ts
+++ b/tests/env-loader.ts
@@ -1,14 +1,20 @@
 /**
- * Load .env into process.env before any tests run.
- * Ensures the test process sees the same env as the server (deploy-run-env.sh sources
- * the same file). Run before dotenv/config so ENV-specific file wins.
- * Fixes CI/local cases where Jest workers or globalSetup would otherwise miss vars.
+ * Environment loader stub.
+ * 
+ * Previously loaded .env files via dotenv/config, but this was redundant because:
+ * - Jest's setupFiles runs before EACH test file (85+ times for integration tests)
+ * - globalSetup (tests/global-setup-auth.ts) already loads env vars ONCE before all tests
+ * - Jest workers inherit process.env from globalSetup
+ * 
+ * This file is kept in setupFiles to preserve the existing Jest configuration structure.
+ * The normalizeRedisUrl helper is retained for potential use by setup.ts if needed.
  */
-import { config } from 'dotenv';
-import { existsSync } from 'fs';
-import { join } from 'path';
 
-function normalizeRedisUrl(rawUrl: string | undefined, rawPassword: string | undefined): string {
+/**
+ * Normalize Redis URL by embedding password if not already present.
+ * Kept for reference; global-setup-auth.ts now handles this during initial env load.
+ */
+export function normalizeRedisUrl(rawUrl: string | undefined, rawPassword: string | undefined): string {
   const url = (rawUrl || '').trim();
   const password = (rawPassword || '').trim();
   if (!url || !password) return url;
@@ -24,22 +30,5 @@ function normalizeRedisUrl(rawUrl: string | undefined, rawPassword: string | und
   }
 }
 
-const env = process.env.ENV;
-const root = process.cwd();
-
-if (env) {
-  const envFile = join(root, `.env.${env}`);
-  if (existsSync(envFile)) {
-    config({ path: envFile, override: false });
-  }
-}
-
-const baseEnvFile = join(root, '.env');
-if (existsSync(baseEnvFile)) {
-  config({ path: baseEnvFile, override: false });
-}
-
-const normalizedRedisUrl = normalizeRedisUrl(process.env.REDIS_URL, process.env.REDIS_PASSWORD);
-if (normalizedRedisUrl) {
-  process.env.REDIS_URL = normalizedRedisUrl;
-}
+// No-op: environment is now loaded once by globalSetup (tests/global-setup-auth.ts)
+// This prevents 85+ redundant dotenv log messages during integration test runs.

--- a/tests/global-setup-auth.ts
+++ b/tests/global-setup-auth.ts
@@ -151,13 +151,36 @@ function cleanStaleAuthState(root: string): void {
   }
 }
 
+function normalizeRedisUrl(rawUrl: string | undefined, rawPassword: string | undefined): string {
+  const url = (rawUrl || '').trim();
+  const password = (rawPassword || '').trim();
+  if (!url || !password) return url;
+  try {
+    const parsed = new URL(url);
+    if ((parsed.protocol !== 'redis:' && parsed.protocol !== 'rediss:') || parsed.username || parsed.password) {
+      return url;
+    }
+    parsed.password = password;
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 function loadEnv(): void {
   const root = process.cwd();
-  const opts = { override: true };
+  const opts = { override: false };
   const env = process.env.ENV || 'dev';
   const envFile = join(root, `.env.${env}`);
-  if (existsSync(join(root, '.env'))) config({ path: join(root, '.env'), ...opts });
+  // Load .env.${ENV} first so ENV-specific file wins, then .env as base
   if (existsSync(envFile)) config({ path: envFile, ...opts });
+  if (existsSync(join(root, '.env'))) config({ path: join(root, '.env'), ...opts });
+  
+  // Normalize Redis URL with password if available
+  const normalizedRedisUrl = normalizeRedisUrl(process.env.REDIS_URL, process.env.REDIS_PASSWORD);
+  if (normalizedRedisUrl) {
+    process.env.REDIS_URL = normalizedRedisUrl;
+  }
 }
 
 /** Run scripts/deploy-configure-keycloak-realms.py so realm and kairos-cli client exist (required for CLI auth E2E). */


### PR DESCRIPTION
## Summary

Two related test-runner optimizations:

1. **Load env once, not 85+ times.** Previously `tests/env-loader.ts` was registered in Jest's `setupFiles`, which runs **before each test file**. With 85+ integration test files, dotenv loaded `.env` and `.env.${ENV}` 85+ times per run, spamming logs and burning startup time. Move env loading into `tests/global-setup-auth.ts` (Jest `globalSetup`) so it runs **once** before any worker starts.

2. **Run integration tests in parallel.** Switch `scripts/deploy-run-env.sh test` from `--runInBand` to `--maxWorkers=10`. The single MCP server can absorb concurrent requests because `.env` already sets `MAX_CONCURRENT_MCP_REQUESTS=1000`.

## Changes

| File | Change |
|------|--------|
| `tests/global-setup-auth.ts` | Add `loadEnv()` body: load `.env.${ENV}` then `.env` (ENV-specific wins), `override: false` so shell env wins over files. Inline `normalizeRedisUrl()` runs once at startup. |
| `tests/env-loader.ts` | Gut to a stub. Keep `normalizeRedisUrl` exported for reference. Comment explains the migration. |
| `jest.config.js` | Drop `'dotenv/config'` from `setupFiles`; keep `env-loader.ts` entry as a no-op to preserve config shape. |
| `scripts/deploy-run-env.sh` | `--runInBand` → `--maxWorkers=10`; comment updated to note `MAX_CONCURRENT_MCP_REQUESTS` requirement. |
| `package-lock.json` | Sync version field 4.5.3-rc.0 → 4.6.0-rc.0 (lockfile drifted in release #506; `package.json` was already 4.6.0-rc.0). |

## Behavior change worth flagging

In `loadEnv()`, `override` flips from `true` → `false`. Concretely: shell-provided env vars now win over `.env*` files. This is the correct precedence for CI (where secrets are injected by the runner) and for local dev where you might temporarily export an override in your shell.

If a test relies on `.env.${ENV}` overriding a shell-set value, it would need to explicitly `delete process.env.X` first. No current tests appear to rely on the old behavior.

## Validation expectation

Test files (`tests/**`), the runner script (`scripts/**`), `jest.config.js`, and `package-lock.json` are all in the path-filter `code:` list, so the **full heavy matrix runs** for this PR — exactly what we want for a test-runner optimization. Look for:

- `verify-integration-primary` (Node 24, AUTH-mode) wall-time should drop noticeably vs the prior `--runInBand` run.
- Far fewer `[dotenv@…] injecting env` log lines in the Jest output.

## Risk

- **Low** for the dotenv migration — globalSetup is the standard Jest pattern; behavior is functionally equivalent.
- **Medium** for `--maxWorkers=10` — parallel execution can surface previously hidden test ordering / shared-state assumptions. CI is the validator. If anything flakes, the fix is either to make the offending test self-contained, or to drop worker count.
