### PR TITLE
fix: tune false-success no-op on multi-layer adapters

### DIFF
--- a/src/services/qdrant/memory-updates.ts
+++ b/src/services/qdrant/memory-updates.ts
@@ -72,8 +72,8 @@ export async function updateMemoryByUUID(conn: QdrantConnection, uuid: string, u
       logger.debug(`updateMemoryByUUID: upsertPoint vector keys=${Object.keys(upsertPoint.vector || {}).join(',')}`);
       await sanitizeAndUpsert(conn.client, conn.collectionName, [upsertPoint]);
 
-      // Invalidate memory, search, and activate caches after update (publishes invalidation events internally)
-      await redisCacheService.invalidateMemoryCache(existingPoint.id);
+      // Strict cache invalidation: propagate errors so callers detect stale-cache risk (tune false-success guard)
+      await redisCacheService.invalidateMemoryCacheStrict(existingPoint.id);
       await redisCacheService.invalidateAfterUpdate();
 
       qdrantOperations.inc({
@@ -173,8 +173,8 @@ export async function updateMemory(conn: QdrantConnection, id: string, updates: 
       logger.debug(`updateMemory: upsertPoint2 vector keys=${Object.keys(upsertPoint2.vector || {}).join(',')}`);
       await sanitizeAndUpsert(conn.client, conn.collectionName, [upsertPoint2]);
 
-      // Invalidate memory, search, and activate caches after update (publishes invalidation events internally)
-      await redisCacheService.invalidateMemoryCache(existingPoint.id);
+      // Strict cache invalidation: propagate errors so callers detect stale-cache risk (tune false-success guard)
+      await redisCacheService.invalidateMemoryCacheStrict(existingPoint.id);
       await redisCacheService.invalidateAfterUpdate();
 
       qdrantOperations.inc({
@@ -209,8 +209,8 @@ export async function deleteMemory(conn: QdrantConnection, id: string): Promise<
       }
       await conn.client.delete(conn.collectionName, { points: [validatedId] });
       
-      // Invalidate memory, search, and activate caches after deletion (publishes invalidation events internally)
-      await redisCacheService.invalidateMemoryCache(validatedId);
+      // Strict cache invalidation: propagate errors so callers detect stale-cache risk
+      await redisCacheService.invalidateMemoryCacheStrict(validatedId);
       await redisCacheService.invalidateAfterUpdate();
       
       qdrantOperations.inc({ 

--- a/src/services/redis-cache.ts
+++ b/src/services/redis-cache.ts
@@ -23,6 +23,8 @@ export class RedisCacheService {
   private invalidationChannel = 'cache:invalidation';
   private statsPrefix = 'stats:';
   private memoryPrefix = MEMORY_CACHE_KEY_PREFIX;
+  /** Bounded TTL for cached memory resources — safety net when invalidation fails. */
+  static readonly MEMORY_CACHE_TTL_SECONDS = 3600;
 
   constructor() {
     logger.info('[RedisCacheService] Initialized with RedisService');
@@ -95,6 +97,7 @@ export class RedisCacheService {
   }
 
   // Remove cached memory by UUID. Key is global (prefix+mem:uuid), so one del invalidates for all spaces.
+  // Errors are caught and logged; callers that need strict invalidation should use invalidateMemoryCacheStrict.
   async invalidateMemoryCache(uuid: string): Promise<void> {
     try {
       if (!uuid || typeof uuid !== 'string') {
@@ -109,6 +112,20 @@ export class RedisCacheService {
     } catch (error) {
       logger.error('[RedisCacheService] Failed to invalidate memory cache:', error);
     }
+  }
+
+  /**
+   * Strict memory cache invalidation that propagates errors.
+   * Use after writes where a stale cache would cause a false-success response.
+   */
+  async invalidateMemoryCacheStrict(uuid: string): Promise<void> {
+    if (!uuid || typeof uuid !== 'string') {
+      throw new Error(`Cannot invalidate memory cache: invalid uuid "${uuid}"`);
+    }
+    const key = `${this.memoryPrefix}${uuid}`;
+    await keyValueStore.del(key);
+    logger.debug(`[RedisCacheService] Strict-invalidated memory cache for UUID ${uuid}`);
+    await this.publishInvalidation('memory');
   }
 
   async publishInvalidation(type: string): Promise<void> {
@@ -175,9 +192,9 @@ export class RedisCacheService {
   async setMemoryResource(memory: Memory): Promise<void> {
     try {
       const key = `${this.memoryPrefix}${memory.memory_uuid}`;
-      // Store memories without TTL (permanent storage)
-      await keyValueStore.setJson(key, memory);
-      logger.debug(`[RedisCacheService] Cached memory resource for UUID ${memory.memory_uuid} (no TTL)`);
+      // Bounded TTL prevents permanent stale data if invalidation fails
+      await keyValueStore.setJson(key, memory, RedisCacheService.MEMORY_CACHE_TTL_SECONDS);
+      logger.debug(`[RedisCacheService] Cached memory resource for UUID ${memory.memory_uuid} (TTL ${RedisCacheService.MEMORY_CACHE_TTL_SECONDS}s)`);
     } catch (error) {
       logger.error('[RedisCacheService] Failed to cache memory resource:', error);
     }

--- a/src/tools/tune-execute.ts
+++ b/src/tools/tune-execute.ts
@@ -11,6 +11,7 @@ import { assertWireAdapterUri, parseKairosUri, buildLayerUri } from './kairos-ur
 import { buildTuneResultMessage } from './tune-messages.js';
 import { isProtectedWriteSpace, protectedWriteErrorMessage } from '../utils/protected-space-write-guard.js';
 import { validateAdapterMarkdownSize } from '../services/memory/validate-adapter-markdown-size.js';
+import { verifyTuneLayerPersistence } from './tune-verify.js';
 
 type AdapterLayerPoint = { uuid: string; payload: any };
 
@@ -209,6 +210,8 @@ async function tuneAdapterMarkdownInPlace(
       inference_contract: next.inference_contract ?? null
     });
   }
+
+  await verifyTuneLayerPersistence(qdrantService, existingLayers, nextLayers);
 
   return buildLayerUri(existingLayers[0]!.uuid);
 }

--- a/src/tools/tune-verify.ts
+++ b/src/tools/tune-verify.ts
@@ -1,0 +1,24 @@
+import type { QdrantService } from '../services/qdrant/service.js';
+
+type AdapterLayerPoint = { uuid: string; payload: any };
+
+/**
+ * Post-write verification: re-read each updated layer from Qdrant and confirm
+ * its text matches the expected value. Catches the silent no-op scenario where
+ * updateMemory reports success but the underlying store did not persist the
+ * change (stale-cache guard).
+ */
+export async function verifyTuneLayerPersistence(
+  qdrantService: QdrantService,
+  layers: AdapterLayerPoint[],
+  expected: Array<{ text: string }>
+): Promise<void> {
+  for (let i = 0; i < layers.length; i++) {
+    const layer = layers[i]!;
+    const refreshed = await qdrantService.getMemoryByUUID(layer.uuid);
+    if (!refreshed) throw new Error(`Post-write verification failed: layer ${layer.uuid} not found after update`);
+    if (typeof refreshed.text !== 'string' || refreshed.text !== expected[i]!.text) {
+      throw new Error(`Post-write verification failed: layer ${layer.uuid} text mismatch — stale cache or write failure`);
+    }
+  }
+}

--- a/tests/integration/redis-pubsub-integration.test.ts
+++ b/tests/integration/redis-pubsub-integration.test.ts
@@ -1,6 +1,6 @@
 import { createClient, RedisClientType } from 'redis';
 import { keyValueStore } from '../../src/services/key-value-store-factory.js';
-import { redisCacheService } from '../../src/services/redis-cache.js';
+import { RedisCacheService, redisCacheService } from '../../src/services/redis-cache.js';
 import { KAIROS_REDIS_PREFIX, KAIROS_APP_SPACE_ID, REDIS_URL, MEMORY_CACHE_KEY_PREFIX } from '../../src/config.js';
 import { runWithSpaceContextAsync } from '../../src/utils/tenant-context.js';
 import type { Memory } from '../../src/types/memory.js';
@@ -146,8 +146,8 @@ describeRedis('Redis Pub/Sub Integration Tests', () => {
     });
   });
 
-  describe('Memory Storage (No TTL)', () => {
-    test('should store memories without TTL (permanent)', async () => {
+  describe('Memory Storage (With TTL)', () => {
+    test('should store memories with bounded TTL (1 hour)', async () => {
       await withDefaultSpace(async () => {
         const testMemory: Memory = {
           memory_uuid: 'test-memory-uuid-123',
@@ -168,9 +168,10 @@ describeRedis('Redis Pub/Sub Integration Tests', () => {
         const exists = await testClient.exists(key);
         expect(exists).toBe(1);
 
-        // Verify TTL is -1 (no expiration)
+        // Verify TTL is set (bounded expiration, not -1 permanent)
         const ttl = await testClient.ttl(key);
-        expect(ttl).toBe(-1); // -1 means no expiration
+        expect(ttl).toBeGreaterThan(0);
+        expect(ttl).toBeLessThanOrEqual(RedisCacheService.MEMORY_CACHE_TTL_SECONDS);
 
         // Verify content
         const stored = await redisCacheService.getMemoryResource(testMemory.memory_uuid);

--- a/tests/unit/tune-execute.test.ts
+++ b/tests/unit/tune-execute.test.ts
@@ -290,4 +290,60 @@ New reward text after tune.
     expect(fakeQdrant.updateCalls).toHaveLength(1);
     expect(fakeQdrant.updateCalls[0]?.id).toBe('11111111-1111-4111-8111-111111111111');
   });
+
+  test('detects silent no-op via post-write verification when updateMemory does not persist', async () => {
+    const adapterName = 'Tune Export Regression Adapter';
+    const adapterId = IDGenerator.generateAdapterUUIDv5(adapterName);
+    const adapterSlug = 'tune-export-regression-adapter';
+    const layers = buildInitialLayers(adapterId, adapterName, adapterSlug);
+
+    // BrokenQdrantService: updateMemory records the call but does NOT update stored data,
+    // simulating the false-success scenario from the bug report.
+    class BrokenQdrantService extends FakeQdrantService {
+      override async updateMemory(_id: string, _updates: Record<string, unknown>): Promise<void> {
+        // Record the call but silently skip the actual write
+        (this as any).updateCalls.push({ id: _id, updates: _updates });
+      }
+    }
+    const brokenQdrant = new BrokenQdrantService(layers);
+
+    const nextMarkdown = `---
+slug: tune-export-regression-adapter
+version: 1.0.2
+---
+
+# ${adapterName}
+
+## Activation Patterns
+
+- run new path
+
+\`\`\`json
+{"contract":{"type":"comment","comment":{"min_length":8},"required":true}}
+\`\`\`
+
+## Apply Fix
+
+Fresh implementation details for the second layer.
+
+\`\`\`json
+{"contract":{"type":"comment","comment":{"min_length":12},"required":true}}
+\`\`\`
+
+## Reward Signal
+
+New reward text after tune.
+`;
+
+    const output = await executeTune(brokenQdrant as any, {
+      uris: [`kairos://adapter/${adapterSlug}`],
+      content: [nextMarkdown]
+    });
+
+    // Post-write verification should catch the stale data and report error instead of false success
+    expect(output.total_updated).toBe(0);
+    expect(output.total_failed).toBe(1);
+    expect(output.results[0]?.status).toBe('error');
+    expect(output.results[0]?.message).toContain('Post-write verification failed');
+  });
 });


### PR DESCRIPTION
## Summary

The `tune` tool reported `status: updated` / `total_updated: 1` for multi-layer adapter edits but did not persist the change — a subsequent `export` showed the adapter content was byte-for-byte identical to the pre-edit version (silent no-op with a misleading success signal).

## Root cause

Stale Redis cache served old data after tune updates. Three contributing factors:

1. **`setMemoryResource` stored memories permanently (no TTL)** — added 1h bounded TTL as safety net when invalidation fails
2. **`invalidateMemoryCache` silently swallowed errors** — added `invalidateMemoryCacheStrict` that propagates failures; `updateMemory` and `deleteMemory` now use strict invalidation
3. **`tuneAdapterMarkdownInPlace` had no post-write verification** — added read-back check that confirms each layer's text matches expected values after update, catching silent write failures

## Changes

| File | Change |
|------|--------|
| `src/services/redis-cache.ts` | Added `MEMORY_CACHE_TTL_SECONDS = 3600` to `setMemoryResource`; added `invalidateMemoryCacheStrict()` |
| `src/services/qdrant/memory-updates.ts` | `updateMemory`, `updateMemoryByUUID`, `deleteMemory` use strict cache invalidation |
| `src/tools/tune-verify.ts` | **New file** — extracted `verifyTuneLayerPersistence` post-write check |
| `src/tools/tune-execute.ts` | Calls `verifyTuneLayerPersistence` after all layer updates in `tuneAdapterMarkdownInPlace` |
| `tests/unit/tune-execute.test.ts` | Regression test with `BrokenQdrantService` that simulates silent no-op write |

## Expected behavior after fix

- If `tune` cannot persist the content change, it returns `status: error` instead of false `status: updated`
- Stale Redis cache entries auto-expire within 1 hour even if invalidation fails
- Cache invalidation failures during writes are surfaced to the caller, not silently logged

## Bug report

See `mcp-bug-user-KAIROS-tune-false-success-no-op-2026-06-02.md` for full reproduction trace.