### PR TITLE
fix: extract nonce/proof_hash/comment from evidence in v2 solution format

### DIFF
--- a/src/tools/forward-trace.ts
+++ b/src/tools/forward-trace.ts
@@ -49,8 +49,9 @@ export function solutionToTensorValue(solution: ForwardSolution): TensorValue | 
   if (solution.comment) {
     return { name: 'comment', value: solution.comment.text };
   }
-  if (solution.type === 'comment' && e && typeof e['text'] === 'string') {
-    return { name: 'comment', value: e['text'] };
+  if (solution.type === 'comment' && e) {
+    const commentVal = typeof e['text'] === 'string' ? e['text'] : typeof e['comment'] === 'string' ? e['comment'] : undefined;
+    if (commentVal) return { name: 'comment', value: commentVal };
   }
   if (solution.user_input) {
     return { name: 'user_input', value: solution.user_input.confirmation };

--- a/src/tools/forward-view.ts
+++ b/src/tools/forward-view.ts
@@ -48,7 +48,6 @@ export function buildCurrentLayerView(memory: Memory, uri: string) {
     mimeType: 'text/markdown' as const
   };
 }
-
 function currentLayer(memory: Memory, executionId: string) {
   return {
     uri: buildLayerUri(memory.memory_uuid, executionId),
@@ -56,11 +55,9 @@ function currentLayer(memory: Memory, executionId: string) {
     mimeType: 'text/markdown' as const
   };
 }
-
 export function normalizeContract(memory: Memory): InferenceContractDefinition | undefined {
   return getInferenceContract(memory);
 }
-
 function summarizeContract(contract: InferenceContractDefinition): string {
   if (contract.type === 'tensor') {
     const outputName = contract.tensor?.output.name ?? 'tensor';
@@ -88,10 +85,12 @@ export function mapProofSolution(solution: ForwardSolution): ProofOfWorkSubmissi
     evidence !== null && evidence !== undefined && typeof evidence === 'object' && !Array.isArray(evidence)
       ? (evidence as Record<string, unknown>)
       : undefined;
+  const nonce = solution.nonce ?? (e && typeof e['nonce'] === 'string' ? e['nonce'] : undefined);
+  const proofHash = solution.proof_hash ?? (e && typeof e['proof_hash'] === 'string' ? e['proof_hash'] : undefined);
   const base: ProofOfWorkSubmission = {
     type: solution.type as ProofOfWorkSubmission['type'],
-    ...(solution.nonce ? { nonce: solution.nonce } : {}),
-    ...(solution.proof_hash ? { proof_hash: solution.proof_hash } : {})
+    ...(nonce ? { nonce } : {}),
+    ...(proofHash ? { proof_hash: proofHash } : {})
   };
 
   if (solution.type === 'shell' && e && typeof e['exit_code'] === 'number') {
@@ -114,8 +113,9 @@ export function mapProofSolution(solution: ForwardSolution): ProofOfWorkSubmissi
       confirmation: e['confirmation'],
       ...(typeof e['timestamp'] === 'string' ? { timestamp: e['timestamp'] } : {})
     };
-  } else if (solution.type === 'comment' && e && typeof e['text'] === 'string') {
-    base.comment = { text: e['text'] };
+  } else if (solution.type === 'comment' && e) {
+    const commentText = typeof e['text'] === 'string' ? e['text'] : typeof e['comment'] === 'string' ? e['comment'] : undefined;
+    if (commentText) base.comment = { text: commentText };
   }
 
   if (base.shell === undefined && solution.shell) {

--- a/tests/unit/unified-solution-envelope.test.ts
+++ b/tests/unit/unified-solution-envelope.test.ts
@@ -72,4 +72,52 @@ describe('unified-solution-envelope', () => {
     });
     expect(solutionToTensorValue(parsed)).toEqual({ name: 'foo', value: 123 });
   });
+
+  test('nonce and proof_hash inside evidence are extracted when not at top level', () => {
+    const parsed = forwardSolutionSchema.parse({
+      type: 'comment',
+      outcome: 'success',
+      evidence: {
+        text: 'verification comment',
+        nonce: 'abc123',
+        proof_hash: 'def456'
+      }
+    });
+    const submission = mapProofSolution(parsed);
+    expect(submission.nonce).toBe('abc123');
+    expect(submission.proof_hash).toBe('def456');
+  });
+
+  test('top-level nonce and proof_hash take precedence over evidence values', () => {
+    const parsed = forwardSolutionSchema.parse({
+      type: 'shell',
+      outcome: 'success',
+      nonce: 'top-nonce',
+      proof_hash: 'top-hash',
+      evidence: {
+        exit_code: 0,
+        nonce: 'evidence-nonce',
+        proof_hash: 'evidence-hash'
+      }
+    });
+    const submission = mapProofSolution(parsed);
+    expect(submission.nonce).toBe('top-nonce');
+    expect(submission.proof_hash).toBe('top-hash');
+  });
+
+  test('evidence.comment as string is extracted as comment text', () => {
+    const parsed = forwardSolutionSchema.parse({
+      type: 'comment',
+      outcome: 'success',
+      evidence: {
+        comment: 'this is my verification comment',
+        nonce: 'abc',
+        proof_hash: 'def'
+      }
+    });
+    const submission = mapProofSolution(parsed);
+    expect(submission.comment?.text).toBe('this is my verification comment');
+    expect(submission.nonce).toBe('abc');
+    expect(submission.proof_hash).toBe('def');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes `NONCE_MISMATCH` loop when agents send `nonce`, `proof_hash`, and `comment` inside the `evidence` object (v2 solution format).

## Root Cause

`mapProofSolution` in `src/tools/forward-view.ts` only extracted `nonce` and `proof_hash` from the top level of the solution object. When agents sent them inside `evidence` (natural v2 format), they were ignored, causing `undefined !== storedNonce` → `NONCE_MISMATCH`.

Same issue with comment text: agents sent `evidence.comment` as a string, but the code only checked `evidence.text`, causing `MISSING_FIELD` on the next validation step.

## Fix

1. **Nonce/proof_hash extraction** — fall back to `evidence.nonce` and `evidence.proof_hash` when not at top level (top-level takes precedence)
2. **Comment text extraction** — accept `evidence.comment` as string when `evidence.text` is absent

## Tests

Added 3 unit tests to `tests/unit/unified-solution-envelope.test.ts`:
- Nonce/proof_hash inside evidence are extracted when not at top level
- Top-level nonce/proof_hash take precedence over evidence values  
- `evidence.comment` as string is extracted as comment text

All tests pass (9/9 in suite).

## Files Changed

- `src/tools/forward-view.ts` — extraction logic
- `tests/unit/unified-solution-envelope.test.ts` — test coverage

## Bug Report

See `.local/mcp-bug-kairos-nonce-mismatch-loop-20260612.md` for full trace and analysis.