### PR TITLE
deps(actions): bump checkout@v5, upload-artifact@v5; refresh node:24-alpine digest

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-version-bump.yml
+++ b/.github/workflows/helm-version-bump.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch (post-bump)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/integration-simple.yml
+++ b/.github/workflows/integration-simple.yml
@@ -32,7 +32,7 @@ jobs:
       code: ${{ steps.combine.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
           fetch-depth: 0
@@ -171,7 +171,7 @@ jobs:
           fi
 
       - name: Upload npm package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-package-simple-node24
           path: dist/*.tgz
@@ -184,7 +184,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -202,7 +202,7 @@ jobs:
         run: node scripts/ci-github-step-summary.mjs "Build package (tgz)" -- npm run build:tgz
 
       - name: Upload npm package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-package-simple-node26
           path: dist/*.tgz
@@ -215,7 +215,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -367,7 +367,7 @@ jobs:
 
       - name: Upload kairos simple log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: kairos-simple-log-node24
           path: var/log/kairos-simple.log
@@ -386,7 +386,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -536,7 +536,7 @@ jobs:
 
       - name: Upload kairos simple log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: kairos-simple-log-node26
           path: var/log/kairos-simple.log

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
       code: ${{ steps.combine.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -100,7 +100,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
           fetch-depth: 0
@@ -183,7 +183,7 @@ jobs:
         run: node scripts/ci-github-step-summary.mjs "Test package install (clean tgz smoke)" -- npm run test:tgz
 
       - name: Upload npm package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-package-node24
           path: dist/*.tgz
@@ -196,7 +196,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -217,7 +217,7 @@ jobs:
         run: node scripts/ci-github-step-summary.mjs "Test package install (clean tgz smoke)" -- npm run test:tgz
 
       - name: Upload npm package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-package-node26
           path: dist/*.tgz
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -285,7 +285,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -339,7 +339,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -496,7 +496,7 @@ jobs:
 
       - name: Upload kairos log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: kairos-log-node24
           path: var/log/kairos.log
@@ -511,7 +511,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -651,7 +651,7 @@ jobs:
 
       - name: Upload kairos log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: kairos-log-node26
           path: var/log/kairos.log
@@ -666,7 +666,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Dependabot PRs do not receive DOCKER_* secrets; login with empty creds fails the step.
       - name: Login to Docker Hub

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/rebase-prs-on-main.yml
+++ b/.github/workflows/rebase-prs-on-main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (fetch all refs)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-tag-on-version-bump.yml
+++ b/.github/workflows/release-tag-on-version-bump.yml
@@ -94,7 +94,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: >-
             ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       TRIVYIGNORE_EXPIRY_WARNING_DAYS: "45"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
       - name: Validate .trivyignore expiry dates
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
@@ -129,7 +129,7 @@ jobs:
           upload-artifact: false
 
       - name: Upload CycloneDX SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cyclonedx-sbom-${{ steps.version.outputs.version }}
           path: kairos-mcp-${{ steps.version.outputs.version }}-sbom.cdx.json

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -42,7 +42,7 @@ jobs:
       npm-tag: ${{ steps.version.outputs.npm_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
@@ -128,7 +128,7 @@ jobs:
 
       - name: Upload npm SBOM
         if: inputs.upload-sbom
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: npm-sbom
           path: kairos-mcp-${{ steps.version.outputs.version }}-npm-sbom.cdx.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
       TRIVYIGNORE_EXPIRY_WARNING_DAYS: "45"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Validate .trivyignore expiry dates
         run: |
           python3 scripts/ci-check-trivyignore-expiry.py \
@@ -45,7 +45,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Dependency review
         uses: actions/dependency-review-action@v5
         with:
@@ -59,7 +59,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -78,7 +78,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Same Hub account as publish-container; without login, pulls are anonymous and share CI IP limits (429).
       # Dependabot PRs do not receive DOCKER_* secrets; login with empty creds fails the step.
@@ -122,7 +122,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/sync-qoder-repowiki-to-github-wiki.yml
+++ b/.github/workflows/sync-qoder-repowiki-to-github-wiki.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate source directory exists
         run: |
@@ -33,7 +33,7 @@ jobs:
           test -d ".qoder/repowiki/en/content"
 
       - name: Checkout wiki repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,3 @@
-# CVE-2026-45447 (OpenSSL Heap Use-After-Free in PKCS7_verify): affects libcrypto3 and libssl3
-# in Alpine 3.23 (node:24-alpine base image). Fixed in OpenSSL 3.5.7-r0.
-# The Dockerfile already runs `apk upgrade --no-cache` but the pinned base image digest
-# may trail the Alpine repo. Revisit when the node:24-alpine digest includes 3.5.7-r0+.
-CVE-2026-45447 exp:2026-07-31
+# No active ignores.
+# CVE-2026-45447 (OpenSSL Heap Use-After-Free in PKCS7_verify) resolved:
+# node:24-alpine digest updated to include OpenSSL 3.5.7-r0.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # Targets:
 #   runtime (default) — npm registry install (Release / publish-container).
 #   runtime-ci — same layers after install, but package from .ci/docker/package.tgz (Integration workflow).
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS base
+FROM node:24-alpine@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS base
 
 VOLUME /snapshots
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@
 # Release images use Dockerfile and install from npm.
 # Base image stays on Node LTS; Node Current is covered in CI via setup-node, not a separate dev image.
 # Multi-arch support for x64 and ARM64
-FROM --platform=$BUILDPLATFORM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
+FROM --platform=$BUILDPLATFORM node:24-alpine@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ COPY logo/ ./logo/
 ENV DOCKER_BUILD=1
 RUN npm run build
 
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS production
+FROM node:24-alpine@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS production
 
 VOLUME /snapshots
 


### PR DESCRIPTION
## Summary

Resolves Node.js 20 deprecation warnings and expiring Trivy ignore entry.

### Changes

**GitHub Actions (41 occurrences across 12 workflow files):**
- `actions/checkout@v4` → `@v5` — v5 runs natively on Node 24
- `actions/upload-artifact@v4` → `@v5` — v5 runs natively on Node 24

**Dockerfile base image digest:**
- Updated `node:24-alpine` digest in both `Dockerfile` and `Dockerfile.dev`
- New digest includes OpenSSL 3.5.7-r0, fixing CVE-2026-45447

**Trivy ignore:**
- Removed `CVE-2026-45447 exp:2026-07-31` from `.trivyignore` (CVE now resolved in pinned base image)

### References
- [Node 20 deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- [actions/checkout v5 release](https://github.com/actions/checkout/releases/tag/v5.0.0)
- [actions/upload-artifact v5 release](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)