### PR TITLE
fix(helm): add optionalClientScopes to Keycloak clients

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "4.6.3"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:

--- a/helm/kairos-mcp/files/kairos-realm.json
+++ b/helm/kairos-mcp/files/kairos-realm.json
@@ -142,7 +142,8 @@
         "http://127.0.0.1",
         "__KAIROS_PUBLIC_ORIGIN__"
       ],
-      "defaultClientScopes": ["basic"],
+      "defaultClientScopes": ["basic", "kairos-groups"],
+      "optionalClientScopes": ["openid", "profile", "email", "offline_access"],
       "attributes": {
         "post.logout.redirect.uris": "http://127.0.0.1/auth/continue-signin##__KAIROS_PUBLIC_ORIGIN__/auth/continue-signin",
         "logout.confirmation.enabled": "false"
@@ -171,7 +172,8 @@
       "directAccessGrantsEnabled": true,
       "redirectUris": ["http://localhost:*", "http://localhost:*/callback", "http://localhost:*/callback/*", "http://localhost:*/*", "http://127.0.0.1:*", "http://127.0.0.1:*/callback", "http://127.0.0.1:*/callback/*", "__KAIROS_PUBLIC_ORIGIN__/*"],
       "webOrigins": ["http://localhost", "__KAIROS_PUBLIC_ORIGIN__"],
-      "defaultClientScopes": ["basic"],
+      "defaultClientScopes": ["basic", "kairos-groups"],
+      "optionalClientScopes": ["openid", "profile", "email", "offline_access"],
       "attributes": {
         "pkce.code.challenge.method": "S256"
       },


### PR DESCRIPTION
## Problem

OAuth authorize returns `invalid_scope` for `openid profile email kairos-groups offline_access` because the `kairos-mcp` and `kairos-cli` clients only had `["basic"]` in `defaultClientScopes` with no `optionalClientScopes`.

## Fix

- Add `kairos-groups` to `defaultClientScopes` — group claim always included in tokens
- Add `["openid", "profile", "email", "offline_access"]` to `optionalClientScopes` — available when explicitly requested by the MCP server

## Scope

Changes only `helm/kairos-mcp/files/kairos-realm.json` (the Keycloak realm definition shipped with the chart).