### PR TITLE
ci: enable integration tests on release/* branches

### DIFF
--- a/.github/workflows/integration-simple.yml
+++ b/.github/workflows/integration-simple.yml
@@ -2,10 +2,10 @@ name: Integration Simple
 
 on:
   pull_request:
-    branches: [main, "ci/**"]
+    branches: [main, "ci/**", "release/**"]
   merge_group:
   push:
-    branches: [main, "ci/**"]
+    branches: [main, "ci/**", "release/**"]
     tags:
       - 'v*.*.*'
   workflow_dispatch:
@@ -74,7 +74,8 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ] \
              || [ "$EVENT_NAME" = "merge_group" ] \
              || [[ "$REF" == refs/tags/* ]] \
-             || [[ "$REF" == refs/heads/ci/* ]]; then
+             || [[ "$REF" == refs/heads/ci/* ]] \
+             || [[ "$REF" == refs/heads/release/* ]]; then
             echo "Forcing code=true for event=$EVENT_NAME ref=$REF"
             echo "code=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,11 +15,11 @@ name: Integration
 on:
   pull_request:
     # Base branches: include ci/** so PRs into integration lines get the same gate as main.
-    branches: [main, "ci/**"]
+    branches: [main, "ci/**", "release/**"]
   merge_group:
   push:
     # Integration + Release tag (workflow_run) must run on beta/integration branches or beta never auto-tags.
-    branches: [main, "ci/**"]
+    branches: [main, "ci/**", "release/**"]
     tags:
       - 'v*.*.*'
   workflow_dispatch:
@@ -85,7 +85,8 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ] \
              || [ "$EVENT_NAME" = "merge_group" ] \
              || [[ "$REF" == refs/tags/* ]] \
-             || [[ "$REF" == refs/heads/ci/* ]]; then
+             || [[ "$REF" == refs/heads/ci/* ]] \
+             || [[ "$REF" == refs/heads/release/* ]]; then
             echo "Forcing code=true for event=$EVENT_NAME ref=$REF"
             echo "code=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Add release/** branch triggers to integration workflows so release branches run full CI.

This enables the workflows in integration.yml and integration-simple.yml to trigger on push/PR to release/* branches with forced code=true (bypasses path filtering).

Required before PR #525 (release: 4.6.0-rc.1) can run integration tests.