### PR TITLE
release: 4.7.5

### DIFF
--- a/helm/kairos-mcp/Chart.yaml
+++ b/helm/kairos-mcp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kairos-mcp
 description: KAIROS MCP application chart (Phase 2+). Phase 1 data plane lives under helm/infrastructure (Kustomize). Operators under helm/operators.
 type: application
-version: 0.9.0
-appVersion: "4.7.4"
+version: 0.9.1
+appVersion: "4.7.5"
 icon: https://raw.githubusercontent.com/debian777/kairos-mcp/main/logo/kairos-mcp.svg
 keywords:
   - kairos

--- a/helm/kairos-mcp/README.md
+++ b/helm/kairos-mcp/README.md
@@ -49,8 +49,11 @@ When any of `redisCluster.enabled`, `keycloakInstance.enabled`, or `postgresClus
 
 ## Gateway API
 
-Set `gateway.enabled: true`, `gateway.hostname`, and
-`gateway.gatewayClassName`. The app route renders only when `app.enabled=true`.
+Set `gateway.enabled: true` and `gateway.hostname`. If `gateway.gatewayClassName`
+is empty (the default), the chart auto-detects the first available GatewayClass in
+the cluster; set it explicitly (e.g. `ngrok`, `istio`, `traefik`) to skip autodetection.
+If no GatewayClass exists and `gateway.ingressClassName` is set, the chart falls back
+to ingress mode. The app route renders only when `app.enabled=true`.
 Keycloak is exposed at `https://<hostname>/sso`. For the repo-local k3d flow,
 `helm/.dev/k3b.sh` installs operators, ngrok, `GatewayClass/ngrok`, and by default
 the `kairos` Helm release (`helm/values.dev.yaml`) so the MCP app and Keycloak get

--- a/helm/kairos-mcp/templates/_helpers.tpl
+++ b/helm/kairos-mcp/templates/_helpers.tpl
@@ -1,12 +1,46 @@
 {{/*
+Resolve Gateway API gatewayClassName.
+Priority: explicit .Values.gateway.gatewayClassName > cluster autodetection.
+Returns empty string when no class is available.
+*/}}
+{{- define "kairos.resolvedGatewayClass" -}}
+{{- $gw := default dict .Values.gateway -}}
+{{- if $gw.gatewayClassName -}}
+  {{- $gw.gatewayClassName -}}
+{{- else -}}
+  {{- $classes := lookup "gateway.networking.k8s.io/v1" "GatewayClass" "" "" -}}
+  {{- if and $classes $classes.items -}}
+    {{- $names := list -}}
+    {{- range $classes.items -}}
+      {{- $names = append $names .metadata.name -}}
+    {{- end -}}
+    {{- index (sortAlpha $names) 0 -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve effective gateway name for parentRefs.
+Uses existingGatewayName when set, otherwise chart-managed gatewayName.
+*/}}
+{{- define "kairos.resolvedGatewayName" -}}
+{{- $gw := default dict .Values.gateway -}}
+{{- default ($gw.gatewayName | default "kairos-gateway") $gw.existingGatewayName -}}
+{{- end -}}
+
+{{/*
 Determine ingress mode: "gateway" | "ingress" | "none".
-Explicit .Values.gateway.mode wins; "auto" picks based on gatewayClassName presence.
+Explicit .Values.gateway.mode wins; "auto" picks based on:
+  1. gatewayClassName (explicit or autodetected from cluster) -> gateway
+  2. ingressClassName -> ingress
+  3. nothing available -> none
 */}}
 {{- define "kairos.ingressMode" -}}
 {{- $gw := default dict .Values.gateway -}}
 {{- $mode := default "auto" $gw.mode -}}
 {{- if eq $mode "auto" -}}
-  {{- if $gw.gatewayClassName -}}gateway{{- else if $gw.ingressClassName -}}ingress{{- else -}}none{{- end -}}
+  {{- $gwClass := include "kairos.resolvedGatewayClass" . | trim -}}
+  {{- if $gwClass -}}gateway{{- else if $gw.ingressClassName -}}ingress{{- else -}}none{{- end -}}
 {{- else -}}
   {{- $mode -}}
 {{- end -}}

