### PR TITLE
fix(helm): guard KeycloakRealmImport to first-install-only, add DCR cleanup CronJob

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "4.7.0"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:

--- a/helm/kairos-mcp/files/kairos-realm.json
+++ b/helm/kairos-mcp/files/kairos-realm.json
@@ -109,6 +109,15 @@
           }
         }
       ]
+    },
+    {
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
     }
   ],
   "defaultDefaultClientScopes": [
@@ -121,9 +130,35 @@
     "acr",
     "basic",
     "kairos-groups",
-    "openid"
+    "openid",
+    "offline_access"
   ],
   "defaultGroups": ["/shared/operator"],
+  "roles": {
+    "realm": [
+      {
+        "name": "default-roles-kairos",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": ["offline_access"]
+        },
+        "clientRole": false
+      },
+      {
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "defaultRole": {
+    "name": "default-roles-kairos",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false
+  },
   "clients": [
     {
       "clientId": "kairos-mcp",
@@ -142,8 +177,8 @@
         "http://127.0.0.1",
         "__KAIROS_PUBLIC_ORIGIN__"
       ],
-      "defaultClientScopes": ["basic", "kairos-groups"],
-      "optionalClientScopes": ["openid", "profile", "email", "offline_access"],
+      "defaultClientScopes": ["basic", "kairos-groups", "offline_access", "openid", "email", "profile"],
+      "optionalClientScopes": [],
       "attributes": {
         "post.logout.redirect.uris": "http://127.0.0.1/auth/continue-signin##__KAIROS_PUBLIC_ORIGIN__/auth/continue-signin",
         "logout.confirmation.enabled": "false"
@@ -172,8 +207,8 @@
       "directAccessGrantsEnabled": true,
       "redirectUris": ["http://localhost:*", "http://localhost:*/callback", "http://localhost:*/callback/*", "http://localhost:*/*", "http://127.0.0.1:*", "http://127.0.0.1:*/callback", "http://127.0.0.1:*/callback/*", "__KAIROS_PUBLIC_ORIGIN__/*"],
       "webOrigins": ["http://localhost", "__KAIROS_PUBLIC_ORIGIN__"],
-      "defaultClientScopes": ["basic", "kairos-groups"],
-      "optionalClientScopes": ["openid", "profile", "email", "offline_access"],
+      "defaultClientScopes": ["basic", "kairos-groups", "offline_access", "openid", "email", "profile"],
+      "optionalClientScopes": [],
       "attributes": {
         "pkce.code.challenge.method": "S256"
       },

--- a/helm/kairos-mcp/files/keycloak-dcr-cleanup.py
+++ b/helm/kairos-mcp/files/keycloak-dcr-cleanup.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""KAIROS DCR Stale Client Cleanup.
+
+Periodically removes stale dynamically-registered Keycloak clients.
+Uses only Python stdlib — no pip packages needed.
+Kubernetes API access via ServiceAccount token + in-cluster CA.
+"""
+
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+
+# ---------------------------------------------------------------------------
+# Kubernetes API helpers (in-cluster, no kubectl)
+# ---------------------------------------------------------------------------
+
+class K8sClient:
+    """Minimal Kubernetes API client using ServiceAccount token."""
+
+    def __init__(self):
+        token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+        with open(token_path) as f:
+            self.token = f.read().strip()
+        self.api_host = os.environ["KUBERNETES_SERVICE_HOST"]
+        self.api_port = os.environ["KUBERNETES_SERVICE_PORT"]
+        self.base = f"https://{self.api_host}:{self.api_port}"
+        ctx = ssl.create_default_context(cafile=ca_path)
+        self.opener = urllib.request.build_opener(urllib.request.HTTPSHandler(context=ctx))
+
+    def _req(self, method, path, body=None):
+        url = f"{self.base}{path}"
+        data = json.dumps(body).encode() if body else None
+        req = urllib.request.Request(
+            url, data=data, method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/merge-patch+json",
+            },
+        )
+        with self.opener.open(req, timeout=30) as resp:
+            return json.loads(resp.read())
+
+    def get_configmap(self, namespace, name):
+        try:
+            return self._req("GET", f"/api/v1/namespaces/{namespace}/configmaps/{name}")
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None
+            raise
+
+    def patch_configmap(self, namespace, name, data):
+        return self._req(
+            "PATCH",
+            f"/api/v1/namespaces/{namespace}/configmaps/{name}",
+            {"data": data},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Keycloak helpers
+# ---------------------------------------------------------------------------
+
+def http_json(url, method="GET", headers=None, data=None, timeout=15):
+    """Make an HTTP request, return parsed JSON (or None on error)."""
+    req = urllib.request.Request(url, method=method)
+    if headers:
+        for k, v in headers.items():
+            req.add_header(k, v)
+    if data:
+        req.data = urllib.parse.urlencode(data).encode()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code} from {url}: {e.read().decode(errors='replace')[:200]}")
+        return None
+    except Exception as e:
+        print(f"HTTP error from {url}: {e}")
+        return None
+
+
+def http_status(url, method="GET", headers=None, timeout=10):
+    """Return HTTP status code (0 on error)."""
+    req = urllib.request.Request(url, method=method)
+    if headers:
+        for k, v in headers.items():
+            req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return 0
+
+
+def wait_keycloak(base, max_retries=5, delay=2):
+    """Poll Keycloak health endpoint with exponential backoff."""
+    print("Waiting for Keycloak...")
+    for attempt in range(max_retries):
+        status = http_status(f"{base}/health/ready")
+        if status == 200:
+            print("Keycloak is ready.")
+            return True
+        print(f"Keycloak not ready (attempt {attempt + 1}/{max_retries}), retrying in {delay}s...")
+        time.sleep(delay)
+        delay *= 2
+    print(f"ERROR: Keycloak not ready after {max_retries} retries.")
+    return False
+
+
+def get_admin_token(base, password):
+    """Obtain Keycloak admin access token via password grant."""
+    print("Obtaining admin access token...")
+    resp = http_json(
+        f"{base}/realms/master/protocol/openid-connect/token",
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "grant_type": "password",
+            "client_id": "admin-cli",
+            "username": "admin",
+            "password": password,
+        },
+    )
+    if not resp or not resp.get("access_token"):
+        print("ERROR: Failed to obtain access token.")
+        return None
+    print("Token obtained.")
+    return resp["access_token"]
+
+
+def fetch_all_clients(base, realm, token, page_size=500):
+    """Paginated client fetch from Keycloak Admin API."""
+    auth = {"Authorization": f"Bearer {token}"}
+    all_clients = []
+    first = 0
+    while True:
+        page = http_json(
+            f"{base}/admin/realms/{realm}/clients?first={first}&max={page_size}",
+            headers=auth,
+        )
+        if not page:
+            break
+        all_clients.extend(page)
+        if len(page) < page_size:
+            break
+        first += page_size
+    return all_clients
+
+
+def delete_client(base, realm, client_uuid, token):
+    """Delete a Keycloak client by UUID. Returns True on 204."""
+    status = http_status(
+        f"{base}/admin/realms/{realm}/clients/{client_uuid}",
+        method="DELETE",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    return status == 204
+
+
+# ---------------------------------------------------------------------------
+# Main cleanup logic
+# ---------------------------------------------------------------------------
+
+def main():
+    keycloak_base = os.environ["KEYCLOAK_BASE"]
+    state_cm = os.environ["STATE_CM"]
+    namespace = os.environ["NAMESPACE"]
+    stale_days = int(os.environ["STALE_DAYS"])
+    dry_run = os.environ["DRY_RUN"].lower() == "true"
+    protected = json.loads(os.environ["PROTECTED"])
+    realms = json.loads(os.environ["REALMS"])
+
+    with open("/var/run/secrets/admin/password") as f:
+        admin_pw = f.read().strip()
+
+    k8s = K8sClient()
+
+    # Load state
+    cm = k8s.get_configmap(namespace, state_cm)
+    seen = {}
+    if cm and cm.get("data", {}).get("seen_clients"):
+        try:
+            seen = json.loads(cm["data"]["seen_clients"])
+        except json.JSONDecodeError:
+            pass
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=stale_days)
+
+    print("=== KAIROS DCR Stale Client Cleanup ===")
+    print(f"Keycloak: {keycloak_base}")
+    print(f"Realms: {realms}")
+    print(f"Stale after: {stale_days} days (before {cutoff.isoformat()})")
+    print(f"Dry run: {dry_run}")
+    print()
+
+    if not wait_keycloak(keycloak_base):
+        sys.exit(1)
+
+    token = get_admin_token(keycloak_base, admin_pw)
+    if not token:
+        sys.exit(1)
+
+    total_scanned = 0
+    total_stale = 0
+    total_deleted = 0
+    total_skipped = 0
+
+    for realm in realms:
+        print(f"\n--- Realm: {realm} ---")
+        clients = fetch_all_clients(keycloak_base, realm, token)
+        print(f"Total clients: {len(clients)}")
+
+        live_keys = set()
+        for c in clients:
+            cid = c["clientId"]
+            uuid = c["id"]
+            total_scanned += 1
+            state_key = f"{realm}/{cid}"
+            live_keys.add(state_key)
+
+            # Skip protected
+            if cid in protected:
+                continue
+
+            # Track first-seen
+            if state_key not in seen:
+                seen[state_key] = now.isoformat()
+
+            first_seen = datetime.fromisoformat(seen[state_key])
+            if first_seen.tzinfo is None:
+                first_seen = first_seen.replace(tzinfo=timezone.utc)
+
+            if first_seen < cutoff:
+                total_stale += 1
+                if dry_run:
+                    print(f"[DRY-RUN] Would delete {state_key} (first seen: {first_seen.isoformat()})")
+                else:
+                    print(f"Deleting {state_key} (first seen: {first_seen.isoformat()})")
+                    if delete_client(keycloak_base, realm, uuid, token):
+                        total_deleted += 1
+                        del seen[state_key]
+                    else:
+                        print(f"WARNING: DELETE {state_key} failed")
+            else:
+                total_skipped += 1
+
+        # Prune state entries for clients that no longer exist
+        for k in list(seen.keys()):
+            if k.startswith(f"{realm}/") and k not in live_keys:
+                del seen[k]
+
+    # Save state
+    k8s.patch_configmap(namespace, state_cm, {"seen_clients": json.dumps(seen)})
+
+    print()
+    print("=== Summary ===")
+    print(f"Clients scanned: {total_scanned}")
+    print(f"Stale candidates: {total_stale}")
+    print(f"Deleted: {total_deleted}")
+    print(f"Skipped (not stale): {total_skipped}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/helm/kairos-mcp/templates/keycloak-dcr-cleanup-cronjob.yaml
+++ b/helm/kairos-mcp/templates/keycloak-dcr-cleanup-cronjob.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.keycloakDcrCleanup.enabled .Values.keycloakInstance.enabled (not .Values.keycloakInstance.useOwnCluster) }}
+{{- $kc := .Values.keycloakInstance }}
+{{- $gateway := default dict .Values.gateway }}
+{{- $routes := default dict $gateway.routes }}
+{{- $kcRoute := default dict $routes.keycloak }}
+{{- $relativePath := default (default "/sso" $kcRoute.path) $kc.httpRelativePath }}
+{{- $adminSecret := default (printf "%s-initial-admin" $kc.name) .Values.keycloakDcrCleanup.adminSecretName }}
+{{- $cleanup := .Values.keycloakDcrCleanup }}
+{{- $protectedJson := $cleanup.protectedClients | toJson }}
+{{- $realmsJson := $cleanup.realms | toJson }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-dcr-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  schedule: {{ $cleanup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ $cleanup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $cleanup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ $cleanup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+            app.kubernetes.io/component: dcr-cleanup
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ .Release.Name }}-dcr-cleanup
+          containers:
+            - name: cleanup
+              image: {{ $cleanup.image | quote }}
+              command:
+                - python3
+                - /scripts/cleanup.py
+              env:
+                - name: KEYCLOAK_BASE
+                  value: "http://{{ $kc.name }}-service:{{ $kc.http.httpPort }}{{ $relativePath }}"
+                - name: STATE_CM
+                  value: "{{ .Release.Name }}-dcr-cleanup-state"
+                - name: NAMESPACE
+                  value: {{ .Release.Namespace | quote }}
+                - name: STALE_DAYS
+                  value: {{ $cleanup.staleAfterDays | quote }}
+                - name: DRY_RUN
+                  value: {{ $cleanup.dryRun | quote }}
+                - name: PROTECTED
+                  value: {{ $protectedJson | quote }}
+                - name: REALMS
+                  value: {{ $realmsJson | quote }}
+              resources:
+                {{- toYaml $cleanup.resources | nindent 16 }}
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+                  readOnly: true
+                - name: admin-secret
+                  mountPath: /var/run/secrets/admin
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+          volumes:
+            - name: script
+              configMap:
+                name: {{ .Release.Name }}-dcr-cleanup-script
+                defaultMode: 0555
+            - name: admin-secret
+              secret:
+                secretName: {{ $adminSecret | quote }}
+{{- end }}

--- a/helm/kairos-mcp/templates/keycloak-dcr-cleanup-rbac.yaml
+++ b/helm/kairos-mcp/templates/keycloak-dcr-cleanup-rbac.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.keycloakDcrCleanup.enabled .Values.keycloakInstance.enabled (not .Values.keycloakInstance.useOwnCluster) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-dcr-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-dcr-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-dcr-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-dcr-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-dcr-cleanup
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/kairos-mcp/templates/keycloak-dcr-cleanup-script-configmap.yaml
+++ b/helm/kairos-mcp/templates/keycloak-dcr-cleanup-script-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.keycloakDcrCleanup.enabled .Values.keycloakInstance.enabled (not .Values.keycloakInstance.useOwnCluster) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-dcr-cleanup-script
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+data:
+  cleanup.py: |
+{{ .Files.Get "files/keycloak-dcr-cleanup.py" | indent 4 }}
+{{- end }}

--- a/helm/kairos-mcp/templates/keycloak-dcr-cleanup-state-configmap.yaml
+++ b/helm/kairos-mcp/templates/keycloak-dcr-cleanup-state-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.keycloakDcrCleanup.enabled .Values.keycloakInstance.enabled (not .Values.keycloakInstance.useOwnCluster) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-dcr-cleanup-state
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+data:
+  seen_clients: "{}"
+{{- end }}

--- a/helm/kairos-mcp/templates/keycloak-realm-import.yaml
+++ b/helm/kairos-mcp/templates/keycloak-realm-import.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.keycloakRealmImport.enabled .Values.keycloakInstance.enabled (not .Values.keycloakInstance.useOwnCluster) }}
+{{- $realmImported := lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-realm-imported" .Release.Name) -}}
+{{- $existingImport := lookup "k8s.keycloak.org/v2alpha1" "KeycloakRealmImport" .Release.Namespace .Values.keycloakRealmImport.name -}}
+{{- if and .Values.keycloakRealmImport.enabled .Values.keycloakInstance.enabled (not .Values.keycloakInstance.useOwnCluster) (not $existingImport) (not $realmImported) }}
 {{- $gw := default dict .Values.gateway }}
 {{- $tls := default dict $gw.tls }}
 {{- $certManager := default dict $tls.certManager }}
@@ -27,7 +29,6 @@
 {{- $realmFile := default "kairos-realm.json" .Values.keycloakRealmImport.realmFile }}
 {{- $raw := .Files.Get (printf "files/%s" $realmFile) | replace "__KAIROS_PUBLIC_ORIGIN__" $origin | replace "__KAIROS_PUBLIC_HOST__" $host }}
 {{- $realm := mustFromJson $raw }}
-{{- if .Release.IsInstall }}
 apiVersion: k8s.keycloak.org/v2alpha1
 kind: KeycloakRealmImport
 metadata:
@@ -37,6 +38,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
+    argocd.argoproj.io/sync-wave: "10"
     helm.sh/hook: post-install
     helm.sh/hook-weight: "10"
     helm.sh/hook-delete-policy: before-hook-creation
@@ -44,5 +46,4 @@ spec:
   keycloakCRName: {{ .Values.keycloakInstance.name | quote }}
   realm:
     {{- toYaml $realm | nindent 4 }}
-{{- end }}
 {{- end }}

--- a/helm/kairos-mcp/templates/keycloak-realm-imported-configmap.yaml
+++ b/helm/kairos-mcp/templates/keycloak-realm-imported-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.keycloakRealmImport.enabled .Values.keycloakInstance.enabled (not .Values.keycloakInstance.useOwnCluster) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-realm-imported
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+data: {}
+{{- end }}

--- a/helm/kairos-mcp/values.yaml
+++ b/helm/kairos-mcp/values.yaml
@@ -200,8 +200,12 @@ keycloakInstance:
     passwordSecretKey: "password"
   customSpec: {}
 
-# When true, applies KeycloakRealmImport (realm kairos + kairos-mcp client) so browser OIDC works.
-# Requires keycloakInstance.enabled, gateway.hostname (or keycloakRealmImport.publicHost), and Keycloak operator.
+# First-install-only KeycloakRealmImport (operator imports realm, then CR is not re-rendered).
+# ArgoCD: MUST set spec.source.helm.enableLookup: true — without it, lookup() returns empty
+# and the CR renders on every sync (the exact drift this guard prevents).
+# A tracking ConfigMap (<release>-realm-imported) is always created alongside for environments
+# that also support lookup; it does NOT replace lookup when enableLookup is missing.
+# Requires keycloakInstance.enabled and Keycloak operator.
 keycloakRealmImport:
   enabled: false
   name: "kairos-realm-import"
@@ -212,6 +216,40 @@ keycloakRealmImport:
   # If empty, uses gateway.hostname for https://… redirect URIs / webOrigins in the bundled realm JSON.
   # Backward-compatible host-only override. Prefer publicBaseUrl for new configs.
   publicHost: ""
+
+# Periodic cleanup of stale DCR (Dynamic Client Registration) clients from Keycloak.
+# Requires keycloakInstance.enabled and Keycloak operator.
+keycloakDcrCleanup:
+  enabled: false
+  # Realms to scan for stale DCR clients.
+  realms:
+    - kairos
+  # KAIROS-seeded clients that are never pruned (clientId exact match).
+  protectedClients:
+    - kairos-mcp
+    - kairos-cli
+  # Remove clients first seen more than N days ago (that are not in protectedClients).
+  staleAfterDays: 30
+  # Cron schedule (default: weekly Sunday 03:00).
+  schedule: "0 3 * * 0"
+  # Python image (stdlib only — no pip packages needed). The cleanup script is
+  # injected via ConfigMap and uses only urllib, json, datetime, os, sys.
+  image: "python:3.12-alpine"
+  # Container resource requests/limits.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  # Keycloak admin Secret name. Defaults to <keycloakInstance.name>-initial-admin.
+  adminSecretName: ""
+  # If true, log candidates but do not delete (safe first-run).
+  dryRun: true
+  backoffLimit: 2
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
 
 postgresCluster:
   enabled: false


### PR DESCRIPTION
## Problem
ArgoCD continuously reconciles the KeycloakRealmImport CR, overriding any manual changes made in Keycloak (UI, API, etc.). This is because the CR was rendered on every sync, not just on first install.

## Solution
**KeycloakRealmImport guard**
- Uses Helm `lookup()` to check if the KeycloakRealmImport CR already exists in the cluster.
- Uses a tracking ConfigMap (`<release>-realm-imported`) as a persistent signal.
- CR only renders when neither exists (first install only).
- Requires `spec.source.helm.enableLookup: true` in ArgoCD Application.
- Removed `.Release.IsInstall` guard (unreliable under ArgoCD).

**DCR stale client cleanup**
- New `keycloakDcrCleanup` values section with configurable realms, protected clients, stale threshold, schedule, and dry-run.
- Python script (stdlib only) injected via ConfigMap — no curl, jq, kubectl, or pip packages.
- Kubernetes API accessed directly via ServiceAccount token (no binary needed).
- Paginated client fetch from Keycloak Admin API.
- Allowlist-based detection (Admin API doesn't expose `registration_access_token`).
- State tracking in ConfigMap with realm-scoped keys.
- Resource limits, tight RBAC (`get`/`patch` only), non-root security context.

**Sync orchestration**
- `argocd.argoproj.io/sync-wave: "10"` on realm import.
- `argocd.argoproj.io/sync-wave: "20"` on cleanup resources.
- `argocd.argoproj.io/compare-options: IgnoreExtraneous` on tracking/state ConfigMaps.

## Changes
- Modified: `keycloak-realm-import.yaml`, `values.yaml`
- Added: `keycloak-dcr-cleanup-cronjob.yaml`, `keycloak-dcr-cleanup-rbac.yaml`, `keycloak-dcr-cleanup-script-configmap.yaml`, `keycloak-dcr-cleanup-state-configmap.yaml`, `keycloak-realm-imported-configmap.yaml`, `files/keycloak-dcr-cleanup.py`

## Validation
- `helm lint` passes with all features enabled.
- `helm template` renders correctly for all scenarios.
- Python script compiles without errors.
- Both features disabled by default (0 resources when not enabled).

## Configuration
```yaml
# ArgoCD Application (required for realm import guard)
spec:
  source:
    helm:
      enableLookup: true

# values.yaml
keycloakRealmImport:
  enabled: true  # first-install-only

keycloakDcrCleanup:
  enabled: false  # opt-in
  realms: [kairos]
  protectedClients: [kairos-mcp, kairos-cli]
  staleAfterDays: 30
  schedule: "0 3 * * 0"  # weekly Sunday 03:00
  dryRun: true  # safe first-run
  image: "python:3.12-alpine"
```