### PR TITLE
fix(tune): invalidate in-process cache after tune writes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -143,7 +143,7 @@ export function createServer(memoryStore: MemoryQdrantStore): McpServer {
     registerForwardTool(server, memoryStore, { qdrantService });
     registerTrainTool(server, memoryStore, { qdrantService });
     registerRewardTool(server, qdrantService);
-    registerTuneTool(server);
+    registerTuneTool(server, memoryStore, { qdrantService });
     registerDeleteTool(server, 'delete');
     registerExportTool(server, memoryStore, { qdrantService });
     registerSpacesTool(server, memoryStore, { toolName: 'spaces' });

--- a/src/tools/tune-cache-invalidation.ts
+++ b/src/tools/tune-cache-invalidation.ts
@@ -1,0 +1,15 @@
+import type { TuneOutput } from './tune_schema.js';
+
+/**
+ * Invalidate the in-process MemoryQdrantStore cache after tune writes.
+ * Without this, subsequent reads (export, forward, activate) return stale
+ * cached data even though Qdrant has the fresh write. PR #545 fixed Redis
+ * cache invalidation but missed this in-process Map layer.
+ */
+export function invalidateTuneInProcessCache(memoryStore: unknown, result: TuneOutput): void {
+  if (result.total_updated <= 0) return;
+  const methods = (memoryStore as any)?.methods;
+  if (methods && typeof methods.invalidateLocalCache === 'function') {
+    methods.invalidateLocalCache();
+  }
+}

--- a/src/tools/tune.ts
+++ b/src/tools/tune.ts
@@ -1,4 +1,5 @@
 import type { QdrantService } from '../services/qdrant/service.js';
+import type { MemoryQdrantStore } from '../services/memory/store.js';
 import { resolveToolDoc } from '../utils/mcp-tool-doc-runtime.js';
 import { getTenantId } from '../utils/tenant-context.js';
 import { tuneInputSchema, tuneOutputSchema } from './tune_schema.js';
@@ -6,11 +7,18 @@ import { mcpToolCalls, mcpToolDuration, mcpToolErrors, mcpToolInputSize, mcpTool
 import { mcpLooseToolInput } from './mcp-loose-input-schema.js';
 import { mcpToolInputValidationErrorResult } from './mcp-tool-input-teaching.js';
 import { executeTune } from './tune-execute.js';
+import { invalidateTuneInProcessCache } from './tune-cache-invalidation.js';
 
 export { executeTune } from './tune-execute.js';
 
-export function registerTuneTool(server: any, toolName = 'tune') {
-  let qdrantService: QdrantService | null = null;
+interface RegisterTuneOptions {
+  toolName?: string;
+  qdrantService?: QdrantService;
+}
+
+export function registerTuneTool(server: any, memoryStore: MemoryQdrantStore, options: RegisterTuneOptions = {}) {
+  const toolName = options.toolName || 'tune';
+  let qdrantService = options.qdrantService ?? null;
   server.registerTool(
     toolName,
     {
@@ -39,6 +47,11 @@ export function registerTuneTool(server: any, toolName = 'tune') {
           qdrantService = qdrantModule.qdrantService;
         }
         const result = await executeTune(qdrantService, input);
+
+        // Invalidate the in-process MemoryQdrantStore cache so subsequent
+        // reads (export, forward, activate) see the freshly written data.
+        invalidateTuneInProcessCache(memoryStore, result);
+
         mcpToolCalls.inc({ tool: toolName, status: 'success', tenant_id: tenantId });
         mcpToolOutputSize.observe({ tool: toolName, tenant_id: tenantId }, JSON.stringify(result).length);
         timer({ tool: toolName, status: 'success', tenant_id: tenantId });

--- a/tests/unit/tune-cache-invalidation.test.ts
+++ b/tests/unit/tune-cache-invalidation.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from '@jest/globals';
+import { invalidateTuneInProcessCache } from '../../src/tools/tune-cache-invalidation.js';
+import { executeTune } from '../../src/tools/tune-execute.js';
+import { IDGenerator } from '../../src/services/id-generator.js';
+import { runWithSpaceContextAsync } from '../../src/utils/tenant-context.js';
+
+type LayerPayload = {
+  slug?: string;
+  space_id: string;
+  label: string;
+  text: string;
+  tags: string[];
+  llm_model_id: string;
+  adapter: {
+    id: string;
+    name: string;
+    layer_index: number;
+    layer_count: number;
+    protocol_version?: string;
+    activation_patterns?: string[];
+    reward_signal?: string;
+  };
+  inference_contract?: unknown;
+};
+
+type LayerRecord = { uuid: string; payload: LayerPayload };
+
+class FakeQdrantService {
+  private readonly layerByUuid = new Map<string, LayerRecord>();
+  constructor(layers: LayerRecord[]) {
+    for (const layer of layers) {
+      this.layerByUuid.set(layer.uuid, { uuid: layer.uuid, payload: structuredClone(layer.payload) });
+    }
+  }
+  async getAdapterLayers(adapterId: string): Promise<Array<{ uuid: string; payload: LayerPayload }>> {
+    return [...this.layerByUuid.values()]
+      .filter((l) => l.payload.adapter.id === adapterId)
+      .sort((a, b) => a.payload.adapter.layer_index - b.payload.adapter.layer_index)
+      .map((l) => ({ uuid: l.uuid, payload: structuredClone(l.payload) }));
+  }
+  async findFirstStepMemoryUuidBySlug(slug: string): Promise<{ layerUuid: string | null }> {
+    const n = slug.trim().toLowerCase();
+    for (const l of this.layerByUuid.values()) {
+      const s = typeof l.payload.slug === 'string' ? l.payload.slug.trim().toLowerCase() : '';
+      if (s === n && l.payload.adapter?.layer_index === 1) return { layerUuid: l.uuid };
+    }
+    return { layerUuid: null };
+  }
+  async getMemoryByUUID(uuid: string): Promise<(LayerPayload & { memory_uuid: string }) | null> {
+    const l = this.layerByUuid.get(uuid);
+    if (!l) return null;
+    return { ...l.payload, memory_uuid: uuid };
+  }
+  async updateMemory(id: string, updates: Record<string, unknown>): Promise<void> {
+    const l = this.layerByUuid.get(id);
+    if (!l) throw new Error(`Missing layer ${id}`);
+    l.payload = { ...l.payload, ...updates, adapter: updates.adapter ? (updates.adapter as any) : l.payload.adapter } as LayerPayload;
+  }
+}
+
+function buildLayers(adapterId: string, name: string, slug: string): LayerRecord[] {
+  return [
+    { uuid: '11111111-1111-4111-8111-111111111111', payload: { slug, space_id: 'user:test-space', label: 'Activation Patterns', text: 'Old trigger text', tags: ['old'], llm_model_id: 'cursor-live', inference_contract: { type: 'comment', comment: { min_length: 10 }, required: true }, adapter: { id: adapterId, name, layer_index: 1, layer_count: 2, protocol_version: '1.0.0', activation_patterns: ['run old path'], reward_signal: '## Reward Signal\n\nOld.' } } },
+    { uuid: '22222222-2222-4222-8222-222222222222', payload: { slug, space_id: 'user:test-space', label: 'Do Work', text: 'Old work step', tags: ['old'], llm_model_id: 'cursor-live', inference_contract: { type: 'comment', comment: { min_length: 10 }, required: true }, adapter: { id: adapterId, name, layer_index: 2, layer_count: 2, protocol_version: '1.0.0', activation_patterns: ['run old path'], reward_signal: '## Reward Signal\n\nOld.' } } }
+  ];
+}
+
+const SPACE_CTX = { userId: 'u1', groupIds: [], allowedSpaceIds: ['user:test-space'], defaultWriteSpaceId: 'user:test-space', personalSpaceId: 'user:test-space' };
+
+describe('invalidateTuneInProcessCache', () => {
+  test('clears in-process cache after successful tune so export sees fresh data', async () => {
+    const name = 'Tune Export Regression Adapter';
+    const id = IDGenerator.generateAdapterUUIDv5(name);
+    const slug = 'tune-export-regression-adapter';
+    const fakeQdrant = new FakeQdrantService(buildLayers(id, name, slug));
+
+    // Simulates MemoryQdrantStore with stale in-process cache entries
+    class FakeMemoryStore {
+      readonly methods = {
+        localCache: new Map<string, any>([
+          ['11111111-1111-4111-8111-111111111111', { text: 'STALE' }],
+          ['22222222-2222-4222-8222-222222222222', { text: 'STALE' }]
+        ]),
+        invalidateLocalCache(): void { this.localCache.clear(); }
+      };
+    }
+    const store = new FakeMemoryStore();
+
+    const md = `---\nslug: ${slug}\nversion: 1.0.2\n---\n\n# ${name}\n\n## Activation Patterns\n\n- run new\n\n\`\`\`json\n{"contract":{"type":"comment","comment":{"min_length":8},"required":true}}\n\`\`\`\n\n## Apply Fix\n\nFresh details.\n\n\`\`\`json\n{"contract":{"type":"comment","comment":{"min_length":12},"required":true}}\n\`\`\`\n\n## Reward Signal\n\nNew reward.\n`;
+
+    const result = await runWithSpaceContextAsync(SPACE_CTX, () =>
+      executeTune(fakeQdrant as any, { uris: [`kairos://adapter/${slug}`], content: [md] })
+    );
+    expect(result.total_updated).toBe(1);
+    expect(result.total_failed).toBe(0);
+
+    invalidateTuneInProcessCache(store, result);
+    expect(store.methods.localCache.size).toBe(0);
+  });
+
+  test('preserves cache when tune fails (zero updates)', () => {
+    class FakeMemoryStore {
+      readonly methods = {
+        localCache: new Map<string, any>([['k', { text: 'keep' }]]),
+        invalidateLocalCache(): void { this.localCache.clear(); }
+      };
+    }
+    const store = new FakeMemoryStore();
+
+    const failed = { results: [{ uri: 'kairos://adapter/x', status: 'error' as const, message: 'fail' }], total_updated: 0, total_failed: 1 };
+    invalidateTuneInProcessCache(store, failed);
+    expect(store.methods.localCache.size).toBe(1);
+  });
+
+  test('tolerates null/undefined/empty memoryStore', () => {
+    const ok = { results: [{ uri: 'kairos://layer/x', status: 'updated' as const, message: 'ok' }], total_updated: 1, total_failed: 0 };
+    expect(() => invalidateTuneInProcessCache(null, ok)).not.toThrow();
+    expect(() => invalidateTuneInProcessCache(undefined, ok)).not.toThrow();
+    expect(() => invalidateTuneInProcessCache({}, ok)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

PR #545 fixed 2 of 3 cache layers (Redis memory cache + Redis search/activate cache) but missed the third: the **in-process `Map<string, Memory>`** in `MemoryQdrantStoreMethods`.

After `tune` writes to Qdrant:
- Redis caches get invalidated ✓
- In-process cache stays stale ✗
- `export`/`forward`/`activate` read through `memoryStore.getMemory()` → hits stale in-process cache → returns old data
- `tune` reports `"updated"` because `verifyTuneLayerPersistence` reads directly from Qdrant

**Result:** silent false-success — tune says updated, but subsequent reads return stale content.

## Root cause

`registerTuneTool(server)` was never wired with `memoryStore`, unlike every other write tool (`train`, `export`, `forward`, `activate`).

## Fix

- Extract `invalidateTuneInProcessCache()` into `src/tools/tune-cache-invalidation.ts` (avoids ESM/Jest import chain issues)
- Wire `memoryStore` + `qdrantService` into `registerTuneTool` in `server.ts`
- Call cache invalidation after successful tune execution
- Add 3 unit tests (success path, failure path, null-safety)

## Files changed

| File | Change |
|------|--------|
| `src/tools/tune-cache-invalidation.ts` | New — extracted invalidation function |
| `src/tools/tune.ts` | Accepts `memoryStore`, calls invalidation |
| `src/server.ts` | Wires `memoryStore` + `qdrantService` |
| `tests/unit/tune-cache-invalidation.test.ts` | New — 3 regression tests |

## Verification

- TypeScript compiles clean
- ESLint clean (including markdown + skills)
- Unit tests: 3/3 pass
- Dev integration tests: 290/293 pass (3 failures are pre-existing parallel-execution flakiness in `adapter-space-fork.test.ts`, passes in isolation)