--- a/helm/kairos-mcp/templates/gateway.yaml
+++ b/helm/kairos-mcp/templates/gateway.yaml
@@ -4,7 +4,9 @@
 {{- $hasTLS := or $certManager.enabled $tls.secretName }}
 {{- $allowHttpWithTLS := default false $gw.allowHttpWithTls }}
 {{- $mode := include "kairos.ingressMode" . | trim }}
-{{- if and $gw.enabled $gw.createGateway $gw.hostname (eq $mode "gateway") }}
+{{- $gwClass := include "kairos.resolvedGatewayClass" . | trim }}
+{{- $infraAnnotations := default dict $gw.infrastructureAnnotations }}
+{{- if and $gw.enabled $gw.createGateway $gw.hostname (eq $mode "gateway") $gwClass }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -13,7 +15,12 @@ metadata:
   labels:
     app.kubernetes.io/part-of: {{ .Chart.Name | quote }}
 spec:
-  gatewayClassName: {{ $gw.gatewayClassName }}
+  gatewayClassName: {{ $gwClass }}
+  {{- if $infraAnnotations }}
+  infrastructure:
+    annotations:
+      {{- toYaml $infraAnnotations | nindent 6 }}
+  {{- end }}
   listeners:
     {{- if or (not $hasTLS) $allowHttpWithTLS }}
     - name: http

--- a/helm/kairos-mcp/templates/httproute-keycloak-admin-redirect.yaml
+++ b/helm/kairos-mcp/templates/httproute-keycloak-admin-redirect.yaml
@@ -16,7 +16,7 @@ spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: {{ $gw.existingGatewayName | default $gw.gatewayName }}
+      name: {{ include "kairos.resolvedGatewayName" . }}
       {{- if $gw.existingGatewayNamespace }}
       namespace: {{ $gw.existingGatewayNamespace }}
       {{- else }}

--- a/helm/kairos-mcp/templates/httproute-keycloak.yaml
+++ b/helm/kairos-mcp/templates/httproute-keycloak.yaml
@@ -4,7 +4,8 @@
 {{- $kc := .Values.keycloakInstance }}
 {{- $serviceName := default (printf "%s-service" $kc.name) $route.serviceName }}
 {{- $servicePort := default $kc.http.httpPort $route.port }}
-{{- if and $gateway.enabled $gateway.hostname $route.enabled $serviceName }}
+{{- $mode := include "kairos.ingressMode" . | trim }}
+{{- if and $gateway.enabled $gateway.hostname $route.enabled $serviceName (eq $mode "gateway") }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -15,7 +16,7 @@ spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: {{ $gateway.existingGatewayName | default $gateway.gatewayName }}
+      name: {{ include "kairos.resolvedGatewayName" . }}
       {{- if $gateway.existingGatewayNamespace }}
       namespace: {{ $gateway.existingGatewayNamespace }}
       {{- else }}

--- a/helm/kairos-mcp/templates/httproute-mcp.yaml
+++ b/helm/kairos-mcp/templates/httproute-mcp.yaml
@@ -1,4 +1,8 @@
-{{- if and .Values.gateway.enabled .Values.gateway.hostname .Values.app.enabled }}
+{{- $gw := default dict .Values.gateway }}
+{{- $routes := default dict $gw.routes }}
+{{- $mcpRoute := default dict $routes.mcp }}
+{{- $mode := include "kairos.ingressMode" . | trim }}
+{{- if and $gw.enabled $gw.hostname .Values.app.enabled (eq $mode "gateway") }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -9,19 +13,19 @@ spec:
   parentRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
-      name: {{ .Values.gateway.existingGatewayName | default .Values.gateway.gatewayName }}
-      {{- if .Values.gateway.existingGatewayNamespace }}
-      namespace: {{ .Values.gateway.existingGatewayNamespace }}
+      name: {{ include "kairos.resolvedGatewayName" . }}
+      {{- if $gw.existingGatewayNamespace }}
+      namespace: {{ $gw.existingGatewayNamespace }}
       {{- else }}
       namespace: {{ .Release.Namespace }}
       {{- end }}
   hostnames:
-    - {{ .Values.gateway.hostname }}
+    - {{ $gw.hostname }}
   rules:
     - matches:
         - path:
             type: PathPrefix
-            value: {{ .Values.gateway.routes.mcp.path | default "/" }}
+            value: {{ $mcpRoute.path | default "/" }}
       filters:
         - type: RequestHeaderModifier
           requestHeaderModifier:
@@ -29,9 +33,23 @@ spec:
               - name: X-Forwarded-Proto
                 value: https
               - name: X-Forwarded-Host
-                value: {{ .Values.gateway.hostname }}
+                value: {{ $gw.hostname }}
               - name: X-Forwarded-Port
                 value: "443"
+        {{- if dig "cors" "enabled" false $mcpRoute }}
+        {{- $cors := $mcpRoute.cors }}
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            add:
+              - name: Access-Control-Allow-Origin
+                value: {{ $cors.allowOrigins | default "*" | quote }}
+              - name: Access-Control-Allow-Methods
+                value: {{ $cors.allowMethods | default "POST, OPTIONS" | quote }}
+              - name: Access-Control-Allow-Headers
+                value: {{ $cors.allowHeaders | default "Content-Type, Authorization, MCP-Protocol-Version" | quote }}
+              - name: Access-Control-Max-Age
+                value: {{ $cors.maxAge | default 86400 | quote }}
+        {{- end }}
       backendRefs:
         - group: ""
           kind: Service

--- a/helm/kairos-mcp/tests/chart_defaults_test.yaml
+++ b/helm/kairos-mcp/tests/chart_defaults_test.yaml
@@ -26,7 +26,7 @@ suite: Gateway resource
 templates:
   - gateway.yaml
 tests:
-  - it: renders Gateway when createGateway and hostname are set
+  - it: renders Gateway when createGateway and explicit gatewayClassName are set
     set:
       gateway.enabled: true
       gateway.createGateway: true
@@ -40,6 +40,81 @@ tests:
       - equal:
           path: spec.gatewayClassName
           value: ngrok
+  - it: does not render Gateway when gatewayClassName is empty and no cluster GatewayClass
+    set:
+      gateway.enabled: true
+      gateway.createGateway: true
+      gateway.hostname: "kairos.example.com"
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders infrastructure annotations when set
+    set:
+      gateway.enabled: true
+      gateway.createGateway: true
+      gateway.hostname: "kairos.example.com"
+      gateway.gatewayClassName: "istio"
+      gateway.infrastructureAnnotations:
+        proxy.istio.io/config: '{"seccompProfile":{"type":"RuntimeDefault"}}'
+    asserts:
+      - isSubset:
+          path: spec.infrastructure.annotations
+          content:
+            proxy.istio.io/config: '{"seccompProfile":{"type":"RuntimeDefault"}}'
+---
+suite: MCP HTTPRoute
+templates:
+  - httproute-mcp.yaml
+tests:
+  - it: renders HTTPRoute when gateway class is set
+    set:
+      gateway.enabled: true
+      gateway.hostname: "kairos.example.com"
+      gateway.gatewayClassName: "ngrok"
+      app.enabled: true
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: kairos-gateway
+  - it: renders CORS ResponseHeaderModifier when cors.enabled
+    set:
+      gateway.enabled: true
+      gateway.hostname: "kairos.example.com"
+      gateway.gatewayClassName: "ngrok"
+      gateway.routes.mcp.cors.enabled: true
+      app.enabled: true
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - contains:
+          path: spec.rules[0].filters
+          content:
+            type: ResponseHeaderModifier
+            responseHeaderModifier:
+              add:
+                - name: Access-Control-Allow-Origin
+                  value: "*"
+                - name: Access-Control-Allow-Methods
+                  value: "POST, OPTIONS"
+                - name: Access-Control-Allow-Headers
+                  value: "Content-Type, Authorization, MCP-Protocol-Version"
+                - name: Access-Control-Max-Age
+                  value: "86400"
+  - it: does not render CORS filter when cors disabled
+    set:
+      gateway.enabled: true
+      gateway.hostname: "kairos.example.com"
+      gateway.gatewayClassName: "ngrok"
+      app.enabled: true
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - notContains:
+          path: spec.rules[0].filters
+          content:
+            type: ResponseHeaderModifier
 ---
 suite: app Service
 templates:

--- a/helm/kairos-mcp/values.yaml
+++ b/helm/kairos-mcp/values.yaml
@@ -93,13 +93,24 @@ gateway:
   gatewayName: "kairos-gateway"
   existingGatewayName: ""
   existingGatewayNamespace: ""
-  gatewayClassName: "ngrok"
+  # Gateway API gatewayClassName. Empty string triggers cluster autodetection:
+  # the chart looks up GatewayClass resources and picks the first available.
+  # Set explicitly (e.g. "ngrok", "istio", "traefik") to skip autodetection.
+  # If no GatewayClass exists and ingressClassName is set, falls back to ingress.
+  gatewayClassName: ""
   hostname: ""
   httpPort: 80
   httpsPort: 443
   # When TLS is enabled, also expose HTTP listener (useful for local dev).
   allowHttpWithTls: false
   ingressClassName: ""
+  # Provider-specific annotations passed to Gateway spec.infrastructure.annotations.
+  # Use for Istio proxy config, ngrok policies, or other provider extensions.
+  # PSA enforcement is a cluster concern - configure at namespace level outside this chart.
+  infrastructureAnnotations: {}
+  # Example for Istio:
+  #   infrastructureAnnotations:
+  #     proxy.istio.io/config: '{"seccompProfile":{"type":"RuntimeDefault"}}'
   tls:
     secretName: ""
     certManager:
@@ -111,6 +122,15 @@ gateway:
   routes:
     mcp:
       path: "/"
+      cors:
+        # When enabled, adds CORS response headers via Gateway API
+        # ResponseHeaderModifier filter. App-level CORS middleware
+        # (src/http/http-mcp-cors.ts) remains as fallback for preflight.
+        enabled: false
+        allowOrigins: "*"
+        allowMethods: "POST, OPTIONS"
+        allowHeaders: "Content-Type, Authorization, MCP-Protocol-Version"
+        maxAge: 86400
     keycloak:
       enabled: true
       path: "/sso"

--- a/helm/values.dev.yaml
+++ b/helm/values.dev.yaml
@@ -51,6 +51,8 @@ gateway:
   routes:
     mcp:
       path: /
+      cors:
+        enabled: true
     keycloak:
       enabled: true
       path: /sso

--- a/helm/values.prod.yaml
+++ b/helm/values.prod.yaml
@@ -63,6 +63,10 @@ gateway:
   routes:
     mcp:
       path: /
+      cors:
+        enabled: true
+        # IMPORTANT: restrict to your actual frontend origin(s) before deploying
+        # allowOrigins: "https://your-frontend.example.com"
     keycloak:
       enabled: true
       path: /sso

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debian777/kairos-mcp",
-      "version": "4.7.4",
+      "version": "4.7.5",
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debian777/kairos-mcp",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "description": "MCP server for agent automation: persistent memory and deterministic workflow execution for AI agents and chats",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Patch release **v4.7.5** — cherry-pick helm gateway changes from #578 onto v4.7.4.

### Included
- Gateway autodetection (drop hardcoded ngrok default)
- CORS support via ResponseHeaderModifier on MCP HTTPRoute
- `spec.infrastructure.annotations` for provider-specific gateway config
- Helm tests (8 tests, 4 suites)

### Excluded
- v4.8.0-beta experimental work (phase-critic quality gate, audit log, journey tooling)
- All repowiki sync changes

### Version bumps
- `package.json`: 4.7.4 → 4.7.5
- `Chart.yaml`: 0.9.0 → 0.9.1 (appVersion 4.7.5)

### Verification
- helm unittest: 8/8 passing
- Helm template rendering verified for all modes