### PR TITLE
feat(helm): default Gateway to Istio ambient dataplane mode

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "4.7.2"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:

--- a/helm/kairos-mcp/templates/gateway.yaml
+++ b/helm/kairos-mcp/templates/gateway.yaml
@@ -12,6 +12,10 @@ metadata:
   name: {{ $gw.gatewayName | default "kairos-gateway" }}
   labels:
     app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
+    {{- $dm := $gw.dataplaneMode }}
+    {{- if not (and (kindIs "string" $dm) (eq $dm "")) }}
+    istio.io/dataplane-mode: {{ default "ambient" $dm }}
+    {{- end }}
 spec:
   gatewayClassName: {{ $gw.gatewayClassName }}
   listeners:

--- a/helm/kairos-mcp/tests/chart_defaults_test.yaml
+++ b/helm/kairos-mcp/tests/chart_defaults_test.yaml
@@ -40,6 +40,37 @@ tests:
       - equal:
           path: spec.gatewayClassName
           value: ngrok
+  - it: sets istio.io/dataplane-mode label to ambient by default
+    set:
+      gateway.enabled: true
+      gateway.createGateway: true
+      gateway.hostname: "kairos.example.com"
+      gateway.gatewayClassName: "istio"
+    asserts:
+      - equal:
+          path: metadata.labels["istio.io/dataplane-mode"]
+          value: ambient
+  - it: allows overriding dataplaneMode to sidecar
+    set:
+      gateway.enabled: true
+      gateway.createGateway: true
+      gateway.hostname: "kairos.example.com"
+      gateway.gatewayClassName: "istio"
+      gateway.dataplaneMode: "sidecar"
+    asserts:
+      - equal:
+          path: metadata.labels["istio.io/dataplane-mode"]
+          value: sidecar
+  - it: omits dataplane-mode label when dataplaneMode is empty
+    set:
+      gateway.enabled: true
+      gateway.createGateway: true
+      gateway.hostname: "kairos.example.com"
+      gateway.gatewayClassName: "ngrok"
+      gateway.dataplaneMode: ""
+    asserts:
+      - isNull:
+          path: metadata.labels["istio.io/dataplane-mode"]
 ---
 suite: app Service
 templates:

--- a/helm/kairos-mcp/values.yaml
+++ b/helm/kairos-mcp/values.yaml
@@ -94,6 +94,10 @@ gateway:
   existingGatewayName: ""
   existingGatewayNamespace: ""
   gatewayClassName: "ngrok"
+  # Istio dataplane mode label on the Gateway resource.
+  # Default "ambient" avoids sidecar injection (no seccompProfile needed under restricted PSA).
+  # Set to "sidecar" for legacy sidecar mode, or "" to omit the label.
+  dataplaneMode: "ambient"
   hostname: ""
   httpPort: 80
   httpsPort: 443


### PR DESCRIPTION
## Summary

Add `gateway.dataplaneMode` (default: `ambient`) to the Helm chart. The Gateway resource now renders `istio.io/dataplane-mode: ambient` label, which tells Istio not to inject a sidecar proxy for the auto-deployed gateway pod.

## Problem

Under restricted Pod Security Admission (PSA), the Istio gateway proxy pod (`kairos-gateway-istio-*`) fails to start because the `istio-proxy` container lacks `securityContext.seccompProfile.type: RuntimeDefault`.

## Fix

Setting `istio.io/dataplane-mode: ambient` on the Gateway resource avoids sidecar injection entirely — ambient mode captures traffic at the node level via CNI, so no `istio-proxy` container is created.

## Changes

| File | Change |
|------|--------|
| `helm/kairos-mcp/values.yaml` | Added `gateway.dataplaneMode: "ambient"` with docs |
| `helm/kairos-mcp/templates/gateway.yaml` | Render `istio.io/dataplane-mode` label with `kindIs` guard |
| `helm/kairos-mcp/tests/chart_defaults_test.yaml` | 3 new tests: default ambient, sidecar override, empty omit |

## Override

- `gateway.dataplaneMode: "sidecar"` — legacy sidecar mode
- `gateway.dataplaneMode: ""` — omit the label entirely