### PR TITLE
fix(helm): remove Namespace resource from chart

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "4.6.3"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:

--- a/helm/kairos-mcp/templates/gateway.yaml
+++ b/helm/kairos-mcp/templates/gateway.yaml
@@ -4,22 +4,6 @@
 {{- $hasTLS := or $certManager.enabled $tls.secretName }}
 {{- $allowHttpWithTLS := default false $gw.allowHttpWithTls }}
 {{- $mode := include "kairos.ingressMode" . | trim }}
-{{- $gwNamespace := .Release.Namespace }}
-{{- $psa := default "" $gw.podSecurityAdmission }}
-{{- if and $psa $gw.enabled }}
----
-# Istio auto-provisioned gateway pods omit securityContext.seccompProfile
-# (see istio/istio#56383). Label the namespace so PSA allows them.
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ $gwNamespace }}
-  labels:
-    pod-security.kubernetes.io/enforce: {{ $psa | quote }}
-    pod-security.kubernetes.io/enforce-version: "latest"
-    pod-security.kubernetes.io/warn: {{ $psa | quote }}
-    pod-security.kubernetes.io/audit: {{ $psa | quote }}
-{{- end }}
 {{- if and $gw.enabled $gw.createGateway $gw.hostname (eq $mode "gateway") }}
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/helm/kairos-mcp/tests/chart_defaults_test.yaml
+++ b/helm/kairos-mcp/tests/chart_defaults_test.yaml
@@ -40,33 +40,6 @@ tests:
       - equal:
           path: spec.gatewayClassName
           value: ngrok
-  - it: renders Namespace with PSA labels when podSecurityAdmission is set
-    set:
-      gateway.enabled: true
-      gateway.podSecurityAdmission: "baseline"
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Namespace
-      - isSubset:
-          path: metadata.labels
-          content:
-            pod-security.kubernetes.io/enforce: baseline
-            pod-security.kubernetes.io/enforce-version: "latest"
-            pod-security.kubernetes.io/warn: baseline
-            pod-security.kubernetes.io/audit: baseline
-  - it: does not render Namespace when podSecurityAdmission is empty
-    set:
-      gateway.enabled: true
-      gateway.createGateway: true
-      gateway.hostname: "kairos.example.com"
-      gateway.gatewayClassName: "ngrok"
-    asserts:
-      - hasDocuments:
-          count: 1
-      - isKind:
-          of: Gateway
 ---
 suite: app Service
 templates:

--- a/helm/kairos-mcp/values.yaml
+++ b/helm/kairos-mcp/values.yaml
@@ -94,11 +94,6 @@ gateway:
   existingGatewayName: ""
   existingGatewayNamespace: ""
   gatewayClassName: "ngrok"
-  # Istio auto-provisioned gateway pods omit securityContext.seccompProfile
-  # (istio/istio#56383), violating "restricted" PSA. Set to "baseline" to
-  # label the release namespace so the gateway pod is admitted. Leave empty
-  # to skip namespace labeling (e.g. when PSA is already relaxed or not used).
-  podSecurityAdmission: ""
   hostname: ""
   httpPort: 80
   httpsPort: 443


### PR DESCRIPTION
## Problem

The `gateway.yaml` template renders a `Namespace` resource with PSA labels when `gateway.podSecurityAdmission` is set. This contradicts the policy that namespaces are **not** managed via ArgoCD — they are managed by Rancher and labeled via `kubectl`.

The Namespace resource causes ArgoCD sync failures (`resource :Namespace is not permitted in project`) and requires AppProject whitelist changes that broaden cluster-scoped permissions unnecessarily.

## Fix

- Remove the `Namespace` resource block and related variables (`$gwNamespace`, `$psa`) from `gateway.yaml`
- Remove the `gateway.podSecurityAdmission` value from `values.yaml`
- Remove the two helm-unittest test cases for PSA Namespace rendering

PSA labels on the `kairos-mcp` namespace remain set via `kubectl label` (managed outside ArgoCD).

## Related

- Follow-up to #533 (v4.6.3) which added the PSA Namespace feature
- istio/istio#56383 — upstream Istio gateway pod seccompProfile gap still exists; PSA labels are the workaround