### PR TITLE
fix: npm audit + Trivy cleanup for 4.7.3 release

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,11 +1,3 @@
-# CVE-2026-33671 (picomatch ReDoS): bundled under global npm CLI
-# (usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch).
-# Revalidated 2026-04-17: npm@11.12.1 (latest) still bundles tinyglobby@0.2.15
-# with picomatch@4.0.3 (fixed upstream in 4.0.4+).
-# Runtime image does not use npm CLI on untrusted glob patterns.
-# Revisit as soon as npm ships picomatch 4.0.4+ in its bundled tree.
-CVE-2026-33671 exp:2026-12-31
-
 # CVE-2026-45447 (OpenSSL Heap Use-After-Free in PKCS7_verify): affects libcrypto3 and libssl3
 # in Alpine 3.23 (node:24-alpine base image). Fixed in OpenSSL 3.5.7-r0.
 # The Dockerfile already runs `apk upgrade --no-cache` but the pinned base image digest

--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,9 @@
 # Runtime image does not use npm CLI on untrusted glob patterns.
 # Revisit as soon as npm ships picomatch 4.0.4+ in its bundled tree.
 CVE-2026-33671 exp:2026-12-31
+
+# CVE-2026-45447 (OpenSSL Heap Use-After-Free in PKCS7_verify): affects libcrypto3 and libssl3
+# in Alpine 3.23 (node:24-alpine base image). Fixed in OpenSSL 3.5.7-r0.
+# The Dockerfile already runs `apk upgrade --no-cache` but the pinned base image digest
+# may trail the Alpine repo. Revisit when the node:24-alpine digest includes 3.5.7-r0+.
+CVE-2026-45447 exp:2026-07-31

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ VOLUME /snapshots
 RUN apk update && apk upgrade --no-cache
 
 # Pin global npm to a newer release than the default in the base image (bundled deps drift with the CLI).
-RUN npm install -g npm@11.12.0
+RUN npm install -g npm@11.17.0
 
 ARG PACKAGE_VERSION
 RUN test -n "$PACKAGE_VERSION" || (echo "Build-arg PACKAGE_VERSION is required" && exit 1)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -34,7 +34,7 @@ VOLUME /snapshots
 RUN apk update && apk upgrade --no-cache
 
 # Match global npm pin in release Dockerfile.
-RUN npm install -g npm@11.12.0
+RUN npm install -g npm@11.17.0
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S kairos -u 1001

--- a/package-lock.json
+++ b/package-lock.json
@@ -1020,9 +1020,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
Unblocks the v4.7.3 Release workflow with three fixes:

1. **npm audit**: bump `@grpc/grpc-js` 1.14.3 → 1.14.4 (CVE in package-lock.json)
2. **Trivy CVE-2026-45447**: add OpenSSL libcrypto3/libssl3 to `.trivyignore` (fix 3.5.7-r0 not yet in pinned node:24-alpine digest)
3. **Remove CVE-2026-33671 exception**: bump global npm 11.12.0 → 11.17.0 in Dockerfile + Dockerfile.dev (npm 11.17 ships picomatch 4.0.4 which fixes the picomatch ReDoS)