### PR TITLE
feat(helm): add Keycloak session affinity + extraOptions (#560)

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.6.5
+version: 0.6.6
 appVersion: "4.7.1"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:

--- a/helm/kairos-mcp/templates/keycloak-cr.yaml
+++ b/helm/kairos-mcp/templates/keycloak-cr.yaml
@@ -83,6 +83,10 @@ spec:
     - name: hostname-admin
       value: {{ printf "https://%s%s" $adminHost $relativePath | quote }}
     {{- end }}
+    {{- range default list $kc.extraOptions }}
+    - name: {{ .name | quote }}
+      value: {{ .value | quote }}
+    {{- end }}
   unsupported:
     podTemplate:
       spec:
@@ -99,6 +103,16 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+    {{- $svcAffinity := default dict $kc.sessionAffinity }}
+    {{- $svcClientIP := default dict $svcAffinity.serviceClientIP }}
+    {{- $svcEnabled := eq (toString (default false $svcClientIP.enabled)) "true" }}
+    {{- if eq (toString $svcClientIP.enabled) "" }}
+    {{- $svcEnabled = gt (int (default 1 $kc.replicas)) 1 }}
+    {{- end }}
+    {{- if $svcEnabled }}
+      serviceSpec:
+        sessionAffinity: ClientIP
+    {{- end }}
   {{- else }}
   {{- toYaml $spec | nindent 2 }}
   {{- end }}

--- a/helm/kairos-mcp/templates/keycloak-destinationrule.yaml
+++ b/helm/kairos-mcp/templates/keycloak-destinationrule.yaml
@@ -1,0 +1,27 @@
+{{- $kc := .Values.keycloakInstance }}
+{{- $sa := default dict $kc.sessionAffinity }}
+{{- $dr := default dict $sa.istioDestinationRule }}
+{{- $drEnabled := eq (toString (default false $dr.enabled)) "true" }}
+{{- if eq (toString $dr.enabled) "" }}
+{{- $drEnabled = gt (int (default 1 $kc.replicas)) 1 }}
+{{- end }}
+{{- if and $kc.enabled $drEnabled (.Capabilities.APIVersions.Has "networking.istio.io/v1") }}
+{{- $ns := $kc.namespace | default .Release.Namespace }}
+{{- $svcName := printf "%s-service" $kc.name }}
+{{- $cookieName := default "AUTH_SESSION_ID" $dr.cookieName }}
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: keycloak-session-affinity
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+spec:
+  host: {{ printf "%s.%s.svc.cluster.local" $svcName $ns }}
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpCookie:
+          name: {{ $cookieName }}
+          ttl: 0s
+{{- end }}

--- a/helm/kairos-mcp/tests/keycloak_ha_test.yaml
+++ b/helm/kairos-mcp/tests/keycloak_ha_test.yaml
@@ -1,0 +1,249 @@
+# helm-unittest — https://github.com/helm-unittest/helm-unittest
+---
+suite: Keycloak DestinationRule (session affinity)
+templates:
+  - keycloak-destinationrule.yaml
+tests:
+  - it: does not render when keycloakInstance is disabled
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: false
+      keycloakInstance.sessionAffinity.istioDestinationRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when istioDestinationRule is explicitly disabled
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.replicas: 3
+      keycloakInstance.sessionAffinity.istioDestinationRule.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render when replicas is 1 (auto default)
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: auto-renders when replicas > 1 and enabled is default empty string
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: DestinationRule
+
+  - it: does not render when Istio CRDs are not installed
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.sessionAffinity.istioDestinationRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders DestinationRule with default cookie name when enabled
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.sessionAffinity.istioDestinationRule.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: DestinationRule
+      - equal:
+          path: metadata.name
+          value: keycloak-session-affinity
+      - equal:
+          path: spec.trafficPolicy.loadBalancer.consistentHash.httpCookie.name
+          value: AUTH_SESSION_ID
+      - equal:
+          path: spec.trafficPolicy.loadBalancer.consistentHash.httpCookie.ttl
+          value: 0s
+
+  - it: uses custom cookie name when set
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.sessionAffinity.istioDestinationRule.enabled: true
+      keycloakInstance.sessionAffinity.istioDestinationRule.cookieName: MY_SESSION
+    asserts:
+      - equal:
+          path: spec.trafficPolicy.loadBalancer.consistentHash.httpCookie.name
+          value: MY_SESSION
+
+  - it: targets the correct service FQDN based on keycloak name and namespace
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.name: my-kc
+      keycloakInstance.namespace: custom-ns
+      keycloakInstance.sessionAffinity.istioDestinationRule.enabled: true
+    asserts:
+      - equal:
+          path: spec.host
+          value: my-kc-service.custom-ns.svc.cluster.local
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+
+  - it: falls back to Release namespace when keycloakInstance.namespace is empty
+    capabilities:
+      apiVersions:
+        - networking.istio.io/v1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.sessionAffinity.istioDestinationRule.enabled: true
+    release:
+      namespace: default-ns
+    asserts:
+      - equal:
+          path: spec.host
+          value: keycloak-service.default-ns.svc.cluster.local
+---
+suite: Keycloak CR extraOptions
+templates:
+  - keycloak-cr.yaml
+tests:
+  - it: renders additionalOptions without extraOptions by default
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.db.host: pg-host
+      keycloakInstance.db.usernameSecretName: pg-user
+      keycloakInstance.db.passwordSecretName: pg-pass
+    asserts:
+      - isKind:
+          of: Keycloak
+      - notExists:
+          path: spec.additionalOptions[?(@.name=="log-level")]
+
+  - it: appends extraOptions to additionalOptions
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.db.host: pg-host
+      keycloakInstance.db.usernameSecretName: pg-user
+      keycloakInstance.db.passwordSecretName: pg-pass
+      keycloakInstance.extraOptions:
+        - name: log-level
+          value: "org.keycloak.events:debug"
+        - name: log-level
+          value: "org.infinispan:info"
+    asserts:
+      - isKind:
+          of: Keycloak
+      - exists:
+          path: spec.additionalOptions[?(@.name=="log-level")]
+
+  - it: does not clobber built-in additionalOptions when extraOptions is set
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.db.host: pg-host
+      keycloakInstance.db.usernameSecretName: pg-user
+      keycloakInstance.db.passwordSecretName: pg-pass
+      keycloakInstance.extraOptions:
+        - name: log-level
+          value: "org.keycloak.events:debug"
+    asserts:
+      - exists:
+          path: spec.additionalOptions[?(@.name=="http-relative-path")]
+
+  - it: is ignored when customSpec replaces the full spec
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.customSpec:
+        instances: 3
+        ingress:
+          enabled: false
+      keycloakInstance.extraOptions:
+        - name: log-level
+          value: "org.keycloak.events:debug"
+    asserts:
+      - isKind:
+          of: Keycloak
+      - notExists:
+          path: spec.additionalOptions
+---
+suite: Keycloak CR serviceClientIP session affinity
+templates:
+  - keycloak-cr.yaml
+tests:
+  - it: does not set serviceSpec.sessionAffinity when replicas is 1 (auto default)
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.replicas: 1
+      keycloakInstance.db.host: pg-host
+      keycloakInstance.db.usernameSecretName: pg-user
+      keycloakInstance.db.passwordSecretName: pg-pass
+    asserts:
+      - notExists:
+          path: spec.unsupported.podTemplate.serviceSpec
+
+  - it: auto-enables serviceClientIP when replicas > 1 (default empty string)
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.replicas: 3
+      keycloakInstance.db.host: pg-host
+      keycloakInstance.db.usernameSecretName: pg-user
+      keycloakInstance.db.passwordSecretName: pg-pass
+    asserts:
+      - equal:
+          path: spec.unsupported.podTemplate.serviceSpec.sessionAffinity
+          value: ClientIP
+
+  - it: explicit false disables serviceClientIP even when replicas > 1
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.replicas: 3
+      keycloakInstance.db.host: pg-host
+      keycloakInstance.db.usernameSecretName: pg-user
+      keycloakInstance.db.passwordSecretName: pg-pass
+      keycloakInstance.sessionAffinity.serviceClientIP.enabled: false
+    asserts:
+      - notExists:
+          path: spec.unsupported.podTemplate.serviceSpec
+
+  - it: sets serviceSpec.sessionAffinity ClientIP when serviceClientIP is explicitly enabled
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.db.host: pg-host
+      keycloakInstance.db.usernameSecretName: pg-user
+      keycloakInstance.db.passwordSecretName: pg-pass
+      keycloakInstance.sessionAffinity.serviceClientIP.enabled: true
+    asserts:
+      - equal:
+          path: spec.unsupported.podTemplate.serviceSpec.sessionAffinity
+          value: ClientIP
+
+  - it: is ignored when customSpec replaces the full spec
+    set:
+      keycloakInstance.enabled: true
+      keycloakInstance.customSpec:
+        instances: 3
+      keycloakInstance.sessionAffinity.serviceClientIP.enabled: true
+    asserts:
+      - notExists:
+          path: spec.unsupported

--- a/helm/kairos-mcp/values.yaml
+++ b/helm/kairos-mcp/values.yaml
@@ -198,6 +198,34 @@ keycloakInstance:
     usernameSecretKey: "user"
     passwordSecretName: ""
     passwordSecretKey: "password"
+  # Append-only list merged into the Keycloak CR additionalOptions.
+  # Use for log-level tuning, proxy options, etc. without replacing the full spec.
+  # Example:
+  #   extraOptions:
+  #     - name: log-level
+  #       value: org.keycloak.events:debug
+  extraOptions: []
+  # Session affinity for multi-replica Keycloak with OIDC identity-provider
+  # brokering. Two mutually-reinforcing mechanisms — enable the one that matches
+  # your cluster networking:
+  #
+  #   istioDestinationRule — cookie-based consistent-hash via Istio (requires
+  #     Istio in the cluster and Keycloak pods in the mesh). Works with both
+  #     Gateway API (HTTPRoute) and Ingress ingress paths.
+  #   serviceClientIP — kube-proxy ClientIP session affinity on the Keycloak
+  #     Service (no mesh required). Coarser than cookie-based (IP-level), but
+  #     effective for most in-cluster setups. Use when Istio is not available.
+  #
+  # Both default to "" (auto): enabled when keycloakInstance.replicas > 1.
+  # Set explicitly to true or false to override auto-detection.
+  # If both are active, the DestinationRule takes precedence for Istio-managed
+  # traffic; serviceClientIP covers non-mesh paths.
+  sessionAffinity:
+    istioDestinationRule:
+      enabled: ""
+      cookieName: "AUTH_SESSION_ID"
+    serviceClientIP:
+      enabled: ""
   customSpec: {}
 
 # First-install-only KeycloakRealmImport (operator imports realm, then CR is not re-rendered).


### PR DESCRIPTION
> **⚠️ Draft — `serviceClientIP` needs verification before merge**
>
> The `serviceClientIP` path uses `unsupported.podTemplate.serviceSpec.sessionAffinity: ClientIP` in the Keycloak CR. This field is **not confirmed** to exist in the Keycloak operator CRD — the official docs only describe pod-level overrides under `unsupported.podTemplate`, not Service-level overrides.
>
> **Before merging:** verify `serviceSpec` is accepted by the Keycloak operator (test against dev cluster), or remove `serviceClientIP` and keep only the Istio DestinationRule + extraOptions changes (both verified).

## Summary

When `keycloakInstance.replicas > 1` and Keycloak brokers to an upstream OIDC IdP, users hit intermittent login redirect loops because the multi-step broker flow can have its callback routed to a replica that does not yet hold the auth session (Infinispan replication race). The chart previously had no way to enable session affinity or raise broker log verbosity without the all-or-nothing `customSpec` escape hatch.

## Changes

### 1. Session affinity — dual-mode with auto-detect

Two mechanisms under `keycloakInstance.sessionAffinity`, both auto-enable when `replicas > 1`:

| | `istioDestinationRule` | `serviceClientIP` |
|---|---|---|
| **Requires** | Istio + pods in mesh | Nothing extra |
| **Mechanism** | Cookie-based consistent-hash (`AUTH_SESSION_ID`) | kube-proxy `ClientIP` pinning |
| **Works with** | Gateway API + Ingress | Gateway API + Ingress + direct Service |

Both use a `""` sentinel default (auto-detect from replica count). Explicit `true`/`false` overrides auto-detection.

- **Istio path:** New `keycloak-destinationrule.yaml` template renders an Istio `DestinationRule` with `consistentHash.httpCookie`, gated by `.Capabilities.APIVersions.Has "networking.istio.io/v1"` (same pattern as `keycloak-admin-authz-policy.yaml`).
- **Non-Istio path:** Patches the Keycloak-managed Service via `unsupported.podTemplate.serviceSpec.sessionAffinity: ClientIP` in the Keycloak CR.

### 2. Extra options — append without clobbering

New `keycloakInstance.extraOptions: []` list merged into the Keycloak CR `additionalOptions`. Allows operators to add e.g. `--log-level=org.keycloak.events:debug` for broker diagnostics without replacing the full spec via `customSpec`.

### 3. Tests

21 helm-unittest cases covering:
- DestinationRule: disabled when Keycloak off, disabled when Istio CRDs absent, auto-enable with replicas > 1, explicit true/false overrides, custom cookie name, correct FQDN/namespace
- serviceClientIP: auto-enable with replicas > 1, explicit false override, customSpec bypass
- extraOptions: no-op by default, appends correctly, preserves built-in options, ignored with customSpec

## Acceptance criteria (from #560)

- [x] A documented value enables Keycloak session affinity without redefining the full CR spec
- [x] A documented value appends Keycloak CR options (e.g. log level) without replacing the built-in spec
- [x] Guidance in values.yaml on enabling affinity when replicas > 1 with OIDC brokering

Closes #560